### PR TITLE
Show raw bytes for binary responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@
 - Add app version to help modal
 - Add "Copy as cURL" action to recipe menu ([#123](https://github.com/LucasPickering/slumber/issues/123))
 - Add hotkeys to select different panes
+- Add pane for rendered request
 
 ### Changed
 
 - Run prompts while rendering request URL/body to be copied
 - Improve UI design of profile pane
+- Show raw bytes for binary responses
 
 ## [0.14.0] - 2024-03-18
 

--- a/src/http/record.rs
+++ b/src/http/record.rs
@@ -214,6 +214,11 @@ impl Body {
     pub fn into_bytes(self) -> Vec<u8> {
         self.0.into()
     }
+
+    /// Get bytes as text, if valid UTF-8
+    pub fn text(&self) -> Option<&str> {
+        std::str::from_utf8(&self.0).ok()
+    }
 }
 
 #[cfg(test)]

--- a/src/tui/view/common.rs
+++ b/src/tui/view/common.rs
@@ -187,7 +187,7 @@ impl Generate for &HeaderValue {
     where
         Self: 'this,
     {
-        MaybeStr(self.as_bytes()).to_str().into()
+        MaybeStr(self.as_bytes()).to_string().into()
     }
 }
 

--- a/src/tui/view/component/record_body.rs
+++ b/src/tui/view/component/record_body.rs
@@ -128,12 +128,16 @@ impl EventHandler for RecordBody {
 impl<'a> Draw<RecordBodyProps<'a>> for RecordBody {
     fn draw(&self, frame: &mut Frame, props: RecordBodyProps, area: Rect) {
         // Body can only be queried if it's been parsed
-        self.query_available.set(props.parsed_body.is_some());
+        let query_available = props.parsed_body.is_some();
+        self.query_available.set(query_available);
 
         let [body_area, query_area] = layout(
             area,
             Direction::Vertical,
-            [Constraint::Min(0), Constraint::Length(1)],
+            [
+                Constraint::Min(0),
+                Constraint::Length(if query_available { 1 } else { 0 }),
+            ],
         );
 
         // Draw the body
@@ -150,7 +154,7 @@ impl<'a> Draw<RecordBodyProps<'a>> for RecordBody {
         });
         text.draw(frame, (), body_area);
 
-        if self.query_available.get() {
+        if query_available {
             self.query_text_box.draw(frame, (), query_area);
         }
     }
@@ -174,7 +178,7 @@ fn init_text_window(
         })
         // Content couldn't be parsed, fall back to the raw text
         // If the text isn't UTF-8, we'll show a placeholder instead
-        .unwrap_or_else(|| MaybeStr(raw_body).to_string());
+        .unwrap_or_else(|| format!("{:#}", MaybeStr(raw_body)));
 
     TextWindow::new(body).into()
 }


### PR DESCRIPTION
- Show raw bytes for binary responses instead of just `<invalid utf-8>`
- Show raw bytes for binary header values too
- Change output for `request` CLI subcommand:
  - Print raw bytes for binary responses. This allows piping binary responses directly to files
  - Print response status/headers to stderr to prevent interfering with content piping