### PR TITLE
Add `ignore_certificate_hosts` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Add config option `ignore_certificate_hosts` ([#109](https://github.com/LucasPickering/slumber/issues/109))
+
 ### Fixed
 
 - Fix prompt in TUI always rendering as sensitive ([#108](https://github.com/LucasPickering/slumber/issues/108))

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -24,3 +24,7 @@
   - [Chain Source](./api/chain_source.md)
   - [Template](./api/template.md)
   - [Content Type](./api/content_type.md)
+
+# Troubleshooting
+
+- [TLS Certificate Errors](./troubleshooting/tls.md)

--- a/docs/src/api/configuration.md
+++ b/docs/src/api/configuration.md
@@ -21,6 +21,7 @@ If the root directory doesn't exist yet, you can create it yourself or have Slum
 
 ## Fields
 
-| Field               | Type      | Description                                                                  | Default |
-| ------------------- | --------- | ---------------------------------------------------------------------------- | ------- |
-| `preview_templates` | `boolean` | Render template values in the TUI? If false, the raw template will be shown. | `true`  |
+| Field                      | Type       | Description                                                                                     | Default |
+| -------------------------- | ---------- | ----------------------------------------------------------------------------------------------- | ------- |
+| `preview_templates`        | `boolean`  | Render template values in the TUI? If false, the raw template will be shown.                    | `true`  |
+| `ignore_certificate_hosts` | `string[]` | Hostnames whose TLS certificate errors will be ignored. [More info](../troubleshooting/tls.md). | `[]`    |

--- a/docs/src/troubleshooting/tls.md
+++ b/docs/src/troubleshooting/tls.md
@@ -1,0 +1,17 @@
+# TLS Certificate Errors
+
+If you're receiving certificate errors such as this one:
+
+```
+invalid peer certificate: UnknownIssuer
+```
+
+This is probably because the TLS certificate of the server you're hitting is expired, invalid, or self-signed. The best solution is to fix the error on the server, either by renewing the certificate or creating a signed one. In most cases this is the best solution. If not possible, you should just disable TLS on your server because it's not doing anything for you anyway.
+
+If you can't or don't want to fix the certificate, and you need to keep TLS enabled for some reason, it's possible to configure Slumber to ignore TLS certificate errors on certain hosts.
+
+> **WARNING:** This is dangerous. You will be susceptible to MITM attacks on these hosts. Only do this if you control the server you're hitting, and are confident your network is not compromised.
+
+- Open your [Slumber configuration](../api/configuration.md)
+- Add the field `ignore_certificate_hosts: ["<hostname>"]`
+  - `<hostname>` is the domain or IP of the server you're requesting from

--- a/src/cli/request.rs
+++ b/src/cli/request.rs
@@ -1,6 +1,7 @@
 use crate::{
     cli::Subcommand,
     collection::{CollectionFile, ProfileId, RecipeId},
+    config::Config,
     db::Database,
     http::{HttpEngine, RecipeOptions, RequestBuilder},
     template::{Prompt, Prompter, TemplateContext},
@@ -70,6 +71,7 @@ pub struct RequestCommand {
 impl Subcommand for RequestCommand {
     async fn execute(self, global: GlobalArgs) -> anyhow::Result<ExitCode> {
         let collection_path = CollectionFile::try_path(global.collection)?;
+        let config = Config::load()?;
         let database = Database::load()?.into_collection(&collection_path)?;
         let mut collection_file = CollectionFile::load(collection_path).await?;
         let collection = &mut collection_file.collection;
@@ -123,7 +125,7 @@ impl Subcommand for RequestCommand {
             }
 
             // Run the request
-            let http_engine = HttpEngine::new(database);
+            let http_engine = HttpEngine::new(&config, database);
             let record = http_engine.send(request).await?;
             let status = record.response.status;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,10 @@ pub struct Config {
     /// the file didn't exist
     #[serde(skip)]
     path: PathBuf,
+
+    /// TLS cert errors on these hostnames are ignored. Be careful!
+    #[serde(default)]
+    pub ignore_certificate_hosts: Vec<String>,
     /// Should templates be rendered inline in the UI, or should we show the
     /// raw text?
     pub preview_templates: bool,
@@ -64,6 +68,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             path: PathBuf::default(),
+            ignore_certificate_hosts: Vec::new(),
             preview_templates: true,
         }
     }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -85,6 +85,7 @@ impl Tui {
         let messages_tx = MessageSender::new(messages_tx);
         // Load a database for this particular collection
         let database = Database::load()?.into_collection(&collection_path)?;
+        let http_engine = HttpEngine::new(&config, database.clone());
         // Initialize global view context
         TuiContext::init(config, messages_tx.clone(), database.clone());
 
@@ -109,7 +110,7 @@ impl Tui {
             terminal,
             messages_rx,
             messages_tx,
-            http_engine: HttpEngine::new(database.clone()),
+            http_engine,
 
             collection_file,
             should_run: true,


### PR DESCRIPTION
This allows you to ignore TLS cert errors on certain domains. Closes #109