### PR TITLE
Add sub-sub-command to `show`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - [BREAKING] Key profiles/chains/requests by ID in collection file
 - [BREAKING] Move request history from `slumber/{id}.sqlite` to `slumber/{id}/state.sqlite`
   - Request history will be lost. If you want to recover it, you can move the old file to the new location (use `slumber show` to find the directory location)
+- [BREAKING] `show` subcommand now takes a `target` argument
+  - Right now the only option is `slumber show dir`, which has the same behavior as the old `slumber show` (except now it prints the bare directory)
 - Hide sensitive chain values in preview
 - Change fullscreen keybinding from F11 to F
   - F11 in some cases is eaten by the IDE or OS, which is annoying

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -53,7 +53,16 @@ pub enum Subcommand {
     },
 
     /// Show meta information about slumber
-    Show,
+    Show {
+        #[command(subcommand)]
+        target: ShowTarget,
+    },
+}
+
+#[derive(Copy, Clone, Debug, clap::Subcommand)]
+pub enum ShowTarget {
+    /// Show the directory where slumber stores data and log files
+    Dir,
 }
 
 impl Subcommand {
@@ -147,8 +156,10 @@ impl Subcommand {
                 Ok(())
             }
 
-            Subcommand::Show => {
-                println!("Directory: {}", Directory::root());
+            Subcommand::Show { target } => {
+                match target {
+                    ShowTarget::Dir => println!("{}", Directory::root()),
+                }
                 Ok(())
             }
         }


### PR DESCRIPTION
Bare output makes it easier to pipeline, e.g. `cd (slumber show dir)`