### PR TITLE
Add horizontal scrolling to response body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Add horizontal scrolling to response body ([#111](https://github.com/LucasPickering/slumber/issues/111))
+  - Use shift+left and shift+right
+- Add app version to help modal
+
 ### Changed
 
 - Run prompts while rendering request URL/body to be copied

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.74.0"
 anyhow = {version = "^1.0.75", features = ["backtrace"]}
 async-trait = "^0.1.73"
 base64 = "0.22.0"
-bytes = { version = "1.5.0", features = ["serde"] }
+bytes = {version = "1.5.0", features = ["serde"]}
 chrono = {version = "^0.4.31", default-features = false, features = ["clock", "serde", "std"]}
 clap = {version = "^4.4.2", features = ["derive"]}
 cli-clipboard = "0.4.0"
@@ -30,8 +30,8 @@ nom = "7.1.3"
 notify = {version = "^6.1.1", default-features = false, features = ["macos_fsevent"]}
 open = "5.1.1"
 pretty_assertions = "1.4.0"
-ratatui = "^0.26.0"
-regex = { version = "1.10.3", default-features = false, features = ["perf"] }
+ratatui = {version = "^0.26.0", features = ["unstable-rendered-line-info"]}
+regex = {version = "1.10.3", default-features = false, features = ["perf"]}
 reqwest = {version = "^0.11.20", default-features = false, features = ["rustls-tls"]}
 rmp-serde = "^1.1.2"
 rusqlite = {version = "^0.30.0", default-features = false, features = ["bundled", "chrono", "uuid"]}
@@ -46,7 +46,7 @@ thiserror = "^1.0.48"
 tokio = {version = "^1.32.0", default-features = false, features = ["full"]}
 tracing = "^0.1.37"
 tracing-subscriber = {version = "^0.3.17", default-features = false, features = ["env-filter", "fmt", "registry"]}
-url = { version = "^2.5.0", features = ["serde"] }
+url = {version = "^2.5.0", features = ["serde"]}
 uuid = {version = "^1.4.1", default-features = false, features = ["serde", "v4"]}
 
 [dev-dependencies]

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -35,6 +35,20 @@ impl InputEngine {
                     Action::ForceQuit,
                 )
                 .hide(),
+                InputBinding::new(
+                    KeyCombination {
+                        key_code: KeyCode::Left,
+                        modifiers: KeyModifiers::SHIFT,
+                    },
+                    Action::ScrollLeft,
+                ),
+                InputBinding::new(
+                    KeyCombination {
+                        key_code: KeyCode::Right,
+                        modifiers: KeyModifiers::SHIFT,
+                    },
+                    Action::ScrollRight,
+                ),
                 InputBinding::new(KeyCode::Char('x'), Action::OpenActions),
                 InputBinding::new(KeyCode::Char('?'), Action::OpenHelp),
                 InputBinding::new(KeyCode::Char('f'), Action::Fullscreen),
@@ -85,6 +99,8 @@ impl InputEngine {
                 MouseEventKind::Up(MouseButton::Middle) => None,
                 MouseEventKind::ScrollDown => Some(Action::ScrollDown),
                 MouseEventKind::ScrollUp => Some(Action::ScrollUp),
+                MouseEventKind::ScrollLeft => Some(Action::ScrollLeft),
+                MouseEventKind::ScrollRight => Some(Action::ScrollRight),
                 _ => None,
             },
 
@@ -129,16 +145,18 @@ impl Default for InputEngine {
 /// modal (but doesn't affect behavior).
 #[derive(Copy, Clone, Debug, Display, Eq, Hash, PartialEq)]
 pub enum Action {
-    /// This is mapped to mouse events, so it's a bit unique. Use the
-    /// associated event for button/position info
-    // #[display("Click")]
-    // Click(MouseEvent),
     // Mouse actions do *not* get mapped, they're hard-coded. Use the
     // associated raw event for button/position info if needed
     LeftClick,
     RightClick,
     ScrollUp,
     ScrollDown,
+    /// This can be triggered by mouse event OR key event
+    #[display("Scroll Left")]
+    ScrollLeft,
+    /// This can be triggered by mouse event OR key event
+    #[display("Scroll Right")]
+    ScrollRight,
 
     /// Exit the app
     Quit,
@@ -253,6 +271,12 @@ impl KeyCombination {
 
 impl Display for KeyCombination {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Write modifiers first
+        for (name, _) in self.modifiers.iter_names() {
+            write!(f, "{}+", name.to_lowercase())?;
+        }
+
+        // Write base code
         match self.key_code {
             KeyCode::BackTab => write!(f, "<shift+tab>"),
             KeyCode::Tab => write!(f, "<tab>"),


### PR DESCRIPTION
Shift+left and shift+right allow for horizontal scrolling now. Theoretically you can also use whatever your native horizontal scroll action is, but that wasn't working for me (in iTerm). Crossterm has `ScrollLeft` and `ScrollRight` [mouse events](https://docs.rs/crossterm/latest/crossterm/event/enum.MouseEventKind.html), but they weren't triggering for me at all (`ScrollUp` and `ScrollDown` work fine). I wasn't able to figure this out but I really don't think it's a bug in Slumber, either crossterm or iTerm.

Closes #111 