### PR TITLE
Refactor modals to use a global queue

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #![deny(clippy::all)]
 #![feature(associated_type_defaults)]
 #![feature(iterator_try_collect)]
+#![feature(trait_upcasting)]
 #![feature(try_blocks)]
 
 mod cli;

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -38,7 +38,7 @@ impl InputEngine {
                 InputBinding::new(KeyCode::Left, Action::Left),
                 InputBinding::new(KeyCode::Right, Action::Right),
                 InputBinding::new(KeyCode::Enter, Action::Interact),
-                InputBinding::new(KeyCode::Esc, Action::Close),
+                InputBinding::new(KeyCode::Esc, Action::Cancel),
             ]
             .into_iter()
             .map(|binding| (binding.action, binding))
@@ -105,9 +105,8 @@ pub enum Action {
     Right,
     /// Do a thing. E.g. select an item in a list
     Interact,
-    /// Close the current modal
-    #[display(fmt = "Close Dialog")]
-    Close,
+    /// Close the current modal/dialog/etc.
+    Cancel,
 }
 
 /// A mapping from a key input sequence to an action. This can optionally have

--- a/src/tui/message.rs
+++ b/src/tui/message.rs
@@ -5,7 +5,9 @@ use crate::{
     config::{ProfileId, RequestCollection, RequestRecipeId},
     http::{RequestBuildError, RequestError, RequestId, RequestRecord},
     template::{Prompt, Prompter},
+    util::ResultExt,
 };
+use anyhow::Context;
 use derive_more::From;
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::trace;
@@ -23,7 +25,11 @@ impl MessageSender {
     pub fn send(&self, message: impl Into<Message>) {
         let message: Message = message.into();
         trace!(?message, "Queueing message");
-        self.0.send(message).expect("Message queue is closed")
+        let _ = self
+            .0
+            .send(message)
+            .context("Error enqueueing message")
+            .traced();
     }
 }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -133,7 +133,7 @@ impl Tui {
             while let Ok(message) = self.messages_rx.try_recv() {
                 // If an error occurs, store it so we can show the user
                 if let Err(error) = self.handle_message(message) {
-                    self.view.set_error(error);
+                    self.view.open_modal(error);
                 }
             }
 
@@ -211,10 +211,10 @@ impl Tui {
             }
 
             Message::PromptStart(prompt) => {
-                self.view.set_prompt(prompt);
+                self.view.open_modal(prompt);
             }
 
-            Message::Error { error } => self.view.set_error(error),
+            Message::Error { error } => self.view.open_modal(error),
             Message::Quit => self.should_run = false,
         }
         Ok(())

--- a/src/tui/view/component/modal.rs
+++ b/src/tui/view/component/modal.rs
@@ -1,0 +1,128 @@
+use crate::tui::{
+    input::Action,
+    view::{
+        component::{Component, Draw, UpdateOutcome, ViewMessage},
+        util::centered_rect,
+    },
+};
+use ratatui::{
+    prelude::Constraint,
+    widgets::{Block, BorderType, Borders, Clear},
+};
+use std::{collections::VecDeque, ops::DerefMut};
+use tracing::trace;
+
+/// A modal (AKA popup or dialog) is a high-priority element to be shown to the
+/// user. It may be informational (e.g. an error message) or interactive (e.g.
+/// an input prompt). Any type that implements this trait can be used as a
+/// modal.
+pub trait Modal: Draw<()> + Component {
+    /// Text at the top of the modal
+    fn title(&self) -> &str;
+
+    /// Dimensions of the modal, relative to the whole screen
+    fn dimensions(&self) -> (Constraint, Constraint);
+
+    /// Optional callback when the modal is closed. Useful for finishing
+    /// operations that require ownership of the modal data.
+    fn on_close(self: Box<Self>) {}
+}
+
+/// Define how a type can be converted into a modal. Often times, implementors
+/// of [Modal] will be esoteric types that external consumers who want to open
+/// a modal aren't concerned about. This trait provides an adapater layer
+/// between the type a user might have (e.g. [anyhow::Error]) and the inner
+/// modal type (e.g. [ErrorModal]). Inspired by `Iterator` and `IntoIterator`.
+pub trait IntoModal {
+    type Target: Modal;
+
+    fn into_modal(self) -> Self::Target;
+}
+
+#[derive(Debug)]
+pub struct ModalQueue {
+    queue: VecDeque<Box<dyn Modal>>,
+}
+
+impl ModalQueue {
+    pub fn new() -> Self {
+        Self {
+            queue: VecDeque::new(),
+        }
+    }
+
+    /// Add a new modal to the end of the queue
+    pub fn open(&mut self, modal: Box<dyn Modal>) {
+        trace!("Opening modal");
+        self.queue.push_back(modal);
+    }
+
+    /// Close the current modal, and return the closed modal if any
+    pub fn close(&mut self) -> Option<Box<dyn Modal>> {
+        trace!("Closing modal");
+        self.queue.pop_front()
+    }
+}
+
+impl Component for ModalQueue {
+    fn update(&mut self, message: ViewMessage) -> UpdateOutcome {
+        match message {
+            // Close the active modal
+            ViewMessage::InputAction {
+                action: Some(Action::Cancel),
+                ..
+            }
+            | ViewMessage::CloseModal => match self.close() {
+                Some(modal) => {
+                    // Inform the modal of its terminal status
+                    modal.on_close();
+                    UpdateOutcome::Consumed
+                }
+                // Modal wasn't open, so don't consume the event
+                None => UpdateOutcome::Propagate(message),
+            },
+
+            // Open a new modal
+            ViewMessage::OpenModal(modal) => {
+                self.open(modal);
+                UpdateOutcome::Consumed
+            }
+
+            _ => UpdateOutcome::Propagate(message),
+        }
+    }
+
+    fn focused_children(&mut self) -> Vec<&mut dyn Component> {
+        match self.queue.front_mut() {
+            Some(first) => vec![first.deref_mut()],
+            None => vec![],
+        }
+    }
+}
+
+impl Draw for ModalQueue {
+    fn draw(
+        &self,
+        context: &crate::tui::view::RenderContext,
+        _: (),
+        frame: &mut crate::tui::view::Frame,
+        chunk: ratatui::prelude::Rect,
+    ) {
+        if let Some(modal) = self.queue.front() {
+            let (x, y) = modal.dimensions();
+            let chunk = centered_rect(x, y, chunk);
+            let block = Block::default()
+                .title(modal.title())
+                .borders(Borders::ALL)
+                .border_type(BorderType::Thick);
+            let inner_chunk = block.inner(chunk);
+
+            // Draw the outline of the modal
+            frame.render_widget(Clear, chunk);
+            frame.render_widget(block, chunk);
+
+            // Render the actual content
+            modal.draw(context, (), frame, inner_chunk);
+        }
+    }
+}

--- a/src/tui/view/component/primary.rs
+++ b/src/tui/view/component/primary.rs
@@ -63,13 +63,11 @@ impl Component for ProfileListPane {
     }
 }
 
-impl Draw for ProfileListPane {
-    type Props<'a> = ListPaneProps where Self: 'a;
-
+impl Draw<ListPaneProps> for ProfileListPane {
     fn draw(
         &self,
         context: &RenderContext,
-        props: Self::Props<'_>,
+        props: ListPaneProps,
         frame: &mut Frame,
         chunk: Rect,
     ) {
@@ -150,13 +148,11 @@ impl Component for RecipeListPane {
     }
 }
 
-impl Draw for RecipeListPane {
-    type Props<'a> = ListPaneProps where Self: 'a;
-
+impl Draw<ListPaneProps> for RecipeListPane {
     fn draw(
         &self,
         context: &RenderContext,
-        props: Self::Props<'_>,
+        props: ListPaneProps,
         frame: &mut Frame,
         chunk: Rect,
     ) {
@@ -211,13 +207,11 @@ impl Component for RequestPane {
     }
 }
 
-impl Draw for RequestPane {
-    type Props<'a> = RequestPaneProps<'a>;
-
+impl<'a> Draw<RequestPaneProps<'a>> for RequestPane {
     fn draw(
         &self,
         context: &RenderContext,
-        props: Self::Props<'_>,
+        props: RequestPaneProps<'a>,
         frame: &mut Frame,
         chunk: Rect,
     ) {
@@ -304,13 +298,11 @@ impl Component for ResponsePane {
     }
 }
 
-impl Draw for ResponsePane {
-    type Props<'a> = ResponsePaneProps<'a>;
-
+impl<'a> Draw<ResponsePaneProps<'a>> for ResponsePane {
     fn draw(
         &self,
         context: &RenderContext,
-        props: Self::Props<'_>,
+        props: ResponsePaneProps<'a>,
         frame: &mut Frame,
         chunk: Rect,
     ) {

--- a/src/tui/view/mod.rs
+++ b/src/tui/view/mod.rs
@@ -7,12 +7,13 @@ pub use state::RequestState;
 
 use crate::{
     config::{RequestCollection, RequestRecipeId},
-    template::Prompt,
     tui::{
         input::{Action, InputEngine},
         message::MessageSender,
         view::{
-            component::{Component, Draw, Root, UpdateOutcome, ViewMessage},
+            component::{
+                Component, Draw, IntoModal, Root, UpdateOutcome, ViewMessage,
+            },
             state::Notification,
             theme::Theme,
         },
@@ -75,14 +76,12 @@ impl View {
         self.handle_message(ViewMessage::HttpSetState { recipe_id, state });
     }
 
-    /// Prompt the user to enter some input
-    pub fn set_prompt(&mut self, prompt: Prompt) {
-        self.handle_message(ViewMessage::Prompt(prompt))
-    }
-
-    /// An error occurred somewhere and the user should be shown a modal
-    pub fn set_error(&mut self, error: anyhow::Error) {
-        self.handle_message(ViewMessage::Error(error));
+    /// Open a new modal. The input can be anything that converts to modal
+    /// content
+    pub fn open_modal(&mut self, modal: impl IntoModal + 'static) {
+        self.handle_message(ViewMessage::OpenModal(Box::new(
+            modal.into_modal(),
+        )));
     }
 
     /// Send an informational notification to the user


### PR DESCRIPTION
- Ensures modal is always rendered on top
- Unifies more modal logic, reducing boilerplate for modal implementors
- Allows modal queue to be shared between modal types