### PR TITLE
Add hotkeys for primary panes, redesign profile pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - Use shift+left and shift+right
 - Add app version to help modal
 - Add "Copy as cURL" action to recipe menu ([#123](https://github.com/LucasPickering/slumber/issues/123))
+- Add hotkeys to select different panes
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Changed
 
 - Run prompts while rendering request URL/body to be copied
+- Improve UI design of profile pane
 
 ## [0.14.0] - 2024-03-18
 

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -52,8 +52,8 @@ impl InputEngine {
                 InputBinding::new(KeyCode::Char('x'), Action::OpenActions),
                 InputBinding::new(KeyCode::Char('?'), Action::OpenHelp),
                 InputBinding::new(KeyCode::Char('f'), Action::Fullscreen),
-                InputBinding::new(KeyCode::Char('r'), Action::ReloadCollection),
                 InputBinding::new(KeyCode::F(2), Action::SendRequest),
+                InputBinding::new(KeyCode::F(5), Action::ReloadCollection),
                 InputBinding::new(KeyCode::Char('/'), Action::Search),
                 InputBinding::new(KeyCode::BackTab, Action::PreviousPane),
                 InputBinding::new(KeyCode::Tab, Action::NextPane),
@@ -67,6 +67,18 @@ impl InputEngine {
                 InputBinding::new(KeyCode::End, Action::End).hide(),
                 InputBinding::new(KeyCode::Enter, Action::Submit),
                 InputBinding::new(KeyCode::Esc, Action::Cancel),
+                // Hide these because they have inline hints
+                InputBinding::new(
+                    KeyCode::Char('p'),
+                    Action::SelectProfileList,
+                )
+                .hide(),
+                InputBinding::new(KeyCode::Char('l'), Action::SelectRecipeList)
+                    .hide(),
+                InputBinding::new(KeyCode::Char('r'), Action::SelectRecipe)
+                    .hide(),
+                InputBinding::new(KeyCode::Char('s'), Action::SelectResponse)
+                    .hide(),
             ]
             .into_iter()
             .map(|binding| (binding.action, binding))
@@ -83,6 +95,17 @@ impl InputEngine {
     /// input in reverse, when showing available bindings to the user.
     pub fn binding(&self, action: Action) -> Option<InputBinding> {
         self.bindings.get(&action).copied()
+    }
+
+    /// Append a hotkey hint to a label. If the given action is bound, adding
+    /// a hint to the end of the given label. If unbound, return the label
+    /// alone.
+    pub fn add_hint(&self, label: impl Display, action: Action) -> String {
+        if let Some(binding) = self.binding(action) {
+            format!("{} ({})", label, binding.input())
+        } else {
+            label.to_string()
+        }
     }
 
     /// Convert an input event into its bound action, if any
@@ -184,6 +207,8 @@ pub enum Action {
 
     /// Do a thing. E.g. select an item in a list
     Submit,
+    /// Close the current modal/dialog/etc.
+    Cancel,
     /// Send the active request from *any* context
     #[display("Send Request")]
     SendRequest,
@@ -191,7 +216,7 @@ pub enum Action {
     #[display("Search/Filter")]
     Search,
     /// Force a collection reload (typically it's automatic)
-    #[display("Reload")]
+    #[display("Reload Collection")]
     ReloadCollection,
     /// Embiggen a pane
     Fullscreen,
@@ -201,8 +226,14 @@ pub enum Action {
     #[display("Help")]
     /// Open the help modal
     OpenHelp,
-    /// Close the current modal/dialog/etc.
-    Cancel,
+    /// Select profile list pane
+    SelectProfileList,
+    /// Select recipe list pane
+    SelectRecipeList,
+    /// Select recipe pane
+    SelectRecipe,
+    /// Select response pane
+    SelectResponse,
 }
 
 /// A mapping from a key input sequence to an action. This can optionally have

--- a/src/tui/view/component/profile_list.rs
+++ b/src/tui/view/component/profile_list.rs
@@ -2,7 +2,6 @@ use crate::{
     collection::{Profile, ProfileId},
     tui::view::{
         common::{list::List, Pane},
-        component::primary::PrimaryPane,
         draw::{Draw, Generate},
         event::{Event, EventHandler, UpdateContext},
         state::{
@@ -12,7 +11,12 @@ use crate::{
         Component,
     },
 };
-use ratatui::{prelude::Rect, Frame};
+use ratatui::{
+    prelude::Rect,
+    style::{Modifier, Style},
+    widgets::Paragraph,
+    Frame,
+};
 
 #[derive(Debug)]
 pub struct ProfileListPane {
@@ -53,19 +57,38 @@ impl EventHandler for ProfileListPane {
 impl Draw<ProfileListPaneProps> for ProfileListPane {
     fn draw(&self, frame: &mut Frame, props: ProfileListPaneProps, area: Rect) {
         self.profiles.set_area(area); // Needed for tracking cursor events
-        let title = PrimaryPane::ProfileList.to_string();
-        let list = List {
-            block: Some(Pane {
-                title: &title,
-                is_focused: props.is_selected,
-            }),
-            list: &self.profiles,
-        };
-        frame.render_stateful_widget(
-            list.generate(),
-            area,
-            &mut self.profiles.state_mut(),
-        )
+        let block = Pane {
+            title: "Profiles",
+            is_focused: props.is_selected,
+        }
+        .generate();
+        let inner_area = block.inner(area);
+        frame.render_widget(block, area);
+
+        if props.is_selected {
+            // Only show the full list if selected
+            let list = List {
+                block: None,
+                list: &self.profiles,
+            };
+            frame.render_stateful_widget(
+                list.generate(),
+                inner_area,
+                &mut self.profiles.state_mut(),
+            );
+        } else {
+            // Pane is not selected - just show the selected profile
+            let profile = self
+                .profiles()
+                .selected()
+                .map(|profile| profile.name())
+                .unwrap_or("<none>");
+            frame.render_widget(
+                Paragraph::new(profile)
+                    .style(Style::new().add_modifier(Modifier::BOLD)),
+                inner_area,
+            )
+        }
     }
 }
 

--- a/src/tui/view/component/profile_list.rs
+++ b/src/tui/view/component/profile_list.rs
@@ -1,14 +1,18 @@
 use crate::{
     collection::{Profile, ProfileId},
-    tui::view::{
-        common::{list::List, Pane},
-        draw::{Draw, Generate},
-        event::{Event, EventHandler, UpdateContext},
-        state::{
-            persistence::{Persistable, Persistent, PersistentKey},
-            select::{Dynamic, SelectState},
+    tui::{
+        context::TuiContext,
+        input::Action,
+        view::{
+            common::{list::List, Pane},
+            draw::{Draw, Generate},
+            event::{Event, EventHandler, UpdateContext},
+            state::{
+                persistence::{Persistable, Persistent, PersistentKey},
+                select::{Dynamic, SelectState},
+            },
+            Component,
         },
-        Component,
     },
 };
 use ratatui::{
@@ -57,8 +61,11 @@ impl EventHandler for ProfileListPane {
 impl Draw<ProfileListPaneProps> for ProfileListPane {
     fn draw(&self, frame: &mut Frame, props: ProfileListPaneProps, area: Rect) {
         self.profiles.set_area(area); // Needed for tracking cursor events
+        let title = TuiContext::get()
+            .input_engine
+            .add_hint("Profiles", Action::SelectProfileList);
         let block = Pane {
-            title: "Profiles",
+            title: &title,
             is_focused: props.is_selected,
         }
         .generate();

--- a/src/tui/view/component/recipe.rs
+++ b/src/tui/view/component/recipe.rs
@@ -15,7 +15,6 @@ use crate::{
                 text_window::TextWindow,
                 Pane,
             },
-            component::primary::PrimaryPane,
             draw::{Draw, Generate, ToStringGenerate},
             event::{Event, EventHandler, Update, UpdateContext},
             state::{
@@ -57,7 +56,7 @@ impl Default for RecipePane {
     }
 }
 
-pub struct RequestPaneProps<'a> {
+pub struct RecipePaneProps<'a> {
     pub is_selected: bool,
     pub selected_recipe: Option<&'a Recipe>,
     pub selected_profile_id: Option<&'a ProfileId>,
@@ -206,12 +205,14 @@ impl EventHandler for RecipePane {
     }
 }
 
-impl<'a> Draw<RequestPaneProps<'a>> for RecipePane {
-    fn draw(&self, frame: &mut Frame, props: RequestPaneProps<'a>, area: Rect) {
+impl<'a> Draw<RecipePaneProps<'a>> for RecipePane {
+    fn draw(&self, frame: &mut Frame, props: RecipePaneProps<'a>, area: Rect) {
         // Render outermost block
-        let pane_kind = PrimaryPane::Request;
+        let title = TuiContext::get()
+            .input_engine
+            .add_hint("Recipe", Action::SelectRecipe);
         let block = Pane {
-            title: &pane_kind.to_string(),
+            title: &title,
             is_focused: props.is_selected,
         };
         let block = block.generate();

--- a/src/tui/view/component/recipe_list.rs
+++ b/src/tui/view/component/recipe_list.rs
@@ -2,16 +2,19 @@
 
 use crate::{
     collection::{Recipe, RecipeId},
-    tui::view::{
-        common::{list::List, Pane},
-        component::primary::PrimaryPane,
-        draw::{Draw, Generate},
-        event::{Event, EventHandler, UpdateContext},
-        state::{
-            persistence::{Persistable, Persistent, PersistentKey},
-            select::{Dynamic, SelectState},
+    tui::{
+        context::TuiContext,
+        input::Action,
+        view::{
+            common::{list::List, Pane},
+            draw::{Draw, Generate},
+            event::{Event, EventHandler, UpdateContext},
+            state::{
+                persistence::{Persistable, Persistent, PersistentKey},
+                select::{Dynamic, SelectState},
+            },
+            Component,
         },
-        Component,
     },
 };
 use ratatui::{prelude::Rect, Frame};
@@ -64,7 +67,9 @@ impl EventHandler for RecipeListPane {
 impl Draw<RecipeListPaneProps> for RecipeListPane {
     fn draw(&self, frame: &mut Frame, props: RecipeListPaneProps, area: Rect) {
         self.recipes.set_area(area); // Needed for tracking cursor events
-        let title = PrimaryPane::RecipeList.to_string();
+        let title = TuiContext::get()
+            .input_engine
+            .add_hint("Recipes", Action::SelectRecipeList);
         let list = List {
             block: Some(Pane {
                 title: &title,

--- a/src/tui/view/component/response.rs
+++ b/src/tui/view/component/response.rs
@@ -8,11 +8,8 @@ use crate::{
         message::Message,
         view::{
             common::{actions::ActionsModal, table::Table, tabs::Tabs, Pane},
-            component::{
-                primary::PrimaryPane,
-                response::body::{
-                    ResponseContentBody, ResponseContentBodyProps,
-                },
+            component::response::body::{
+                ResponseContentBody, ResponseContentBodyProps,
             },
             draw::{Draw, Generate, ToStringGenerate},
             event::{Event, EventHandler, Update, UpdateContext},
@@ -68,9 +65,11 @@ impl<'a> Draw<ResponsePaneProps<'a>> for ResponsePane {
         area: Rect,
     ) {
         // Render outermost block
-        let pane_kind = PrimaryPane::Response;
+        let title = TuiContext::get()
+            .input_engine
+            .add_hint("Response", Action::SelectResponse);
         let block = Pane {
-            title: &pane_kind.to_string(),
+            title: &title,
             is_focused: props.is_selected,
         };
         let block = block.generate();

--- a/src/tui/view/theme.rs
+++ b/src/tui/view/theme.rs
@@ -1,10 +1,5 @@
 use ratatui::style::{Color, Modifier, Style};
 
-// Ideally these should be part of the theme, but that requires some sort of
-// two-stage themeing
-pub const PRIMARY_COLOR: Color = Color::LightGreen;
-pub const ERROR_COLOR: Color = Color::Red;
-
 /// Configurable visual settings for the UI. Styles are grouped into sub-structs
 /// generally by component.
 #[derive(Debug)]
@@ -17,6 +12,13 @@ pub struct Theme {
     pub text: ThemeText,
     pub text_box: ThemeTextBox,
     pub text_window: ThemeTextWindow,
+}
+
+impl Theme {
+    // Ideally these should be part of the theme, but that requires some sort of
+    // two-stage themeing
+    pub const PRIMARY_COLOR: Color = Color::LightGreen;
+    pub const ERROR_COLOR: Color = Color::Red;
 }
 
 #[derive(Debug)]
@@ -83,18 +85,18 @@ impl Default for Theme {
             pane: ThemePane {
                 border: Style::default(),
                 border_selected: Style::default()
-                    .fg(PRIMARY_COLOR)
+                    .fg(Self::PRIMARY_COLOR)
                     .add_modifier(Modifier::BOLD),
             },
             list: ThemeList {
                 highlight: Style::default()
-                    .bg(PRIMARY_COLOR)
+                    .bg(Self::PRIMARY_COLOR)
                     .fg(Color::Black)
                     .add_modifier(Modifier::BOLD),
             },
             tab: ThemeTab {
                 highlight: Style::default()
-                    .fg(PRIMARY_COLOR)
+                    .fg(Self::PRIMARY_COLOR)
                     .add_modifier(Modifier::BOLD)
                     .add_modifier(Modifier::UNDERLINED),
             },
@@ -106,7 +108,7 @@ impl Default for Theme {
                 alt: Style::default().bg(Color::DarkGray),
                 disabled: Style::default().add_modifier(Modifier::DIM),
                 highlight: Style::default()
-                    .bg(PRIMARY_COLOR)
+                    .bg(Self::PRIMARY_COLOR)
                     .fg(Color::Black)
                     .add_modifier(Modifier::BOLD)
                     .add_modifier(Modifier::UNDERLINED),
@@ -114,10 +116,12 @@ impl Default for Theme {
             },
             template_preview: ThemeTemplatePreview {
                 text: Style::default().fg(Color::Blue),
-                error: Style::default().bg(ERROR_COLOR),
+                error: Style::default().bg(Self::ERROR_COLOR),
             },
             text: ThemeText {
-                highlight: Style::default().fg(Color::Black).bg(PRIMARY_COLOR),
+                highlight: Style::default()
+                    .fg(Color::Black)
+                    .bg(Self::PRIMARY_COLOR),
             },
             text_box: ThemeTextBox {
                 text: Style::default().bg(Color::DarkGray),


### PR DESCRIPTION
- Add hotkeys to select the Profiles, Recipes, Recipe (renamed from Request) and Response panes
  - Hotkeys are visible in the pane titles for discoverability
- Minimize Profiles pane while not selected (only show the selected rather than the full list)