### PR TITLE
Improvements to `slumber show` subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,16 +12,23 @@
 - Unknown fields in config/collection files will now be rejected ([#154](https://github.com/LucasPickering/slumber/issues/154))
   - In most cases this field is a mistake, so this is meant to make debugging easier
   - If you have an intentional unknown field, you can now nest it under `.ignore` to ignore it
+- Replace `slumber show dir` with `slumber show paths`
 
 ### Added
 
 - Request recipes can now be organized into folders ([#60](https://github.com/LucasPickering/slumber/issues/60))
   - See [the docs](https://slumber.lucaspickering.me/book/api/request_collection/request_recipe.html#folder-fields) for usage examples
+- Add `slumber show config` and `slumber show collection` subcommands
 
 ### Changed
 
 - Prevent infinite recursion in templates
   - It now triggers a helpful error instead of a panic
+- Support additional key codes for input mapping, including media keys
+
+### Fixed
+
+- Multiple spaces between modifiers/key codes in a key combination are now ignored
 
 ## [0.17.0] - 2024-04-08
 

--- a/docs/src/api/configuration/input_bindings.md
+++ b/docs/src/api/configuration/input_bindings.md
@@ -89,12 +89,18 @@ All single-character keys (e.g. `w`, `/`, `=`, etc.) are not listed; the code is
 - `end`
 - `pageup`/`pgup`
 - `pagedown`/`pgdn`
-- `capslock`/`caps`
 - `tab`
 - `backtab`
 - `backspace`
 - `delete`/`del`
 - `insert`/`ins`
+- `capslock`/`caps`
+- `scrolllock`
+- `numlock`
+- `printscreen`
+- `pausebreak` (sometimes just called Pause; _not_ the same as the Pause media key)
+- `menu`
+- `keypadbegin`
 - `f1`
 - `f2`
 - `f3`
@@ -108,6 +114,19 @@ All single-character keys (e.g. `w`, `/`, `=`, etc.) are not listed; the code is
 - `f11`
 - `f12`
 - `space`
+- `play`
+- `pause` (the media key, _not_ Pause/Break)
+- `playpause`
+- `reverse`
+- `stop`
+- `fastforward`
+- `rewind`
+- `tracknext`
+- `trackprevious`
+- `record`
+- `lowervolume`
+- `raisevolume`
+- `mute`
 
 ### Key Modifiers
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,28 +1,24 @@
 use crate::{
     tui::input::{Action, InputBinding},
-    util::{parse_yaml, Directory, ResultExt},
+    util::{
+        parse_yaml,
+        paths::{DataDirectory, FileGuard},
+        ResultExt,
+    },
 };
 use anyhow::Context;
 use indexmap::IndexMap;
-use serde::Deserialize;
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
+use serde::{Deserialize, Serialize};
+use std::fs;
 use tracing::info;
 
 /// App-level configuration, which is global across all sessions and
 /// collections. This is *not* meant to modifiable during a session. If changes
 /// are made to the config file while a session is running, they won't be
 /// picked up until the app restarts.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct Config {
-    /// The path that the config was loaded from, or tried to be loaded from if
-    /// the file didn't exist
-    #[serde(skip)]
-    path: PathBuf,
-
     /// TLS cert errors on these hostnames are ignored. Be careful!
     #[serde(default)]
     pub ignore_certificate_hosts: Vec<String>,
@@ -42,10 +38,10 @@ impl Config {
     /// deserialization failed. This is *not* async because it's only run during
     /// startup, when all operations are synchronous.
     pub fn load() -> anyhow::Result<Self> {
-        let path = Directory::root().create()?.join(Self::FILE);
+        let path = Self::path().create_parent()?;
         info!(?path, "Loading configuration file");
 
-        let mut config = match fs::read(&path) {
+        match fs::read(&path) {
             Ok(bytes) => parse_yaml::<Self>(&bytes)
                 .context(format!("Error loading configuration from {path:?}"))
                 .traced(),
@@ -59,22 +55,18 @@ impl Config {
                 );
                 Ok(Self::default())
             }
-        }?;
-
-        config.path = path;
-        Ok(config)
+        }
     }
 
-    /// The path where configuration is stored
-    pub fn path(&self) -> &Path {
-        &self.path
+    /// Path to the configuration file
+    pub fn path() -> FileGuard {
+        DataDirectory::root().file(Self::FILE)
     }
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
-            path: PathBuf::default(),
             ignore_certificate_hosts: Vec::new(),
             preview_templates: true,
             input_bindings: IndexMap::default(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ mod test_util;
 mod tui;
 mod util;
 
-use crate::{cli::CliCommand, tui::Tui, util::Directory};
+use crate::{cli::CliCommand, tui::Tui, util::paths::DataDirectory};
 use clap::Parser;
 use std::{fs::File, path::PathBuf, process::ExitCode};
 use tracing_subscriber::{filter::EnvFilter, prelude::*};
@@ -76,7 +76,7 @@ async fn main() -> anyhow::Result<ExitCode> {
 
 /// Set up tracing to log to a file
 fn initialize_tracing() -> anyhow::Result<()> {
-    let path = Directory::log().create()?.join("slumber.log");
+    let path = DataDirectory::log().create_parent()?;
     let log_file = File::create(path)?;
     let file_subscriber = tracing_subscriber::fmt::layer()
         .with_file(true)

--- a/src/tui/view/component/help.rs
+++ b/src/tui/view/component/help.rs
@@ -1,11 +1,14 @@
-use crate::tui::{
-    context::TuiContext,
-    input::{Action, InputBinding},
-    view::{
-        common::{modal::Modal, table::Table},
-        draw::{Draw, Generate},
-        event::EventHandler,
-        util::layout,
+use crate::{
+    config::Config,
+    tui::{
+        context::TuiContext,
+        input::{Action, InputBinding},
+        view::{
+            common::{modal::Modal, table::Table},
+            draw::{Draw, Generate},
+            event::EventHandler,
+            util::layout,
+        },
     },
 };
 use itertools::Itertools;
@@ -100,10 +103,7 @@ impl Draw for HelpModal {
             title: Some("General"),
             rows: [
                 ("Version", Line::from(CRATE_VERSION)),
-                (
-                    "Configuration",
-                    Line::from(tui_context.config.path().display().to_string()),
-                ),
+                ("Configuration", Line::from(Config::path().to_string())),
                 (
                     "Collection",
                     Line::from(

--- a/src/util/paths.rs
+++ b/src/util/paths.rs
@@ -1,0 +1,70 @@
+use anyhow::{anyhow, Context};
+use derive_more::Display;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+/// The root data directory. All files that Slumber creates on the system should
+/// live here.
+///
+/// Intentionally does not implement `Debug`, to prevent accidental debug
+/// printing when looking for Path's `Debug` impl, which just wraps in quotes.
+#[derive(Clone, Display)]
+#[display("{}", _0.display())]
+pub struct DataDirectory(PathBuf);
+
+impl DataDirectory {
+    /// Root directory for all generated files. The value is contextual:
+    /// - In development, use a directory in the current directory
+    /// - In release, use a platform-specific directory in the user's home
+    pub fn root() -> Self {
+        if cfg!(debug_assertions) {
+            Self("./data/".into())
+        } else {
+            // According to the docs, this dir will be present on all platforms
+            // https://docs.rs/dirs/latest/dirs/fn.data_dir.html
+            Self(dirs::data_dir().unwrap().join("slumber"))
+        }
+    }
+
+    /// Path to the log file
+    pub fn log() -> FileGuard {
+        // Use a random new file for each session:
+        // https://github.com/LucasPickering/slumber/issues/61
+        Self::root().file("log/slumber.log")
+    }
+
+    /// Get the path of a file in the directory.
+    pub fn file(self, path: impl AsRef<Path>) -> FileGuard {
+        FileGuard(self.0.join(path))
+    }
+}
+
+/// A wrapper around a path to a specific file in the data directory. The
+/// purpose is to make it easy to print a path without any side effects, but
+/// enforce that the path's parent directory is created before actually using
+/// it. To accomplish that, this implements `Display` but does not provide any
+/// other access to the inner `PathBuf`. To get the parent, use
+/// [Self::create_parent].
+///
+/// Intentionally does not implement Debug, to prevent accidental debug printing
+/// when looking for Path's debug impl, which just wraps in quotes.
+#[derive(Clone, Display)]
+#[display("{}", _0.display())]
+pub struct FileGuard(PathBuf);
+
+impl FileGuard {
+    /// Create the parent directory and return the path to the file. This
+    /// enforces that the directory exists before using the path for any
+    /// operations.
+    pub fn create_parent(self) -> anyhow::Result<PathBuf> {
+        let parent = self
+            .0
+            .parent()
+            .ok_or_else(|| anyhow!("Path {:?} has no parent", self.0))?;
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Error creating directory {parent:?}"))?;
+        Ok(self.0)
+    }
+}


### PR DESCRIPTION
- Add `slumber show config` and `slumber show collection` subcommands
- Replace `slumber show dir` with `slumber show paths`

Additionally, some changes to input management that I came across:

- Support media keys and a few others for inputs
- Fix bug with multiple spaces between pieces of a key combination