### PR TITLE
Add shortcuts for defining authentication in a recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add config option `ignore_certificate_hosts` ([#109](https://github.com/LucasPickering/slumber/issues/109))
 - Add menu action to open collection file in editor ([#105](https://github.com/LucasPickering/slumber/issues/105))
+- Add `authentication` field to request recipe ([#110](https://github.com/LucasPickering/slumber/issues/110))
 
 ### Fixed
 
@@ -13,6 +14,7 @@
 - Fix content type identification for extended JSON MIME types ([#103](https://github.com/LucasPickering/slumber/issues/103))
 - Use named records in binary blobs in the local DB
   - This required wiping out existing binary blobs, meaning **all request history and UI state will be lost on upgrade**
+- Fix basic auth in Insomnia import
 
 ## [0.13.1] - 2024-03-07
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,6 +425,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1298,6 +1304,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1821,6 +1837,7 @@ dependencies = [
  "nom",
  "notify",
  "open",
+ "pretty_assertions",
  "ratatui",
  "regex",
  "reqwest",
@@ -2731,6 +2748,12 @@ name = "xml-rs"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ itertools = "^0.12.0"
 nom = "7.1.3"
 notify = {version = "^6.1.1", default-features = false, features = ["macos_fsevent"]}
 open = "5.1.1"
+pretty_assertions = "1.4.0"
 ratatui = "^0.26.0"
 regex = { version = "1.10.3", default-features = false, features = ["perf"] }
 reqwest = {version = "^0.11.20", default-features = false, features = ["rustls-tls"]}

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -20,6 +20,7 @@
   - [Profile](./api/profile.md)
   - [Profile Value](./api/profile_value.md)
   - [Request Recipe](./api/request_recipe.md)
+  - [Authentication](./api/authentication.md)
   - [Chain](./api/chain.md)
   - [Chain Source](./api/chain_source.md)
   - [Template](./api/template.md)

--- a/docs/src/api/authentication.md
+++ b/docs/src/api/authentication.md
@@ -1,0 +1,29 @@
+# Authentication
+
+Authentication provides shortcuts for common HTTP authentication schemes. It populates the `authentication` field of a recipe. There are multiple source types, and the type is specified using [YAML's tag syntax](https://yaml.org/spec/1.2.2/#24-tags).
+
+## Variants
+
+| Variant  | Type                                            | Value                                                                                                          |
+| -------- | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `basic`  | [`Basic Authentication`](#basic-authentication) | [Basic authentication](https://swagger.io/docs/specification/authentication/basic-authentication/) credentials |
+| `bearer` | `string`                                        | [Bearer token](https://swagger.io/docs/specification/authentication/bearer-authentication/)                    |
+
+### Basic Authentication
+
+Basic authentication contains a username and optional password.
+
+| Field      | Type     | Description | Default  |
+| ---------- | -------- | ----------- | -------- |
+| `username` | `string` | Username    | Required |
+| `password` | `string` | Password    | `""`     |
+
+## Examples
+
+```yaml
+!basic
+username: user
+password: pass
+---
+!bearer 4J2e0TYqKA3gFllfTu17OF7n8g1CeAxZyi/MK5g40/o=
+```

--- a/docs/src/api/request_recipe.md
+++ b/docs/src/api/request_recipe.md
@@ -4,14 +4,15 @@ A request recipe defines how to make a particular request. For a REST API, you'l
 
 ## Fields
 
-| Field     | Type                                         | Description                       | Default                |
-| --------- | -------------------------------------------- | --------------------------------- | ---------------------- |
-| `name`    | `string`                                     | Descriptive name to use in the UI | Value of key in parent |
-| `method`  | `string`                                     | HTTP request method               | Required               |
-| `url`     | [`Template`](./template.md)                  | HTTP request URL                  | Required               |
-| `query`   | [`mapping[string, Template]`](./template.md) | HTTP request query parameters     | `{}`                   |
-| `headers` | [`mapping[string, Template]`](./template.md) | HTTP request headers              | `{}`                   |
-| `body`    | [`Template`](./template.md)                  | HTTP request body                 | `null`                 |
+| Field            | Type                                         | Description                       | Default                |
+| ---------------- | -------------------------------------------- | --------------------------------- | ---------------------- |
+| `name`           | `string`                                     | Descriptive name to use in the UI | Value of key in parent |
+| `method`         | `string`                                     | HTTP request method               | Required               |
+| `url`            | [`Template`](./template.md)                  | HTTP request URL                  | Required               |
+| `query`          | [`mapping[string, Template]`](./template.md) | HTTP request query parameters     | `{}`                   |
+| `headers`        | [`mapping[string, Template]`](./template.md) | HTTP request headers              | `{}`                   |
+| `authentication` | [`Authentication`](./authentication.md)      | Authentication scheme             | `null`                 |
+| `body`           | [`Template`](./template.md)                  | HTTP request body                 | `null`                 |
 
 ## Examples
 

--- a/docs/src/user_guide/inheritance.md
+++ b/docs/src/user_guide/inheritance.md
@@ -21,14 +21,14 @@ requests:
     url: "{{host}}/fishes"
     headers:
       Accept: application/json
-      Authorization: Bearer {{chains.token}}
+    authentication: !bearer "{{chains.token}}"
 
   get_fish:
     method: GET
     url: "{{host}}/fishes/{{fish_id}}"
     headers:
       Accept: application/json
-      Authorization: Bearer {{chains.token}}
+    authentication: !bearer "{{chains.token}}"
 ```
 
 ## The Solution
@@ -51,7 +51,7 @@ chains:
 request_base: &request_base
   headers:
     Accept: application/json
-    Authorization: Bearer {{chains.auth_token}}
+  authentication: !bearer "{{chains.token}}"
 
 requests:
   list_fish:
@@ -85,7 +85,7 @@ chains:
 request_base: &request_base
   headers: &headers_base # This will let us pull in the header map to extend it
     Accept: application/json
-    Authorization: Bearer {{chains.auth_token}}
+  authentication: !bearer "{{chains.token}}"
 
 requests:
   list_fish:
@@ -99,9 +99,6 @@ requests:
     url: "{{host}}/fishes/{{chains.fish_id}}"
 
   create_fish:
-    # Note: in this case, pulling in request_base doesn't do anything since we
-    # then overwite its only field (headers), but this is good practice in case
-    # you add an additional field to request_base
     <<: *request_base
     method: POST
     url: "{{host}}/fishes"

--- a/slumber.yml
+++ b/slumber.yml
@@ -26,9 +26,9 @@ chains:
     selector: $.headers["X-Amzn-Trace-Id"]
 
 base: &base
+  authentication: !bearer "{{chains.auth_token}}"
   headers:
     Accept: application/json
-    Authorization: Bearer {{chains.auth_token}}
     Content-Type: application/json
 
 requests:

--- a/src/collection/models.rs
+++ b/src/collection/models.rs
@@ -14,6 +14,7 @@ use std::path::PathBuf;
 /// A collection of profiles, requests, etc. This is the primary Slumber unit
 /// of configuration.
 #[derive(Debug, Default, Serialize, Deserialize)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct Collection {
     #[serde(default, deserialize_with = "cereal::deserialize_id_map")]
     pub profiles: IndexMap<ProfileId, Profile>,
@@ -31,6 +32,7 @@ pub struct Collection {
 
 /// Mutually exclusive hot-swappable config group
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct Profile {
     #[serde(skip)] // This will be auto-populated from the map key
     pub id: ProfileId,
@@ -80,6 +82,7 @@ pub enum ProfileValue {
 /// not called `RequestTemplate` because the word "template" has a specific
 /// meaning related to string interpolation.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct Recipe {
     #[serde(skip)] // This will be auto-populated from the map key
     pub id: RecipeId,
@@ -89,6 +92,7 @@ pub struct Recipe {
     pub method: String,
     pub url: Template,
     pub body: Option<Template>,
+    pub authentication: Option<Authentication>,
     #[serde(default)]
     pub query: IndexMap<String, Template>,
     #[serde(default)]
@@ -117,10 +121,27 @@ impl PartialEq<Recipe> for RecipeId {
     }
 }
 
+/// Shortcut for defining authentication method. If this is defined in addition
+/// to the `Authorization` header, that header will end up being included in the
+/// request twice.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(PartialEq))]
+#[serde(rename_all = "snake_case")]
+pub enum Authentication {
+    /// `Authorization: Basic {username:password | base64}`
+    Basic {
+        username: Template,
+        password: Option<Template>,
+    },
+    /// `Authorization: Bearer {token}`
+    Bearer(Template),
+}
+
 /// A chain is a means to data from one response in another request. The chain
 /// is the middleman: it defines where and how to pull the value, then recipes
 /// can use it in a template via `{{chains.<chain_id>}}`.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct Chain {
     #[serde(skip)] // This will be auto-populated from the map key
     pub id: ChainId,
@@ -178,6 +199,7 @@ impl Equivalent<ChainId> for ChainId<&str> {
 
 /// The source of data for a chain
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(PartialEq))]
 #[serde(rename_all = "snake_case")]
 pub enum ChainSource {
     /// Load data from the most recent response of a particular request recipe

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -24,6 +24,7 @@ factori!(Request, {
         method = Method::GET,
         url = "http://localhost/url".parse().unwrap(),
         headers = HeaderMap::new(),
+        authentication = None,
         body = None,
     }
 });

--- a/src/http/record.rs
+++ b/src/http/record.rs
@@ -102,11 +102,24 @@ pub struct Request {
 
     #[serde(with = "serde_method")]
     pub method: Method,
+    /// URL, including query params/fragment
     pub url: Url,
     #[serde(with = "serde_header_map")]
     pub headers: HeaderMap,
+    #[serde(default)]
+    pub authentication: Option<Authentication>,
     /// Body content as bytes. This should be decoded as needed
     pub body: Option<Bytes>,
+}
+
+/// A copy of [collection::Authentication], with templates rendered to strings
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum Authentication {
+    Basic {
+        username: String,
+        password: Option<String>,
+    },
+    Bearer(String),
 }
 
 /// A resolved HTTP response, with all content loaded and ready to be displayed

--- a/src/template.rs
+++ b/src/template.rs
@@ -65,15 +65,17 @@ impl Template {
     /// for the purpose of being serialized, e.g. when importing an external
     /// config into a request collection.
     ///
-    /// If you try to render this thing, you'll get garbage. The "correct" thing
-    /// to do would be to add some safeguards to make that impossible (either
-    /// type state or a runtime check), but it's not worth the extra code for
-    /// something that is very unlikely to happen. It says "dangerous", don't be
-    /// stupid.
-    pub(crate) fn dangerous_new(template: String) -> Self {
+    /// If you try to render this thing, you'll always get the raw string back.
+    /// The "correct" thing to do would be to add some safeguards to make that
+    /// impossible (either type state or a runtime check), but it's not worth
+    /// the extra code for something that is very unlikely to happen. It says
+    /// "dangerous", don't be stupid.
+    pub(crate) fn dangerous(template: String) -> Self {
+        // Create one raw chunk for everything
+        let chunk = TemplateInputChunk::Raw(Span::new(0, template.len()));
         Self {
             template,
-            chunks: Vec::new(),
+            chunks: vec![chunk],
         }
     }
 }

--- a/src/template/render.rs
+++ b/src/template/render.rs
@@ -42,6 +42,19 @@ impl Template {
             .traced()
     }
 
+    /// Render an optional template. This is useful because `Option::map`
+    /// doesn't work with an async operation in the closure
+    pub async fn render_opt(
+        template: &Option<Self>,
+        context: &TemplateContext,
+    ) -> anyhow::Result<Option<String>> {
+        if let Some(template) = template {
+            Ok(Some(template.render(context).await?))
+        } else {
+            Ok(None)
+        }
+    }
+
     /// Render the template string using values from the given context,
     /// returning the individual rendered chunks. This is useful in any
     /// application where rendered chunks need to be handled differently from

--- a/test_data/insomnia.json
+++ b/test_data/insomnia.json
@@ -1,0 +1,210 @@
+{
+  "_type": "export",
+  "__export_format": 4,
+  "__export_date": "2024-03-16T21:32:08.712Z",
+  "__export_source": "insomnia.desktop.app:v8.6.1",
+  "resources": [
+    {
+      "_id": "req_467d7ec5ceee4893aa443b09e25c6e53",
+      "parentId": "wrk_scratchpad",
+      "modified": 1710623983901,
+      "created": 1710623974770,
+      "url": "https://httpbin.org/get",
+      "name": "No Auth",
+      "description": "",
+      "method": "GET",
+      "body": {},
+      "parameters": [],
+      "headers": [
+        {
+          "name": "User-Agent",
+          "value": "insomnia/8.6.1"
+        }
+      ],
+      "authentication": {},
+      "metaSortKey": -1710623974770,
+      "isPrivate": false,
+      "pathParameters": [],
+      "settingStoreCookies": true,
+      "settingSendCookies": true,
+      "settingDisableRenderRequestBody": false,
+      "settingEncodeUrl": true,
+      "settingRebuildPath": true,
+      "settingFollowRedirects": "global",
+      "_type": "request"
+    },
+    {
+      "_id": "wrk_scratchpad",
+      "parentId": null,
+      "modified": 1710623607163,
+      "created": 1710623607163,
+      "name": "Scratch Pad",
+      "description": "",
+      "scope": "collection",
+      "_type": "workspace"
+    },
+    {
+      "_id": "req_30f68ae3069b4ec59707bf793a4b74cb",
+      "parentId": "wrk_scratchpad",
+      "modified": 1710623989622,
+      "created": 1710623967061,
+      "url": "https://httpbin.org/get",
+      "name": "Bearer Auth",
+      "description": "",
+      "method": "GET",
+      "body": {},
+      "parameters": [],
+      "headers": [
+        {
+          "name": "User-Agent",
+          "value": "insomnia/8.6.1"
+        }
+      ],
+      "authentication": {
+        "type": "bearer",
+        "token": "asdfasdf"
+      },
+      "metaSortKey": -1710623967061,
+      "isPrivate": false,
+      "pathParameters": [],
+      "settingStoreCookies": true,
+      "settingSendCookies": true,
+      "settingDisableRenderRequestBody": false,
+      "settingEncodeUrl": true,
+      "settingRebuildPath": true,
+      "settingFollowRedirects": "global",
+      "_type": "request"
+    },
+    {
+      "_id": "req_b537f7f12d2f4dffbda12fdff2ff3704",
+      "parentId": "wrk_scratchpad",
+      "modified": 1710623995429,
+      "created": 1710623638685,
+      "url": "https://httpbin.org/get",
+      "name": "Basic Auth",
+      "description": "",
+      "method": "GET",
+      "body": {},
+      "parameters": [],
+      "headers": [
+        {
+          "name": "User-Agent",
+          "value": "insomnia/8.6.1"
+        }
+      ],
+      "authentication": {
+        "type": "basic",
+        "useISO88591": false,
+        "disabled": false,
+        "username": "user",
+        "password": "pass"
+      },
+      "metaSortKey": -1710623638685,
+      "isPrivate": false,
+      "pathParameters": [],
+      "settingStoreCookies": true,
+      "settingSendCookies": true,
+      "settingDisableRenderRequestBody": false,
+      "settingEncodeUrl": true,
+      "settingRebuildPath": true,
+      "settingFollowRedirects": "global",
+      "_type": "request"
+    },
+    {
+      "_id": "req_bff9461c4e81463b890856a283d5e2f3",
+      "parentId": "wrk_scratchpad",
+      "modified": 1710624637410,
+      "created": 1710624620060,
+      "url": "https://httpbin.org/post",
+      "name": "With Body",
+      "description": "",
+      "method": "POST",
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\n\t\"message\": \"hello!\"\n}"
+      },
+      "parameters": [],
+      "headers": [
+        {
+          "name": "Content-Type",
+          "value": "application/json"
+        },
+        {
+          "name": "User-Agent",
+          "value": "insomnia/8.6.1"
+        }
+      ],
+      "authentication": {},
+      "metaSortKey": -1700797504081.5,
+      "isPrivate": false,
+      "pathParameters": [],
+      "settingStoreCookies": true,
+      "settingSendCookies": true,
+      "settingDisableRenderRequestBody": false,
+      "settingEncodeUrl": true,
+      "settingRebuildPath": true,
+      "settingFollowRedirects": "global",
+      "_type": "request"
+    },
+    {
+      "_id": "env_99d30891da4bdcebc63947a8fc17f076de878684",
+      "parentId": "wrk_scratchpad",
+      "modified": 1710624720355,
+      "created": 1710623619898,
+      "name": "Base Environment",
+      "data": {},
+      "dataPropertyOrder": {},
+      "color": null,
+      "isPrivate": false,
+      "metaSortKey": 1710623619898,
+      "_type": "environment"
+    },
+    {
+      "_id": "jar_99d30891da4bdcebc63947a8fc17f076de878684",
+      "parentId": "wrk_scratchpad",
+      "modified": 1710623619901,
+      "created": 1710623619901,
+      "name": "Default Jar",
+      "cookies": [],
+      "_type": "cookie_jar"
+    },
+    {
+      "_id": "env_b54010f85b024f5d89724bd918f983ec",
+      "parentId": "env_99d30891da4bdcebc63947a8fc17f076de878684",
+      "modified": 1710624708900,
+      "created": 1710624684621,
+      "name": "Local",
+      "data": {
+        "host": "http://localhost:3000"
+      },
+      "dataPropertyOrder": {
+        "&": [
+          "host"
+        ]
+      },
+      "color": null,
+      "isPrivate": false,
+      "metaSortKey": 1710624684621,
+      "_type": "environment"
+    },
+    {
+      "_id": "env_6203e0435e4f44e19406bde63f7bfa62",
+      "parentId": "env_99d30891da4bdcebc63947a8fc17f076de878684",
+      "modified": 1710624701808,
+      "created": 1710624689589,
+      "name": "Remote",
+      "data": {
+        "host": "https://httpbin.org"
+      },
+      "dataPropertyOrder": {
+        "&": [
+          "host"
+        ]
+      },
+      "color": null,
+      "isPrivate": false,
+      "metaSortKey": 1710624689589,
+      "_type": "environment"
+    }
+  ]
+}

--- a/test_data/insomnia_imported.yml
+++ b/test_data/insomnia_imported.yml
@@ -1,0 +1,50 @@
+# What we expect the Insomnia example collection to import as
+profiles:
+  env_99d30891da4bdcebc63947a8fc17f076de878684:
+    name: Base Environment
+    data: {}
+  env_b54010f85b024f5d89724bd918f983ec:
+    name: Local
+    data:
+      host: !raw http://localhost:3000
+  env_6203e0435e4f44e19406bde63f7bfa62:
+    name: Remote
+    data:
+      host: !raw https://httpbin.org
+chains: {}
+requests:
+  req_467d7ec5ceee4893aa443b09e25c6e53:
+    name: No Auth
+    method: GET
+    url: https://httpbin.org/get
+    body: null
+    authentication: null
+    query: {}
+    headers: {}
+  req_30f68ae3069b4ec59707bf793a4b74cb:
+    name: Bearer Auth
+    method: GET
+    url: https://httpbin.org/get
+    body: null
+    authentication: !bearer asdfasdf
+    query: {}
+    headers: {}
+  req_b537f7f12d2f4dffbda12fdff2ff3704:
+    name: Basic Auth
+    method: GET
+    url: https://httpbin.org/get
+    body: null
+    authentication: !basic
+      username: user
+      password: pass
+    query: {}
+    headers: {}
+  req_bff9461c4e81463b890856a283d5e2f3:
+    name: With Body
+    method: POST
+    url: https://httpbin.org/post
+    body: "{\n\t\"message\": \"hello!\"\n}"
+    authentication: null
+    query: {}
+    headers:
+      content-type: application/json


### PR DESCRIPTION
For now only Basic and Bearer auth are supported, but more can be added later. Closes #110