### PR TITLE
Remove all nightly features and move to stable toolchain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ license = "MIT"
 name = "slumber"
 repository = "https://github.com/LucasPickering/slumber"
 version = "0.7.0"
+# Keep in sync w/ rust-toolchain.toml
+rust-version = "1.74.0"
 
 [dependencies]
 anyhow = {version = "^1.0.75", features = ["backtrace"]}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
-channel = "nightly-2023-09-20"
+# Keep in sync w/ Cargo.toml
+channel = "1.74.0"
 components = ["cargo", "clippy", "rustfmt"]

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -182,7 +182,13 @@ pub enum ChainSource {
 impl<S> RequestCollection<S> {
     /// Replace the source value on this collection
     pub fn with_source<T>(self, source: T) -> RequestCollection<T> {
-        RequestCollection { source, ..self }
+        RequestCollection {
+            source,
+            id: self.id,
+            profiles: self.profiles,
+            chains: self.chains,
+            recipes: self.recipes,
+        }
     }
 }
 

--- a/src/http/record.rs
+++ b/src/http/record.rs
@@ -255,7 +255,7 @@ mod serde_header_map {
                     v.try_into().map_err(de::Error::custom)?,
                 ))
             })
-            .try_collect()
+            .collect()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,5 @@
+#![forbid(unsafe_code)]
 #![deny(clippy::all)]
-#![feature(associated_type_defaults)]
-#![feature(iterator_try_collect)]
-#![feature(lazy_cell)]
-#![feature(trait_upcasting)]
-#![feature(try_blocks)]
-#![feature(type_changing_struct_update)]
 
 mod cli;
 mod collection;

--- a/src/tui/view/component/misc.rs
+++ b/src/tui/view/component/misc.rs
@@ -37,6 +37,10 @@ impl Modal for ErrorModal {
     fn dimensions(&self) -> (Constraint, Constraint) {
         (Constraint::Percentage(60), Constraint::Percentage(20))
     }
+
+    fn as_component(&mut self) -> &mut dyn Component {
+        self
+    }
 }
 
 impl Component for ErrorModal {
@@ -135,6 +139,10 @@ impl Modal for PromptModal {
             let input = self.text_area.into_lines().join("\n");
             self.prompt.respond(input);
         }
+    }
+
+    fn as_component(&mut self) -> &mut dyn Component {
+        self
     }
 }
 

--- a/src/tui/view/component/modal.rs
+++ b/src/tui/view/component/modal.rs
@@ -12,7 +12,7 @@ use ratatui::{
     prelude::{Constraint, Rect},
     widgets::{Block, BorderType, Borders, Clear},
 };
-use std::{collections::VecDeque, ops::DerefMut};
+use std::collections::VecDeque;
 use tracing::trace;
 
 /// A modal (AKA popup or dialog) is a high-priority element to be shown to the
@@ -33,6 +33,10 @@ pub trait Modal: Draw<()> + Component {
     /// Optional callback when the modal is closed. Useful for finishing
     /// operations that require ownership of the modal data.
     fn on_close(self: Box<Self>) {}
+
+    /// Annoying thing to cast from a modal to a base component. Remove after
+    /// https://github.com/rust-lang/rust/issues/65991
+    fn as_component(&mut self) -> &mut dyn Component;
 }
 
 /// Define how a type can be converted into a modal. Often times, implementors
@@ -129,7 +133,7 @@ impl Component for ModalQueue {
 
     fn children(&mut self) -> Vec<&mut dyn Component> {
         match self.queue.front_mut() {
-            Some(first) => vec![first.deref_mut()],
+            Some(first) => vec![first.as_component()],
             None => vec![],
         }
     }

--- a/src/tui/view/component/settings.rs
+++ b/src/tui/view/component/settings.rs
@@ -40,6 +40,10 @@ impl Modal for SettingsModal {
     fn dimensions(&self) -> (Constraint, Constraint) {
         (Constraint::Length(30), Constraint::Length(5))
     }
+
+    fn as_component(&mut self) -> &mut dyn Component {
+        self
+    }
 }
 
 impl Component for SettingsModal {


### PR DESCRIPTION
Most of the nightly features used were mild conveniences. The only one that was actually annoying to replace was `trait_upcasting`, and that seems to be pretty close to stabilizing anyway so maybe in 1.76?