### PR TITLE
Fix scrolling on response body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Move checkbox to left side of toggle tables
 
+### Fixed
+
+- Fix scrolling on response body pane
+
 ## [0.13.0] - 2024-02-21
 
 ### Added

--- a/src/tui/view/common/text_window.rs
+++ b/src/tui/view/common/text_window.rs
@@ -88,9 +88,10 @@ impl<T: Debug> EventHandler for TextWindow<T> {
     }
 }
 
-impl<'a, T> Draw for &'a TextWindow<T>
+impl<T> Draw for TextWindow<T>
 where
-    &'a T: 'a + Generate<Output<'a> = Text<'a>>,
+    T: 'static,
+    for<'a> &'a T: Generate<Output<'a> = Text<'a>>,
 {
     fn draw(&self, frame: &mut Frame, _: (), area: Rect) {
         let theme = &TuiContext::get().theme;
@@ -128,7 +129,7 @@ where
 
         // Darw the text content
         frame.render_widget(
-            Paragraph::new(self.text.generate()).scroll((self.offset_y, 0)),
+            Paragraph::new(text).scroll((self.offset_y, 0)),
             text_area,
         );
     }

--- a/src/tui/view/component.rs
+++ b/src/tui/view/component.rs
@@ -108,16 +108,6 @@ impl<P, T: Draw<P>> Draw<P> for Component<T> {
     }
 }
 
-impl<'a, P, T> Draw<P> for &'a Component<T>
-where
-    &'a T: Draw<P>,
-{
-    fn draw(&self, frame: &mut Frame, props: P, area: Rect) {
-        self.area.set(area); // Cache the visual area, for event handling
-        (&self.inner).draw(frame, props, area);
-    }
-}
-
 impl<T> From<T> for Component<T> {
     fn from(inner: T) -> Self {
         Self::new(inner)

--- a/src/tui/view/component/response.rs
+++ b/src/tui/view/component/response.rs
@@ -20,7 +20,7 @@ use crate::{
         },
     },
 };
-use derive_more::Display;
+use derive_more::{Debug, Display};
 use itertools::Itertools;
 use ratatui::{
     prelude::{Alignment, Constraint, Direction, Rect},
@@ -165,9 +165,11 @@ impl<'a> Draw<ResponsePaneProps<'a>> for ResponsePane {
 /// Display response success state (tab container)
 #[derive(Debug)]
 struct CompleteResponseContent {
+    #[debug(skip)]
     tabs: Component<Tabs<Tab>>,
     /// Persist the response body to track view state. Update whenever the
     /// loaded request changes
+    #[debug(skip)]
     body: Component<ResponseContentBody>,
 }
 

--- a/src/tui/view/component/response/body.rs
+++ b/src/tui/view/component/response/body.rs
@@ -16,6 +16,7 @@ use crate::{
     util::ResultExt,
 };
 use anyhow::Context;
+use derive_more::Debug;
 use ratatui::{
     layout::{Constraint, Direction},
     prelude::Rect,
@@ -28,10 +29,12 @@ use serde_json_path::JsonPath;
 pub struct ResponseContentBody {
     /// Response body text content. State cell allows us to reset this whenever
     /// the request changes
+    #[debug(skip)]
     text_window: StateCell<StateKey, Component<TextWindow<String>>>,
     /// Expression used to filter the content of the body down
     query: Option<Query>,
     /// Where the user enters their body query
+    #[debug(skip)]
     query_text_box: Component<TextBox>,
 }
 
@@ -141,7 +144,7 @@ impl<'a> Draw<ResponseContentBodyProps<'a>> for ResponseContentBody {
                 self.query.as_ref(),
             )
         });
-        text.inner().draw(frame, (), body_area);
+        text.draw(frame, (), body_area);
 
         self.query_text_box.draw(frame, (), query_area);
     }


### PR DESCRIPTION
Response body wasn't scrolling because I was accidentally calling `.draw()` directly on the `TextWindow` rather than the wrapping `Component`, meaning the visual area never got set and the cursor events were never forwarded.

In the process I also cleaned up some lifetimes on `Draw` impls, to make this less likely to happen again in the future.