### PR TITLE
Remove cursor toggle

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -20,7 +20,6 @@ use anyhow::{anyhow, Context};
 use crossterm::{
     event::{DisableMouseCapture, EnableMouseCapture},
     terminal::{EnterAlternateScreen, LeaveAlternateScreen},
-    ExecutableCommand,
 };
 use futures::Future;
 use notify::{RecursiveMode, Watcher};
@@ -267,15 +266,6 @@ impl Tui {
                     profile_id.as_ref(),
                     destination,
                 )?;
-            }
-
-            Message::ToggleMouseCapture { capture } => {
-                let mut stdout = io::stdout();
-                if capture {
-                    stdout.execute(EnableMouseCapture)?;
-                } else {
-                    stdout.execute(DisableMouseCapture)?;
-                }
             }
         }
         Ok(())

--- a/src/tui/message.rs
+++ b/src/tui/message.rs
@@ -105,7 +105,4 @@ pub enum Message {
         profile_id: Option<ProfileId>,
         destination: Arc<OnceLock<Vec<TemplateChunk>>>,
     },
-
-    /// Enable/disable mouse capture in the terminal
-    ToggleMouseCapture { capture: bool },
 }

--- a/src/tui/view.rs
+++ b/src/tui/view.rs
@@ -189,17 +189,12 @@ struct ViewConfig {
     /// Should templates be rendered inline in the UI, or should we show the
     /// raw text?
     preview_templates: bool,
-
-    /// Are we capture cursor events, or are they being handled by the terminal
-    /// emulator? This can be toggled by the user
-    capture_mouse: bool,
 }
 
 impl Default for ViewConfig {
     fn default() -> Self {
         Self {
             preview_templates: true,
-            capture_mouse: true,
         }
     }
 }

--- a/src/tui/view/common/modal.rs
+++ b/src/tui/view/common/modal.rs
@@ -132,7 +132,6 @@ impl EventHandler for ModalQueue {
 impl Draw for ModalQueue {
     fn draw(&self, context: &mut DrawContext, _: (), area: Rect) {
         if let Some(modal) = self.queue.front() {
-            // TODO treat dimensions as inner, not outer
             let (x, y) = modal.dimensions();
             let area = centered_rect(x, y, area);
             let block = Block::default()

--- a/src/tui/view/component/settings.rs
+++ b/src/tui/view/component/settings.rs
@@ -1,13 +1,9 @@
-use crate::tui::{
-    context::TuiContext,
-    message::Message,
-    view::{
-        common::{modal::Modal, table::Table, Checkbox},
-        draw::{Draw, DrawContext, Generate},
-        event::{EventHandler, UpdateContext},
-        state::select::{Fixed, SelectState},
-        Component, ViewConfig,
-    },
+use crate::tui::view::{
+    common::{modal::Modal, table::Table, Checkbox},
+    draw::{Draw, DrawContext, Generate},
+    event::{EventHandler, UpdateContext},
+    state::select::{Fixed, SelectState},
+    Component, ViewConfig,
 };
 use derive_more::Display;
 use itertools::Itertools;
@@ -30,14 +26,6 @@ impl Default for SettingsModal {
             match setting {
                 Setting::PreviewTemplates => {
                     context.config().preview_templates ^= true;
-                }
-                Setting::CaptureMouse => {
-                    context.config().capture_mouse ^= true;
-                    // Tell the terminal to actually do the switch
-                    let capture = context.config().capture_mouse;
-                    TuiContext::send_message(Message::ToggleMouseCapture {
-                        capture,
-                    });
                 }
             }
         }
@@ -101,8 +89,6 @@ enum Setting {
     #[default]
     #[display("Preview Templates")]
     PreviewTemplates,
-    #[display("Capture Mouse")]
-    CaptureMouse,
 }
 
 impl Setting {
@@ -110,7 +96,6 @@ impl Setting {
     fn get_value(self, config: &ViewConfig) -> bool {
         match self {
             Self::PreviewTemplates => config.preview_templates,
-            Self::CaptureMouse => config.capture_mouse,
         }
     }
 }


### PR DESCRIPTION
Turns out it's not that useful since I discovered most terminals provide a hotkey to override. It's option+click in iterm.