### PR TITLE
Replace `tui-textarea` with custom `TextBox`, upgrade to ratatui 0.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
+name = "castaway"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,6 +309,19 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "compact_str"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "console"
@@ -1256,19 +1278,20 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5659e52e4ba6e07b2dad9f1158f578ef84a73762625ddb51536019f34d180eb"
+checksum = "bcb12f8fbf6c62614b0d56eb352af54f6a22410c3b079eb53ee93c7b97dd31d8"
 dependencies = [
  "bitflags 2.4.1",
  "cassowary",
+ "compact_str",
  "crossterm",
  "indoc",
  "itertools",
  "lru",
  "paste",
  "stability",
- "strum",
+ "strum 0.26.1",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -1768,7 +1791,7 @@ dependencies = [
  "serde_json_path",
  "serde_yaml",
  "signal-hook",
- "strum",
+ "strum 0.25.0",
  "thiserror",
  "tokio",
  "tracing",
@@ -1810,6 +1833,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "str-buf"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1827,7 +1856,16 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.25.3",
+]
+
+[[package]]
+name = "strum"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f"
+dependencies = [
+ "strum_macros 0.26.1",
 ]
 
 [[package]]
@@ -1835,6 +1873,19 @@ name = "strum_macros"
 version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.41",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1773,7 +1773,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "tui-textarea",
  "url",
  "uuid",
 ]
@@ -2070,17 +2069,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "tui-textarea"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e38ced1f941a9cfc923fbf2fe6858443c42cc5220bfd35bdd3648371e7bd8e"
-dependencies = [
- "crossterm",
- "ratatui",
- "unicode-width",
-]
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ thiserror = "^1.0.48"
 tokio = {version = "^1.32.0", default-features = false, features = ["full"]}
 tracing = "^0.1.37"
 tracing-subscriber = {version = "^0.3.17", default-features = false, features = ["env-filter", "fmt", "registry"]}
-tui-textarea = "^0.4.0"
 url = "^2.5.0"
 uuid = {version = "^1.4.1", default-features = false, features = ["serde", "v4"]}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ indexmap = {version = "^2.0.1", features = ["serde"]}
 itertools = "^0.12.0"
 nom = "7.1.3"
 notify = {version = "^6.1.1", default-features = false, features = ["macos_fsevent"]}
-ratatui = "^0.25.0"
+ratatui = "^0.26.0"
 reqwest = {version = "^0.11.20", default-features = false, features = ["rustls-tls"]}
 rmp-serde = "^1.1.2"
 rusqlite = {version = "^0.30.0", default-features = false, features = ["bundled", "chrono", "uuid"]}

--- a/src/tui/view/common.rs
+++ b/src/tui/view/common.rs
@@ -7,6 +7,7 @@ pub mod modal;
 pub mod table;
 pub mod tabs;
 pub mod template_preview;
+pub mod text_box;
 pub mod text_window;
 
 use crate::{

--- a/src/tui/view/common/tabs.rs
+++ b/src/tui/view/common/tabs.rs
@@ -57,11 +57,9 @@ impl<T: FixedSelect + Persistable> EventHandler for Tabs<T> {
 impl<T: FixedSelect + Persistable> Draw for Tabs<T> {
     fn draw(&self, frame: &mut Frame, _: (), area: Rect) {
         frame.render_widget(
-            ratatui::widgets::Tabs::new(
-                T::iter().map(|e| e.to_string()).collect(),
-            )
-            .select(self.tabs.selected_index())
-            .highlight_style(TuiContext::get().theme.tab_highlight_style),
+            ratatui::widgets::Tabs::new(T::iter().map(|e| e.to_string()))
+                .select(self.tabs.selected_index())
+                .highlight_style(TuiContext::get().theme.tab_highlight_style),
             area,
         )
     }

--- a/src/tui/view/common/text_box.rs
+++ b/src/tui/view/common/text_box.rs
@@ -1,0 +1,345 @@
+//! A single-line text box with callbacks
+
+use crate::tui::{
+    context::TuiContext,
+    input::Action,
+    view::{
+        draw::Draw,
+        event::{Event, EventHandler, Update, UpdateContext},
+    },
+};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use nom::AsChar;
+use ratatui::{
+    layout::Rect,
+    text::{Masked, Text},
+    widgets::Paragraph,
+    Frame,
+};
+
+/// Single line text submission component
+#[derive(derive_more::Debug)]
+pub struct TextBox {
+    // Parameters
+    sensitive: bool,
+    focused: bool,
+
+    state: TextState,
+
+    // Callbacks
+    #[debug(skip)]
+    on_submit: Option<Callback>,
+    #[debug(skip)]
+    on_cancel: Option<Callback>,
+}
+
+type Callback = Box<dyn Fn(&TextBox, &mut UpdateContext)>;
+
+impl Default for TextBox {
+    fn default() -> Self {
+        Self {
+            sensitive: false,
+            focused: true,
+            state: Default::default(),
+            on_submit: Default::default(),
+            on_cancel: Default::default(),
+        }
+    }
+}
+
+impl TextBox {
+    /// Mark content as sensitive, to be replaced with a placeholder character
+    pub fn sensitive(mut self, sensitive: bool) -> Self {
+        self.sensitive = sensitive;
+        self
+    }
+
+    /// Set the callback to be called when the user hits escape
+    pub fn on_cancel(
+        mut self,
+        on_cancel: impl 'static + Fn(&Self, &mut UpdateContext),
+    ) -> Self {
+        self.on_cancel = Some(Box::new(on_cancel));
+        self
+    }
+
+    /// Set the callback to be called when the user hits enter
+    pub fn on_submit(
+        mut self,
+        on_submit: impl 'static + Fn(&Self, &mut UpdateContext),
+    ) -> Self {
+        self.on_submit = Some(Box::new(on_submit));
+        self
+    }
+
+    /// Style this text box to look active
+    pub fn focus(&mut self) {
+        self.focused = true;
+    }
+
+    /// Style this text box to look inactive
+    pub fn unfocus(&mut self) {
+        self.focused = false;
+    }
+
+    /// Move the text out of this text box and return it
+    pub fn into_text(self) -> String {
+        self.state.text
+    }
+
+    /// Call parent's submissionc callback
+    fn submit(&mut self, context: &mut UpdateContext) {
+        if let Some(on_submit) = &self.on_submit {
+            on_submit(self, context);
+        }
+        self.unfocus();
+    }
+
+    /// Call parent's cancel callback
+    fn cancel(&mut self, context: &mut UpdateContext) {
+        if let Some(on_cancel) = &self.on_cancel {
+            on_cancel(self, context);
+        }
+        self.unfocus();
+    }
+
+    /// Handle input key event to modify state
+    fn handle_key_event(&mut self, key_event: KeyEvent) {
+        match key_event.code {
+            KeyCode::Char(c) => self.state.insert(c),
+            KeyCode::Backspace => self.state.delete_left(),
+            KeyCode::Delete => self.state.delete_right(),
+            KeyCode::Left => {
+                if key_event.modifiers.contains(KeyModifiers::CONTROL) {
+                    self.state.home();
+                } else {
+                    self.state.left();
+                }
+            }
+            KeyCode::Right => {
+                if key_event.modifiers.contains(KeyModifiers::CONTROL) {
+                    self.state.end();
+                } else {
+                    self.state.right();
+                }
+            }
+            KeyCode::Home => self.state.home(),
+            KeyCode::End => self.state.end(),
+            _ => {}
+        }
+    }
+}
+
+impl EventHandler for TextBox {
+    fn update(&mut self, context: &mut UpdateContext, event: Event) -> Update {
+        match event {
+            Event::Input {
+                action: Some(Action::Submit),
+                ..
+            } => self.submit(context),
+            Event::Input {
+                action: Some(Action::Cancel),
+                ..
+            } => self.cancel(context),
+            Event::Input {
+                action: Some(Action::LeftClick),
+                ..
+            } => self.focus(),
+            Event::Input {
+                event: crossterm::event::Event::Key(key_event),
+                ..
+            } => self.handle_key_event(key_event),
+            _ => return Update::Propagate(event),
+        }
+        Update::Consumed
+    }
+}
+
+impl Draw for TextBox {
+    fn draw(&self, frame: &mut Frame, _: (), area: Rect) {
+        let theme = &TuiContext::get().theme;
+
+        // Hide top secret data
+        let text: Text = if self.sensitive {
+            Masked::new(&self.state.text, '•').into()
+        } else {
+            self.state.text.as_str().into()
+        };
+
+        frame.render_widget(
+            Paragraph::new(text).style(theme.text_box_text),
+            area,
+        );
+
+        // Apply cursor styling on type
+        let cursor_area = Rect {
+            x: area.x + self.state.cursor_offset() as u16,
+            y: area.y,
+            width: 1,
+            height: 1,
+        };
+        frame
+            .buffer_mut()
+            .set_style(cursor_area, theme.text_box_cursor);
+    }
+}
+
+/// Encapsulation of text/cursor state. Encapsulating this makes reading and
+/// testing the functionality easier.
+#[derive(Debug, Default)]
+struct TextState {
+    text: String,
+    /// **Byte** (not character) index in the text. Must be in the range `[0,
+    /// text.len()]`. This must always fall on a character boundary.
+    cursor: usize,
+}
+
+impl TextState {
+    /// Is the cursor at the beginning of the text?
+    fn is_at_home(&self) -> bool {
+        self.cursor == 0
+    }
+
+    /// Is the cursor at the end of the text?
+    fn is_at_end(&self) -> bool {
+        self.cursor == self.char_len()
+    }
+
+    /// Get the number of **characters* (not bytes) in the text
+    fn char_len(&self) -> usize {
+        self.text.chars().count()
+    }
+
+    /// Move cursor to the beginning of text
+    fn home(&mut self) {
+        self.cursor = 0;
+    }
+
+    /// Move cursor to the end of text
+    fn end(&mut self) {
+        self.cursor = self.text.len();
+    }
+
+    /// Insert one character at the current cursor position
+    fn insert(&mut self, c: char) {
+        self.text.insert(self.cursor, c);
+        self.cursor += c.len();
+    }
+
+    /// Move cursor left one **character**. This may be multiple bytes, if the
+    /// character to the left is multiple bytes.
+    fn left(&mut self) {
+        if !self.is_at_home() {
+            // unstable: use floor_char_boundary
+            // https://github.com/rust-lang/rust/issues/93743
+            // We know there's a char to the left, but we don't know how long
+            // it is. Keep jumping left until we've hit a char boundary
+            self.cursor -= 1;
+            while !self.text.is_char_boundary(self.cursor) {
+                self.cursor -= 1;
+            }
+        }
+    }
+
+    /// Move cursor right one character
+    fn right(&mut self) {
+        if !self.is_at_end() {
+            // unstable: use ceil_char_boundary
+            // https://github.com/rust-lang/rust/issues/93743
+            // We checked that we're not at the end of a string, and we know the
+            // cursor must be on a char boundary, so jump by the length of the
+            // next char
+            let next_char = self.text[self.cursor..]
+                .chars()
+                .next()
+                .expect("Another char (not at end of string yet)");
+            self.cursor += next_char.len();
+        }
+    }
+
+    /// Delete character immediately left of the cursor
+    fn delete_left(&mut self) {
+        if !self.is_at_home() {
+            self.left();
+            self.text.remove(self.cursor);
+        }
+    }
+
+    /// Delete character immediately rightof the cursor
+    fn delete_right(&mut self) {
+        if !self.is_at_end() {
+            self.text.remove(self.cursor);
+        }
+    }
+
+    /// Get the **character** offset of the cursor into the text
+    fn cursor_offset(&self) -> usize {
+        self.text[..self.cursor].chars().count()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_insert() {
+        let mut state = TextState::default();
+        state.insert('a');
+        state.insert('b');
+        state.left();
+        state.insert('c');
+        assert_eq!(state.text, "acb");
+
+        state.home();
+        state.insert('h');
+        state.end();
+        state.insert('e');
+        assert_eq!(state.text, "hacbe")
+    }
+
+    #[test]
+    fn test_delete() {
+        let mut state = TextState {
+            text: "abcde".into(),
+            cursor: 0,
+        };
+
+        // does nothing
+        state.delete_left();
+        assert_eq!(state.text, "abcde");
+
+        state.delete_right();
+        assert_eq!(state.text, "bcde");
+
+        state.right();
+        state.delete_left();
+        assert_eq!(state.text, "cde");
+
+        // does nothing
+        state.end();
+        state.delete_right();
+        assert_eq!(state.text, "cde");
+
+        state.delete_left();
+        assert_eq!(state.text, "cd");
+    }
+
+    #[test]
+    fn test_multi_char() {
+        let mut state = TextState {
+            text: "äëõß".into(),
+            cursor: 0,
+        };
+        state.delete_right();
+        state.end();
+        state.delete_left();
+        assert_eq!(state.text, "ëõ");
+
+        state.left();
+        state.insert('ü');
+        assert_eq!(state.text, "ëüõ");
+
+        assert_eq!(state.cursor_offset(), 2);
+    }
+}

--- a/src/tui/view/component/primary.rs
+++ b/src/tui/view/component/primary.rs
@@ -274,7 +274,7 @@ impl<'a> Draw<PrimaryViewProps<'a>> for PrimaryView {
                 let [left_area, right_area] = layout(
                     area,
                     Direction::Horizontal,
-                    [Constraint::Max(40), Constraint::Percentage(50)],
+                    [Constraint::Max(40), Constraint::Min(40)],
                 );
 
                 // Split left column vertically

--- a/src/tui/view/theme.rs
+++ b/src/tui/view/theme.rs
@@ -33,6 +33,9 @@ pub struct Theme {
     pub template_preview_text: Style,
     pub template_preview_error: Style,
 
+    pub text_box_text: Style,
+    pub text_box_cursor: Style,
+
     /// Text that needs some visual emphasis/separation
     pub text_highlight: Style,
 }
@@ -84,6 +87,9 @@ impl Default for Theme {
 
             template_preview_text: Style::default().fg(Color::Blue),
             template_preview_error: Style::default().bg(ERROR_COLOR),
+
+            text_box_text: Style::default(),
+            text_box_cursor: Style::default().bg(Color::White).fg(Color::Black),
 
             text_highlight: Style::default().fg(Color::Black).bg(PRIMARY_COLOR),
         }


### PR DESCRIPTION
Having `tui-textarea` as a dep was annoying. It was way overkill for what we need and also blocked ratatui upgrades. This replaces it with a much simpler text box that gives us more control over styling and behavior.