### PR TITLE
Use text area for text display

### DIFF
--- a/src/tui/view/component/modal.rs
+++ b/src/tui/view/component/modal.rs
@@ -2,7 +2,7 @@ use crate::tui::{
     input::Action,
     view::{
         component::{
-            Component, Draw, DrawContext, Event, UpdateContext, UpdateOutcome,
+            Component, Draw, DrawContext, Event, Update, UpdateContext,
         },
         util::centered_rect,
     },
@@ -97,11 +97,7 @@ impl ModalQueue {
 }
 
 impl Component for ModalQueue {
-    fn update(
-        &mut self,
-        _context: &mut UpdateContext,
-        event: Event,
-    ) -> UpdateOutcome {
+    fn update(&mut self, _context: &mut UpdateContext, event: Event) -> Update {
         match event {
             // Close the active modal. If there's no modal open, we'll propagate
             // the event down
@@ -114,20 +110,20 @@ impl Component for ModalQueue {
                     Some(modal) => {
                         // Inform the modal of its terminal status
                         modal.on_close();
-                        UpdateOutcome::Consumed
+                        Update::Consumed
                     }
                     // Modal wasn't open, so don't consume the event
-                    None => UpdateOutcome::Propagate(event),
+                    None => Update::Propagate(event),
                 }
             }
 
             // Open a new modal
             Event::OpenModal { modal, priority } => {
                 self.open(modal, priority);
-                UpdateOutcome::Consumed
+                Update::Consumed
             }
 
-            _ => UpdateOutcome::Propagate(event),
+            _ => Update::Propagate(event),
         }
     }
 

--- a/src/tui/view/component/root.rs
+++ b/src/tui/view/component/root.rs
@@ -10,7 +10,7 @@ use crate::{
                 primary::{PrimaryView, PrimaryViewProps},
                 request::RequestPaneProps,
                 response::ResponsePaneProps,
-                Component, Draw, Event, UpdateContext, UpdateOutcome,
+                Component, Draw, Event, Update, UpdateContext,
             },
             state::RequestState,
             util::layout,
@@ -104,11 +104,7 @@ impl Root {
 }
 
 impl Component for Root {
-    fn update(
-        &mut self,
-        context: &mut UpdateContext,
-        event: Event,
-    ) -> UpdateOutcome {
+    fn update(&mut self, context: &mut UpdateContext, event: Event) -> Update {
         match event {
             Event::Init => {
                 // Load the initial state for the selected recipe
@@ -151,9 +147,9 @@ impl Component for Root {
             Event::Input { .. } => {}
 
             // There shouldn't be anything left unhandled. Bubble up to log it
-            _ => return UpdateOutcome::Propagate(event),
+            _ => return Update::Propagate(event),
         }
-        UpdateOutcome::Consumed
+        Update::Consumed
     }
 
     fn children(&mut self) -> Vec<&mut dyn Component> {

--- a/src/tui/view/component/tabs.rs
+++ b/src/tui/view/component/tabs.rs
@@ -2,7 +2,7 @@ use crate::tui::{
     input::Action,
     view::{
         component::{
-            Component, Draw, DrawContext, Event, UpdateContext, UpdateOutcome,
+            Component, Draw, DrawContext, Event, Update, UpdateContext,
         },
         state::{FixedSelect, StatefulSelect},
     },
@@ -25,35 +25,24 @@ impl<T: FixedSelect> Tabs<T> {
 }
 
 impl<T: Debug + FixedSelect> Component for Tabs<T> {
-    fn update(
-        &mut self,
-        _context: &mut UpdateContext,
-        event: Event,
-    ) -> UpdateOutcome {
+    fn update(&mut self, _context: &mut UpdateContext, event: Event) -> Update {
         match event {
             Event::Input {
                 action: Some(action),
                 ..
             } => match action {
-                // Propagate TabChanged event if appropriate
                 Action::Left => {
-                    if self.tabs.previous() {
-                        UpdateOutcome::Propagate(Event::TabChanged)
-                    } else {
-                        UpdateOutcome::Consumed
-                    }
+                    self.tabs.previous();
+                    Update::Consumed
                 }
                 Action::Right => {
-                    if self.tabs.next() {
-                        UpdateOutcome::Propagate(Event::TabChanged)
-                    } else {
-                        UpdateOutcome::Consumed
-                    }
+                    self.tabs.next();
+                    Update::Consumed
                 }
 
-                _ => UpdateOutcome::Propagate(event),
+                _ => Update::Propagate(event),
             },
-            _ => UpdateOutcome::Propagate(event),
+            _ => Update::Propagate(event),
         }
     }
 }

--- a/src/tui/view/component/text_window.rs
+++ b/src/tui/view/component/text_window.rs
@@ -1,114 +1,124 @@
 use crate::tui::{
     input::Action,
     view::{
-        component::{Component, Draw, DrawContext, Event, UpdateOutcome},
-        util::layout,
+        component::{Component, Draw, DrawContext, Event, Update},
+        theme::Theme,
     },
 };
 use derive_more::Display;
-use ratatui::{
-    prelude::{Alignment, Constraint, Direction, Rect},
-    text::{Line, Text},
-    widgets::Paragraph,
-};
-use std::cmp;
+use ratatui::{prelude::Rect, style::Style};
+use std::{cell::RefCell, fmt::Debug, ops::Deref};
+use tui_textarea::TextArea;
 
-/// A view of text that can be scrolled through vertically. This should be used
-/// for *immutable* text only.
-///
-/// TODO try TextArea instead?
-///
-/// Some day hopefully we can get rid of this in favor of a widget from ratatui
-/// https://github.com/ratatui-org/ratatui/issues/174
-#[derive(Debug, Default, Display)]
+/// A scrollable (but not editable) block of text. The `Key` parameter is used
+/// to tell the text window when to reset its internal state. The type should be
+/// cheap to compare (e.g. a `Uuid` or short string), and the value is passed to
+/// the `draw` function as a prop. Whenever the value changes, the text buffer
+/// will be reset to the content of the `text` prop on that draw. As such, the
+/// key and text should be in sync: when one changes, the other does too.
+#[derive(Debug, Display)]
 #[display(fmt = "TextWindow")]
-pub struct TextWindow {
-    offset_y: u16,
+pub struct TextWindow<Key> {
+    /// State is stored in a refcell so it can be mutated during the draw. It
+    /// can be very hard to drill down the text content in the update phase, so
+    /// this makes it transparent to the caller.
+    ///
+    /// `RefCell` is safe here because its accesses are never held across
+    /// phases, and all view code is synchronous.
+    state: RefCell<Option<State<Key>>>,
 }
 
-impl TextWindow {
-    /// Reset scroll state
-    pub fn reset(&mut self) {
-        self.offset_y = 0;
-    }
-
-    fn up(&mut self) {
-        self.offset_y = self.offset_y.saturating_sub(1);
-    }
-
-    fn down(&mut self) {
-        self.offset_y += 1;
-    }
+pub struct TextWindowProps<'a, Key> {
+    pub key: &'a Key,
+    pub text: &'a str,
 }
 
-pub struct TextWindowProps<'a> {
-    pub text: Text<'a>,
+#[derive(Debug)]
+struct State<Key> {
+    key: Key,
+    text_area: TextArea<'static>,
 }
 
-impl Component for TextWindow {
+impl<Key: Debug> Component for TextWindow<Key> {
     fn update(
         &mut self,
         _context: &mut super::UpdateContext,
         event: Event,
-    ) -> UpdateOutcome {
-        match event {
-            Event::Input {
-                action: Some(action),
-                ..
-            } => match action {
-                Action::Up => {
-                    self.up();
-                    UpdateOutcome::Consumed
+    ) -> Update {
+        // Don't handle any events if state isn't initialized yet
+        if let Some(state) = self.state.get_mut() {
+            match event {
+                Event::Input {
+                    action: Some(Action::Up),
+                    ..
+                } => {
+                    state.text_area.scroll((-1, 0));
+                    Update::Consumed
                 }
-                Action::Down => {
-                    self.down();
-                    UpdateOutcome::Consumed
+                Event::Input {
+                    action: Some(Action::Down),
+                    ..
+                } => {
+                    state.text_area.scroll((1, 0));
+                    Update::Consumed
                 }
-                _ => UpdateOutcome::Propagate(event),
-            },
-            _ => UpdateOutcome::Propagate(event),
+                _ => Update::Propagate(event),
+            }
+        } else {
+            Update::Propagate(event)
         }
     }
 }
 
-impl<'a> Draw<TextWindowProps<'a>> for TextWindow {
+impl<'a, Key: Clone + Debug + PartialEq> Draw<TextWindowProps<'a, Key>>
+    for TextWindow<Key>
+{
     fn draw(
         &self,
         context: &mut DrawContext,
-        props: TextWindowProps<'a>,
+        props: TextWindowProps<'a, Key>,
         chunk: Rect,
     ) {
-        let num_lines = props.text.lines.len() as u16;
+        // This uses a reactive pattern to initialize the text area. The key
+        // should change whenever the text does, and that signals to rebuild the
+        // text area.
 
-        let [gutter_chunk, _, text_chunk] = layout(
-            chunk,
-            Direction::Horizontal,
-            [
-                // Size gutter based on max line number width
-                Constraint::Length(
-                    (num_lines as f32).log10().floor() as u16 + 1,
-                ),
-                Constraint::Length(1), // Spacer gap
-                Constraint::Min(0),
-            ],
-        );
+        // Check if the data is either uninitialized or outdated
+        {
+            let mut state = self.state.borrow_mut();
+            match state.deref() {
+                Some(state) if &state.key == props.key => {}
+                _ => {
+                    // (Re)create the state
+                    *state = Some(State {
+                        key: props.key.clone(),
+                        text_area: init_text_area(context.theme, props.text),
+                    });
+                }
+            }
+        }
 
-        // Add line numbers to the gutter
-        let first_line = self.offset_y + 1;
-        let last_line = cmp::min(first_line + chunk.height, num_lines);
-        context.frame.render_widget(
-            Paragraph::new(
-                (first_line..=last_line)
-                    .map(|n| n.to_string().into())
-                    .collect::<Vec<Line>>(),
-            )
-            .alignment(Alignment::Right),
-            gutter_chunk,
-        );
-
-        context.frame.render_widget(
-            Paragraph::new(props.text).scroll((self.offset_y, 0)),
-            text_chunk,
-        );
+        // Unwrap is safe because we know we just initialized state above
+        let state = self.state.borrow();
+        let text_area = &state.as_ref().unwrap().text_area;
+        context.frame.render_widget(text_area.widget(), chunk);
     }
+}
+
+/// Derive impl applies unnecessary bound on the generic parameter
+impl<Key> Default for TextWindow<Key> {
+    fn default() -> Self {
+        Self {
+            state: RefCell::new(None),
+        }
+    }
+}
+
+fn init_text_area(theme: &Theme, text: &str) -> TextArea<'static> {
+    let mut text_area: TextArea = text.lines().map(str::to_owned).collect();
+    // Hide cursor/line selection highlights
+    text_area.set_cursor_style(Style::default());
+    text_area.set_cursor_line_style(Style::default());
+    text_area.set_line_number_style(theme.line_number_style);
+    text_area
 }

--- a/src/tui/view/theme.rs
+++ b/src/tui/view/theme.rs
@@ -6,6 +6,8 @@ pub struct Theme {
     pub pane_border_style: Style,
     pub pane_border_focus_style: Style,
     pub text_highlight_style: Style,
+    /// Style for line numbers on large text areas
+    pub line_number_style: Style,
     pub list_highlight_symbol: &'static str,
 }
 
@@ -30,6 +32,7 @@ impl Default for Theme {
                 .bg(Color::LightGreen)
                 .fg(Color::Black)
                 .add_modifier(Modifier::BOLD),
+            line_number_style: Style::default(),
             list_highlight_symbol: ">> ",
         }
     }


### PR DESCRIPTION
This required some `RefCell` shenanigans, but I like the pattern.

Also, refactored update to add queueing for subsequent events, instead of just propagating up. This feels less icky and allows components to propagate events to their children.