### PR TITLE
Toggle query/header rows in recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Move app-level configuration into a file ([#89](https://github.com/LucasPickering/slumber/issues/89))
   - Right now the only supported field is `preview_templates`
+- Toggle query parameters and headers in recipe pane ([#30](https://github.com/LucasPickering/slumber/issues/30))
+  - You can easily enable/disable parameters and headers without having to modify the collection file now
 
 ### Changed
 

--- a/src/cli/request.rs
+++ b/src/cli/request.rs
@@ -2,7 +2,7 @@ use crate::{
     cli::Subcommand,
     collection::{CollectionFile, ProfileId, RecipeId},
     db::Database,
-    http::{HttpEngine, RequestBuilder},
+    http::{HttpEngine, RecipeOptions, RequestBuilder},
     template::{Prompt, Prompter, TemplateContext},
     util::ResultExt,
     GlobalArgs,
@@ -75,6 +75,7 @@ impl Subcommand for RequestCommand {
         let overrides: IndexMap<_, _> = self.overrides.into_iter().collect();
         let request = RequestBuilder::new(
             recipe,
+            RecipeOptions::default(),
             TemplateContext {
                 profile,
                 chains: collection.chains.clone(),

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -7,7 +7,7 @@ use crate::{
     collection::{Collection, CollectionFile, ProfileId, RecipeId},
     config::Config,
     db::{CollectionDatabase, Database},
-    http::{HttpEngine, RequestBuilder},
+    http::{HttpEngine, RecipeOptions, RequestBuilder},
     template::{Prompter, Template, TemplateChunk, TemplateContext},
     tui::{
         context::TuiContext,
@@ -206,7 +206,8 @@ impl Tui {
             Message::HttpBeginRequest {
                 recipe_id,
                 profile_id,
-            } => self.send_request(profile_id, recipe_id)?,
+                options,
+            } => self.send_request(profile_id, recipe_id, options)?,
             Message::HttpBuildError {
                 profile_id,
                 recipe_id,
@@ -313,6 +314,7 @@ impl Tui {
         &mut self,
         profile_id: Option<ProfileId>,
         recipe_id: RecipeId,
+        options: RecipeOptions,
     ) -> anyhow::Result<()> {
         let recipe = self
             .collection_file
@@ -327,7 +329,7 @@ impl Tui {
         let template_context = self
             .template_context(profile_id.as_ref(), self.messages_tx.clone())?;
         let http_engine = self.http_engine.clone();
-        let builder = RequestBuilder::new(recipe, template_context);
+        let builder = RequestBuilder::new(recipe, options, template_context);
         let messages_tx = self.messages_tx.clone();
 
         // Mark request state as building

--- a/src/tui/message.rs
+++ b/src/tui/message.rs
@@ -3,7 +3,10 @@
 
 use crate::{
     collection::{Collection, ProfileId, RecipeId},
-    http::{RequestBuildError, RequestError, RequestId, RequestRecord},
+    http::{
+        RecipeOptions, RequestBuildError, RequestError, RequestId,
+        RequestRecord,
+    },
     template::{Prompt, Prompter, Template, TemplateChunk},
     util::ResultExt,
 };
@@ -61,6 +64,7 @@ pub enum Message {
     HttpBeginRequest {
         profile_id: Option<ProfileId>,
         recipe_id: RecipeId,
+        options: RecipeOptions,
     },
     /// Request failed to build
     HttpBuildError {

--- a/src/tui/view/common/text_window.rs
+++ b/src/tui/view/common/text_window.rs
@@ -170,7 +170,10 @@ struct TextWindowActionsModal {
 
 impl Default for TextWindowActionsModal {
     fn default() -> Self {
-        fn on_submit(context: &mut UpdateContext, action: &TextWindowAction) {
+        fn on_submit(
+            context: &mut UpdateContext,
+            action: &mut TextWindowAction,
+        ) {
             // Close the modal *first*, so the action event gets handled by our
             // parent rather than the modal. Jank but it works
             context.queue_event(Event::CloseModal);

--- a/src/tui/view/component/primary.rs
+++ b/src/tui/view/component/primary.rs
@@ -168,6 +168,7 @@ impl EventHandler for PrimaryView {
                         profile_id: self
                             .selected_profile()
                             .map(|profile| profile.id.clone()),
+                        options: self.request_pane.recipe_options(),
                     });
                 }
                 Update::Consumed

--- a/src/tui/view/component/profile_list.rs
+++ b/src/tui/view/component/profile_list.rs
@@ -26,7 +26,7 @@ pub struct ProfileListPaneProps {
 impl ProfileListPane {
     pub fn new(profiles: Vec<Profile>) -> Self {
         // Loaded request depends on the profile, so refresh on change
-        fn on_select(context: &mut UpdateContext, _: &Profile) {
+        fn on_select(context: &mut UpdateContext, _: &mut Profile) {
             context.queue_event(Event::HttpLoadRequest);
         }
 

--- a/src/tui/view/component/recipe_list.rs
+++ b/src/tui/view/component/recipe_list.rs
@@ -28,12 +28,12 @@ pub struct RecipeListPaneProps {
 impl RecipeListPane {
     pub fn new(recipes: Vec<Recipe>) -> Self {
         // When highlighting a new recipe, load it from the repo
-        fn on_select(context: &mut UpdateContext, _: &Recipe) {
+        fn on_select(context: &mut UpdateContext, _: &mut Recipe) {
             context.queue_event(Event::HttpLoadRequest);
         }
 
         // Trigger a request on submit
-        fn on_submit(context: &mut UpdateContext, _: &Recipe) {
+        fn on_submit(context: &mut UpdateContext, _: &mut Recipe) {
             // Parent has to be responsible for actually sending the request
             // because it also needs access to the profile list state
             context.queue_event(Event::HttpSendRequest);

--- a/src/tui/view/component/request.rs
+++ b/src/tui/view/component/request.rs
@@ -1,15 +1,20 @@
 use crate::{
     collection::{ProfileId, Recipe, RecipeId},
+    http::RecipeOptions,
     template::Template,
     tui::view::{
         common::{
             table::Table, tabs::Tabs, template_preview::TemplatePreview,
-            text_window::TextWindow, Pane,
+            text_window::TextWindow, Checkbox, Pane,
         },
         component::primary::PrimaryPane,
         draw::{Draw, Generate},
-        event::EventHandler,
-        state::{persistence::PersistentKey, StateCell},
+        event::{EventHandler, UpdateContext},
+        state::{
+            persistence::{Persistable, Persistent, PersistentKey},
+            select::{Dynamic, SelectState},
+            StateCell,
+        },
         util::layout,
         Component,
     },
@@ -18,10 +23,12 @@ use derive_more::Display;
 use itertools::Itertools;
 use ratatui::{
     prelude::{Constraint, Direction, Rect},
-    widgets::Paragraph,
+    text::Text,
+    widgets::{Paragraph, TableState},
     Frame,
 };
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use strum::EnumIter;
 
 /// Display a request recipe
@@ -36,7 +43,7 @@ pub struct RequestPane {
 impl Default for RequestPane {
     fn default() -> Self {
         Self {
-            tabs: Tabs::new(PersistentKey::RequestTab).into(),
+            tabs: Tabs::new(PersistentKey::RecipeTab).into(),
             recipe_state: Default::default(),
         }
     }
@@ -58,8 +65,8 @@ struct RecipeStateKey {
 #[derive(Debug)]
 struct RecipeState {
     url: TemplatePreview,
-    query: Vec<(String, TemplatePreview)>,
-    headers: Vec<(String, TemplatePreview)>,
+    query: Component<Persistent<SelectState<Dynamic, RowState, TableState>>>,
+    headers: Component<Persistent<SelectState<Dynamic, RowState, TableState>>>,
     body: Option<Component<TextWindow<TemplatePreview>>>,
 }
 
@@ -81,24 +88,60 @@ enum Tab {
     Headers,
 }
 
+/// One row in the query/header table
+#[derive(Debug)]
+struct RowState {
+    key: String,
+    value: TemplatePreview,
+    enabled: Persistent<bool>,
+}
+
+impl RequestPane {
+    /// Generate a [RecipeOptions] instance based on current UI state
+    pub fn recipe_options(&self) -> RecipeOptions {
+        if let Some(state) = self.recipe_state.get() {
+            /// Convert select state into the set of disabled keys
+            fn to_disabled_set(
+                select_state: &SelectState<Dynamic, RowState, TableState>,
+            ) -> HashSet<String> {
+                select_state
+                    .items()
+                    .iter()
+                    .filter(|row| !*row.enabled)
+                    .map(|row| row.key.clone())
+                    .collect()
+            }
+
+            RecipeOptions {
+                disabled_headers: to_disabled_set(&state.headers),
+                disabled_query_parameters: to_disabled_set(&state.query),
+            }
+        } else {
+            // Shouldn't be possible, because state is initialized on first
+            // render
+            RecipeOptions::default()
+        }
+    }
+}
+
 impl EventHandler for RequestPane {
     fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {
         let selected_tab = *self.tabs.selected();
         let mut children = vec![self.tabs.as_child()];
-        match selected_tab {
-            Tab::Body => {
-                // If the body is initialized and present, send events there too
-                if let Some(body) = self
-                    .recipe_state
-                    .get_mut()
-                    .and_then(|state| state.body.as_mut())
-                {
-                    children.push(body.as_child());
+
+        // Send events to the tab pane as well
+        if let Some(state) = self.recipe_state.get_mut() {
+            match selected_tab {
+                Tab::Body => {
+                    if let Some(body) = state.body.as_mut() {
+                        children.push(body.as_child());
+                    }
                 }
+                Tab::Query => children.push(state.query.as_child()),
+                Tab::Headers => children.push(state.headers.as_child()),
             }
-            Tab::Query => {}
-            Tab::Headers => {}
         }
+
         children
     }
 }
@@ -147,27 +190,7 @@ impl<'a> Draw<RequestPaneProps<'a>> for RequestPane {
                     selected_profile_id: props.selected_profile_id.cloned(),
                     recipe_id: recipe.id.clone(),
                 },
-                || RecipeState {
-                    url: TemplatePreview::new(
-                        recipe.url.clone(),
-                        props.selected_profile_id.cloned(),
-                    ),
-                    query: to_template_previews(
-                        &recipe.query,
-                        props.selected_profile_id,
-                    ),
-                    headers: to_template_previews(
-                        &recipe.headers,
-                        props.selected_profile_id,
-                    ),
-                    body: recipe.body.as_ref().map(|body| {
-                        TextWindow::new(TemplatePreview::new(
-                            body.clone(),
-                            props.selected_profile_id.cloned(),
-                        ))
-                        .into()
-                    }),
-                },
+                || RecipeState::new(recipe, props.selected_profile_id),
             );
 
             // First line: Method + URL
@@ -187,56 +210,150 @@ impl<'a> Draw<RequestPaneProps<'a>> for RequestPane {
                         body.draw(frame, (), content_area);
                     }
                 }
-                Tab::Query => frame.render_widget(
-                    Table {
-                        rows: recipe_state
-                            .query
-                            .iter()
-                            .map(|(param, value)| {
-                                [param.as_str().into(), value.generate()]
-                            })
-                            .collect_vec(),
-                        header: Some(["Parameter", "Value"]),
-                        alternate_row_style: true,
-                        ..Default::default()
-                    }
-                    .generate(),
+                Tab::Query => frame.render_stateful_widget(
+                    to_table(&recipe_state.query, ["Parameter", "Value", ""])
+                        .generate(),
                     content_area,
+                    &mut recipe_state.query.state_mut(),
                 ),
-                Tab::Headers => frame.render_widget(
-                    Table {
-                        rows: recipe_state
-                            .headers
-                            .iter()
-                            .map(|(param, value)| {
-                                [param.as_str().into(), value.generate()]
-                            })
-                            .collect_vec(),
-                        header: Some(["Header", "Value"]),
-                        alternate_row_style: true,
-                        ..Default::default()
-                    }
-                    .generate(),
+                Tab::Headers => frame.render_stateful_widget(
+                    to_table(&recipe_state.headers, ["Header", "Value", ""])
+                        .generate(),
                     content_area,
+                    &mut recipe_state.headers.state_mut(),
                 ),
             }
         }
     }
 }
 
-/// Convert a map of (string, template) from a recipe into (string, template
-/// preview) to kick off the template preview for each value. The output should
-/// be stored in state.
-fn to_template_previews<'a>(
-    iter: impl IntoIterator<Item = (&'a String, &'a Template)>,
-    profile_id: Option<&ProfileId>,
-) -> Vec<(String, TemplatePreview)> {
-    iter.into_iter()
-        .map(|(k, v)| {
-            (
-                k.clone(),
-                TemplatePreview::new(v.clone(), profile_id.cloned()),
+impl RecipeState {
+    /// Initialize new recipe state. Should be called whenever the recipe or
+    /// profile changes
+    fn new(recipe: &Recipe, selected_profile_id: Option<&ProfileId>) -> Self {
+        let query_items = recipe
+            .query
+            .iter()
+            .map(|(param, value)| {
+                RowState::new(
+                    param.clone(),
+                    value.clone(),
+                    selected_profile_id.cloned(),
+                    PersistentKey::RecipeQuery {
+                        recipe: recipe.id.clone(),
+                        param: param.clone(),
+                    },
+                )
+            })
+            .collect();
+        let header_items = recipe
+            .headers
+            .iter()
+            .map(|(header, value)| {
+                RowState::new(
+                    header.clone(),
+                    value.clone(),
+                    selected_profile_id.cloned(),
+                    PersistentKey::RecipeHeader {
+                        recipe: recipe.id.clone(),
+                        header: header.clone(),
+                    },
+                )
+            })
+            .collect();
+
+        Self {
+            url: TemplatePreview::new(
+                recipe.url.clone(),
+                selected_profile_id.cloned(),
+            ),
+            query: Persistent::new(
+                PersistentKey::RecipeSelectedQuery(recipe.id.clone()),
+                SelectState::new(query_items).on_submit(RowState::on_submit),
             )
-        })
-        .collect()
+            .into(),
+            headers: Persistent::new(
+                PersistentKey::RecipeSelectedHeader(recipe.id.clone()),
+                SelectState::new(header_items).on_submit(RowState::on_submit),
+            )
+            .into(),
+            body: recipe.body.as_ref().map(|body| {
+                TextWindow::new(TemplatePreview::new(
+                    body.clone(),
+                    selected_profile_id.cloned(),
+                ))
+                .into()
+            }),
+        }
+    }
+}
+
+impl RowState {
+    fn new(
+        key: String,
+        value: Template,
+        selected_profile_id: Option<ProfileId>,
+        persistent_key: PersistentKey,
+    ) -> Self {
+        Self {
+            key,
+            value: TemplatePreview::new(value, selected_profile_id),
+            enabled: Persistent::new(
+                persistent_key,
+                // Value itself is the container, so just pass a default value
+                true,
+            ),
+        }
+    }
+
+    /// Toggle row state on submit
+    fn on_submit(_: &mut UpdateContext, row: &mut Self) {
+        *row.enabled ^= true;
+    }
+}
+
+/// Convert table select state into a renderable table
+fn to_table<'a>(
+    state: &'a SelectState<Dynamic, RowState, TableState>,
+    header: [&'a str; 3],
+) -> Table<'a, 3, Vec<[Text<'a>; 3]>> {
+    Table {
+        rows: state
+            .items()
+            .iter()
+            .map(|item| {
+                [
+                    item.key.as_str().into(),
+                    item.value.generate(),
+                    Checkbox {
+                        checked: *item.enabled,
+                    }
+                    .generate(),
+                ]
+            })
+            .collect_vec(),
+        header: Some(header),
+        column_widths: &[
+            Constraint::Percentage(50),
+            Constraint::Percentage(50),
+            Constraint::Min(3),
+        ],
+        alternate_row_style: true,
+        ..Default::default()
+    }
+}
+
+/// This impl persists just which row is *selected*
+impl Persistable for RowState {
+    type Persisted = String;
+
+    fn get_persistent(&self) -> &Self::Persisted {
+        &self.key
+    }
+}
+
+impl PartialEq<RowState> for String {
+    fn eq(&self, other: &RowState) -> bool {
+        self == &other.key
+    }
 }

--- a/src/tui/view/state.rs
+++ b/src/tui/view/state.rs
@@ -47,9 +47,19 @@ impl<K, V> StateCell<K, V> {
         Ref::map(self.state.borrow(), |state| &state.as_ref().unwrap().1)
     }
 
-    /// Get a mutable reference to the V. This will never panic because
-    /// `&mut self` guarantees exclusive access. Returns `None` iff the state
-    /// cell is uninitialized.
+    /// Get a reference to the state value. This can panic, if the state value
+    /// is already borrowed elsewhere. Returns `None` iff the state cell is
+    /// uninitialized.
+    pub fn get(&self) -> Option<Ref<'_, V>> {
+        Ref::filter_map(self.state.borrow(), |state| {
+            state.as_ref().map(|(_, v)| v)
+        })
+        .ok()
+    }
+
+    /// Get a mutable reference to the state value. This will never panic
+    /// because `&mut self` guarantees exclusive access. Returns `None` iff
+    /// the state cell is uninitialized.
     pub fn get_mut(&mut self) -> Option<&mut V> {
         self.state.get_mut().as_mut().map(|state| &mut state.1)
     }


### PR DESCRIPTION
This includes a breaking DB schema change: `ui_state.key` is now a serialized blob instead of just a string, since keys can now include parameters. Shouldn't cause any issues beyond losing existing rows on first startup.

Closes #30 