### PR TITLE
Don't print stack traces for failed CLI commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- Don't print full stack trace for failed CLI commands
+
 ## [0.16.0] - 2024-04-01
 
 ### Added

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -73,8 +73,9 @@ impl Tui {
 
     /// Start the TUI. Any errors that occur during startup will be panics,
     /// because they prevent TUI execution.
-    pub async fn start(collection_path: PathBuf) -> anyhow::Result<()> {
+    pub async fn start(collection_path: Option<PathBuf>) -> anyhow::Result<()> {
         initialize_panic_handler();
+        let collection_path = CollectionFile::try_path(collection_path)?;
 
         // ===== Initialize global state =====
         // This stuff only needs to be set up *once per session*


### PR DESCRIPTION
## Before

```
> slumber rq get
Error: No request with ID `get`; options are: login, get_users, get_user, modify_user, get_image, delay

Stack backtrace:
   0: std::backtrace_rs::backtrace::libunwind::trace
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/../../backtrace/src/backtrace/libunwind.rs:93:5
   1: std::backtrace_rs::backtrace::trace_unsynchronized
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2: std::backtrace::Backtrace::create
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/backtrace.rs:331:13
   3: anyhow::error::<impl anyhow::Error>::msg
   4: slumber::cli::request::BuildRequestCommand::build_request::{{closure}}
   5: <slumber::cli::request::RequestCommand as slumber::cli::Subcommand>::execute::{{closure}}
   6: slumber::main::{{closure}}
   7: tokio::runtime::park::CachedParkThread::block_on
   8: slumber::main
   9: std::sys_common::backtrace::__rust_begin_short_backtrace
  10: std::rt::lang_start::{{closure}}
  11: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/ops/function.rs:284:13
  12: std::panicking::try::do_call
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/panicking.rs:504:40
  13: std::panicking::try
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/panicking.rs:468:19
  14: std::panic::catch_unwind
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/panic.rs:142:14
  15: std::rt::lang_start_internal::{{closure}}
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/rt.rs:148:48
  16: std::panicking::try::do_call
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/panicking.rs:504:40
  17: std::panicking::try
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/panicking.rs:468:19
  18: std::panic::catch_unwind
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/panic.rs:142:14
  19: std::rt::lang_start_internal
             at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/rt.rs:148:20
  20: _main
```

## After

```
> c run -q -- rq get
No request with ID `get`; options are: login, get_users, get_user, modify_user, get_image, delay
```