### PR TITLE
Make event queue globally available in view

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -168,6 +168,10 @@ impl Tui {
                 }
             }
 
+            // ===== Event Phase =====
+            // Let the view handle all queued events
+            self.view.handle_events();
+
             // ===== Draw Phase =====
             self.terminal.draw(|f| self.view.draw(f))?;
 

--- a/src/tui/view.rs
+++ b/src/tui/view.rs
@@ -20,14 +20,14 @@ use crate::{
         view::{
             component::{Component, Root},
             draw::Draw,
-            event::{Event, EventHandler, Update, UpdateContext},
+            event::{Event, EventHandler, EventQueue, Update},
             state::Notification,
         },
     },
 };
 use anyhow::anyhow;
 use ratatui::Frame;
-use std::{collections::VecDeque, fmt::Debug};
+use std::fmt::Debug;
 use tracing::{error, trace, trace_span};
 
 /// Primary entrypoint for the view. This contains the main draw functions, as
@@ -35,6 +35,12 @@ use tracing::{error, trace, trace_span};
 /// architecture based on React, meaning the view is responsible for managing
 /// its own state. Certain global state (e.g. the database) is managed by the
 /// controller and exposed via event passing.
+///
+/// External updates on the view are lazy, meaning calls to methods like
+/// [Self::handle_input] simply queue an event to handle the input. Call
+/// [Self::handle_events] to drain the queue once per loop. This is necessary
+/// because events can be triggered from other places too (e.g. from other
+/// events), so we need to make sure the queue is constantly being drained.
 #[derive(Debug)]
 pub struct View {
     root: Component<Root>,
@@ -42,12 +48,9 @@ pub struct View {
 
 impl View {
     pub fn new(collection: &Collection) -> Self {
-        let mut view = Self {
+        Self {
             root: Root::new(collection).into(),
-        };
-        // Tell the components to wake up
-        view.handle_event(Event::Init);
-        view
+        }
     }
 
     /// Draw the view to screen. This needs access to the input engine in order
@@ -57,40 +60,76 @@ impl View {
         self.root.draw(frame, (), chunk)
     }
 
-    /// Update the request state for the given profile+recipe. The state will
-    /// only be updated if this is a new request or it matches the current
-    /// request for this recipe. We only store one request per profile+recipe at
-    /// a time.
+    /// Queue an event to update the request state for the given profile+recipe.
+    /// The state will only be updated if this is a new request or it
+    /// matches the current request for this recipe. We only store one
+    /// request per profile+recipe at a time.
     pub fn set_request_state(
         &mut self,
         profile_id: Option<ProfileId>,
         recipe_id: RecipeId,
         state: RequestState,
     ) {
-        self.handle_event(Event::HttpSetState {
+        EventQueue::push(Event::HttpSetState {
             profile_id,
             recipe_id,
             state,
         });
     }
 
-    /// Open a new modal. The input can be anything that converts to modal
-    /// content
+    /// Queue an event to open a new modal. The input can be anything that
+    /// converts to modal content
     pub fn open_modal(
         &mut self,
         modal: impl IntoModal + 'static,
         priority: ModalPriority,
     ) {
-        self.handle_event(Event::OpenModal {
+        EventQueue::push(Event::OpenModal {
             modal: Box::new(modal.into_modal()),
             priority,
         });
     }
 
-    /// Send an informational notification to the user
+    /// Queue an event to send an informational notification to the user
     pub fn notify(&mut self, message: impl ToString) {
         let notification = Notification::new(message.to_string());
-        self.handle_event(Event::Notify(notification));
+        EventQueue::push(Event::Notify(notification));
+    }
+
+    /// Queue an event to update the view according to an input event from the
+    /// user. If possible, a bound action is provided which tells us what
+    /// abstract action the input maps to.
+    pub fn handle_input(
+        &mut self,
+        event: crossterm::event::Event,
+        action: Option<Action>,
+    ) {
+        EventQueue::push(Event::Input { event, action })
+    }
+
+    /// Drain all view events from the queue. The component three will process
+    /// events one by one. This should be called on every TUI loop
+    pub fn handle_events(&mut self) {
+        // It's possible for components to queue additional events
+        while let Some(event) = EventQueue::pop() {
+            // Certain events *just don't matter*, AT ALL. They're not even
+            // supposed to be around, like, in the area
+            if event.should_kill() {
+                continue;
+            }
+
+            trace_span!("View event", ?event).in_scope(|| {
+                match Self::update_all(self.root.as_child(), event) {
+                    Update::Consumed => {
+                        trace!("View event consumed")
+                    }
+                    // Consumer didn't eat the event - huh?
+                    Update::Propagate(_) => {
+                        error!("View event was unhandled");
+                    }
+                }
+            });
+        }
     }
 
     /// Copy text to the user's clipboard, and notify them
@@ -109,62 +148,17 @@ impl View {
         }
     }
 
-    /// Update the view according to an input event from the user. If possible,
-    /// a bound action is provided which tells us what abstract action the
-    /// input maps to.
-    pub fn handle_input(
-        &mut self,
-        event: crossterm::event::Event,
-        action: Option<Action>,
-    ) {
-        self.handle_event(Event::Input { event, action })
-    }
-
-    /// Process a view event by passing it to the root component and letting
-    /// it pass it down the tree
-    fn handle_event(&mut self, event: Event) {
-        let mut event_queue: VecDeque<Event> = [event].into();
-
-        // Each event being handled could potentially queue more. Keep going
-        // until the queue is drained
-        while let Some(event) = event_queue.pop_front() {
-            // Certain events *just don't matter*, AT ALL. They're not even
-            // supposed to be around, like, in the area
-            if event.should_kill() {
-                continue;
-            }
-
-            let span = trace_span!("View event", ?event);
-            span.in_scope(|| {
-                let mut context = UpdateContext::new(&mut event_queue);
-
-                let update =
-                    Self::update_all(self.root.as_child(), &mut context, event);
-                match update {
-                    Update::Consumed => {
-                        trace!("View event consumed")
-                    }
-                    // Consumer didn't eat the event - huh?
-                    Update::Propagate(_) => {
-                        error!("View event was unhandled");
-                    }
-                }
-            });
-        }
-    }
-
     /// Update the state of a component *and* its children, starting at the
     /// lowest descendant. Recursively walk up the tree until a component
     /// consumes the event.
     fn update_all(
         mut component: Component<&mut dyn EventHandler>,
-        context: &mut UpdateContext,
         mut event: Event,
     ) -> Update {
         // If we have a child, send them the event. If not, eat it ourselves
         for child in component.children() {
             if event.should_handle(&child) {
-                let update = Self::update_all(child, context, event); // RECURSION
+                let update = Self::update_all(child, event); // RECURSION
                 match update {
                     Update::Propagate(returned) => {
                         // Keep going to the next child. It's possible the child
@@ -187,7 +181,7 @@ impl View {
             component = ?component.inner(),
         );
         span.in_scope(|| {
-            let update = component.update(context, event);
+            let update = component.update(event);
             trace!(?update);
             update
         })

--- a/src/tui/view/common/modal.rs
+++ b/src/tui/view/common/modal.rs
@@ -2,7 +2,7 @@ use crate::tui::{
     input::Action,
     view::{
         draw::Draw,
-        event::{Event, EventHandler, Update, UpdateContext},
+        event::{Event, EventHandler, Update},
         util::centered_rect,
         Component,
     },
@@ -92,7 +92,7 @@ impl ModalQueue {
 }
 
 impl EventHandler for ModalQueue {
-    fn update(&mut self, _context: &mut UpdateContext, event: Event) -> Update {
+    fn update(&mut self, event: Event) -> Update {
         match event {
             // Close the active modal. If there's no modal open, we'll propagate
             // the event down
@@ -161,8 +161,8 @@ impl Draw for ModalQueue {
 }
 
 impl EventHandler for Box<dyn Modal> {
-    fn update(&mut self, context: &mut UpdateContext, event: Event) -> Update {
-        self.deref_mut().update(context, event)
+    fn update(&mut self, event: Event) -> Update {
+        self.deref_mut().update(event)
     }
 
     fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {

--- a/src/tui/view/common/tabs.rs
+++ b/src/tui/view/common/tabs.rs
@@ -3,7 +3,7 @@ use crate::tui::{
     input::Action,
     view::{
         draw::Draw,
-        event::{Event, EventHandler, Update, UpdateContext},
+        event::{Event, EventHandler, Update},
         state::{
             persistence::{Persistable, Persistent, PersistentKey},
             select::{Fixed, FixedSelect, SelectState},
@@ -32,18 +32,18 @@ impl<T: FixedSelect + Persistable> Tabs<T> {
 }
 
 impl<T: FixedSelect + Persistable> EventHandler for Tabs<T> {
-    fn update(&mut self, context: &mut UpdateContext, event: Event) -> Update {
+    fn update(&mut self, event: Event) -> Update {
         match event {
             Event::Input {
                 action: Some(action),
                 ..
             } => match action {
                 Action::Left => {
-                    self.tabs.previous(context);
+                    self.tabs.previous();
                     Update::Consumed
                 }
                 Action::Right => {
-                    self.tabs.next(context);
+                    self.tabs.next();
                     Update::Consumed
                 }
 

--- a/src/tui/view/common/text_box.rs
+++ b/src/tui/view/common/text_box.rs
@@ -5,7 +5,7 @@ use crate::tui::{
     input::Action,
     view::{
         draw::Draw,
-        event::{Event, EventHandler, Update, UpdateContext},
+        event::{Event, EventHandler, Update},
     },
 };
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
@@ -37,7 +37,7 @@ pub struct TextBox {
     on_cancel: Option<Callback>,
 }
 
-type Callback = Box<dyn Fn(&TextBox, &mut UpdateContext)>;
+type Callback = Box<dyn Fn(&TextBox)>;
 
 type Validator = Box<dyn Fn(&str) -> bool>;
 
@@ -87,7 +87,7 @@ impl TextBox {
     /// Set the callback to be called when the user hits escape
     pub fn with_on_cancel(
         mut self,
-        on_cancel: impl 'static + Fn(&Self, &mut UpdateContext),
+        on_cancel: impl 'static + Fn(&Self),
     ) -> Self {
         self.on_cancel = Some(Box::new(on_cancel));
         self
@@ -96,7 +96,7 @@ impl TextBox {
     /// Set the callback to be called when the user hits enter
     pub fn with_on_submit(
         mut self,
-        on_submit: impl 'static + Fn(&Self, &mut UpdateContext),
+        on_submit: impl 'static + Fn(&Self),
     ) -> Self {
         self.on_submit = Some(Box::new(on_submit));
         self
@@ -138,17 +138,17 @@ impl TextBox {
     }
 
     /// Call parent's submissionc callback
-    fn submit(&mut self, context: &mut UpdateContext) {
+    fn submit(&mut self) {
         if let Some(on_submit) = &self.on_submit {
-            on_submit(self, context);
+            on_submit(self);
         }
         self.unfocus();
     }
 
     /// Call parent's cancel callback
-    fn cancel(&mut self, context: &mut UpdateContext) {
+    fn cancel(&mut self) {
         if let Some(on_cancel) = &self.on_cancel {
-            on_cancel(self, context);
+            on_cancel(self);
         }
         self.unfocus();
     }
@@ -181,16 +181,16 @@ impl TextBox {
 }
 
 impl EventHandler for TextBox {
-    fn update(&mut self, context: &mut UpdateContext, event: Event) -> Update {
+    fn update(&mut self, event: Event) -> Update {
         match event {
             Event::Input {
                 action: Some(Action::Submit),
                 ..
-            } => self.submit(context),
+            } => self.submit(),
             Event::Input {
                 action: Some(Action::Cancel),
                 ..
-            } => self.cancel(context),
+            } => self.cancel(),
             Event::Input {
                 action: Some(Action::LeftClick),
                 ..

--- a/src/tui/view/common/text_window.rs
+++ b/src/tui/view/common/text_window.rs
@@ -3,7 +3,7 @@ use crate::tui::{
     input::Action,
     view::{
         draw::{Draw, Generate},
-        event::{Event, EventHandler, Update, UpdateContext},
+        event::{Event, EventHandler, Update},
         util::layout,
     },
 };
@@ -91,7 +91,7 @@ impl<T> TextWindow<T> {
 }
 
 impl<T: Debug> EventHandler for TextWindow<T> {
-    fn update(&mut self, _context: &mut UpdateContext, event: Event) -> Update {
+    fn update(&mut self, event: Event) -> Update {
         match event {
             Event::Input {
                 action: Some(action),

--- a/src/tui/view/component.rs
+++ b/src/tui/view/component.rs
@@ -16,7 +16,7 @@ pub use root::Root;
 
 use crate::tui::view::{
     draw::Draw,
-    event::{Event, EventHandler, Update, UpdateContext},
+    event::{Event, EventHandler, Update},
 };
 use crossterm::event::MouseEvent;
 use derive_more::{Deref, DerefMut};
@@ -94,8 +94,8 @@ impl<T> Component<T> {
 }
 
 impl<T: EventHandler> EventHandler for Component<T> {
-    fn update(&mut self, context: &mut UpdateContext, event: Event) -> Update {
-        self.inner.update(context, event)
+    fn update(&mut self, event: Event) -> Update {
+        self.inner.update(event)
     }
 
     fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {

--- a/src/tui/view/component/misc.rs
+++ b/src/tui/view/component/misc.rs
@@ -10,7 +10,7 @@ use crate::{
         },
         component::Component,
         draw::{Draw, Generate},
-        event::{Event, EventHandler},
+        event::{Event, EventHandler, EventQueue},
         state::Notification,
     },
 };
@@ -72,14 +72,14 @@ impl PromptModal {
         let text_box = TextBox::default()
             .with_sensitive(prompt.sensitive())
             // Make sure cancel gets propagated to close the modal
-            .with_on_cancel(|_, context| context.queue_event(Event::CloseModal))
-            .with_on_submit(move |_, context| {
+            .with_on_cancel(|_| EventQueue::push(Event::CloseModal))
+            .with_on_submit(move |_| {
                 // We have to defer submission to on_close, because we need the
                 // owned value of `self.prompt`. We could have just put that in
                 // a refcell, but this felt a bit cleaner because we know this
                 // submitter will only be called once.
                 submit_cell.set(true);
-                context.queue_event(Event::CloseModal);
+                EventQueue::push(Event::CloseModal);
             })
             .into();
         Self {

--- a/src/tui/view/component/primary.rs
+++ b/src/tui/view/component/primary.rs
@@ -18,7 +18,7 @@ use crate::{
                 response_pane::{ResponsePane, ResponsePaneProps},
             },
             draw::Draw,
-            event::{Event, EventHandler, Update, UpdateContext},
+            event::{Event, EventHandler, EventQueue, Update},
             state::{
                 persistence::{Persistent, PersistentKey},
                 select::{Fixed, SelectState},
@@ -267,7 +267,7 @@ impl PrimaryView {
 }
 
 impl EventHandler for PrimaryView {
-    fn update(&mut self, context: &mut UpdateContext, event: Event) -> Update {
+    fn update(&mut self, event: Event) -> Update {
         match &event {
             // Load latest request for selected recipe from database
             Event::HttpLoadRequest => {
@@ -308,52 +308,47 @@ impl EventHandler for PrimaryView {
                     };
                     // See if any child panes were clicked
                     if self.profile_list_pane.intersects(mouse) {
-                        self.selected_pane
-                            .select(context, &PrimaryPane::ProfileList);
+                        self.selected_pane.select(&PrimaryPane::ProfileList);
                     } else if self.recipe_list_pane.intersects(mouse) {
-                        self.selected_pane
-                            .select(context, &PrimaryPane::RecipeList);
+                        self.selected_pane.select(&PrimaryPane::RecipeList);
                     } else if self.recipe_pane.intersects(mouse) {
-                        self.selected_pane
-                            .select(context, &PrimaryPane::Recipe);
+                        self.selected_pane.select(&PrimaryPane::Recipe);
                     } else if self.request_pane.intersects(mouse) {
-                        self.selected_pane
-                            .select(context, &PrimaryPane::Request);
+                        self.selected_pane.select(&PrimaryPane::Request);
                     } else if self.response_pane.intersects(mouse) {
-                        self.selected_pane
-                            .select(context, &PrimaryPane::Response);
+                        self.selected_pane.select(&PrimaryPane::Response);
                     }
                 }
                 Action::PreviousPane if self.fullscreen_mode.is_none() => {
-                    self.selected_pane.previous(context);
+                    self.selected_pane.previous();
                 }
                 Action::NextPane if self.fullscreen_mode.is_none() => {
-                    self.selected_pane.next(context);
+                    self.selected_pane.next();
                 }
                 Action::Submit => {
                     // Send a request from anywhere
-                    context.queue_event(Event::HttpSendRequest);
+                    EventQueue::push(Event::HttpSendRequest);
                 }
                 Action::OpenActions => {
-                    context.open_modal_default::<ActionsModal>();
+                    EventQueue::open_modal_default::<ActionsModal>();
                 }
                 Action::OpenHelp => {
-                    context.open_modal_default::<HelpModal>();
+                    EventQueue::open_modal_default::<HelpModal>();
                 }
-                Action::SelectProfileList => self
-                    .selected_pane
-                    .select(context, &PrimaryPane::ProfileList),
+                Action::SelectProfileList => {
+                    self.selected_pane.select(&PrimaryPane::ProfileList)
+                }
                 Action::SelectRecipeList => {
-                    self.selected_pane.select(context, &PrimaryPane::RecipeList)
+                    self.selected_pane.select(&PrimaryPane::RecipeList)
                 }
                 Action::SelectRecipe => {
-                    self.selected_pane.select(context, &PrimaryPane::Recipe)
+                    self.selected_pane.select(&PrimaryPane::Recipe)
                 }
                 Action::SelectRequest => {
-                    self.selected_pane.select(context, &PrimaryPane::Request)
+                    self.selected_pane.select(&PrimaryPane::Request)
                 }
                 Action::SelectResponse => {
-                    self.selected_pane.select(context, &PrimaryPane::Response)
+                    self.selected_pane.select(&PrimaryPane::Response)
                 }
 
                 // Toggle fullscreen

--- a/src/tui/view/component/profile_list.rs
+++ b/src/tui/view/component/profile_list.rs
@@ -6,7 +6,7 @@ use crate::{
         view::{
             common::{list::List, Pane},
             draw::{Draw, Generate},
-            event::{Event, EventHandler, Update, UpdateContext},
+            event::{Event, EventHandler, EventQueue, Update},
             state::{
                 persistence::{Persistable, Persistent, PersistentKey},
                 select::{Dynamic, SelectState},
@@ -34,8 +34,8 @@ pub struct ProfileListPaneProps {
 impl ProfileListPane {
     pub fn new(profiles: Vec<Profile>) -> Self {
         // Loaded request depends on the profile, so refresh on change
-        fn on_select(context: &mut UpdateContext, _: &mut Profile) {
-            context.queue_event(Event::HttpLoadRequest);
+        fn on_select(_: &mut Profile) {
+            EventQueue::push(Event::HttpLoadRequest);
         }
 
         Self {
@@ -53,7 +53,7 @@ impl ProfileListPane {
 }
 
 impl EventHandler for ProfileListPane {
-    fn update(&mut self, _context: &mut UpdateContext, event: Event) -> Update {
+    fn update(&mut self, event: Event) -> Update {
         match event {
             // Sending requests from the profile pane is unintuitive, so eat
             // submission events here

--- a/src/tui/view/component/recipe_list.rs
+++ b/src/tui/view/component/recipe_list.rs
@@ -8,7 +8,7 @@ use crate::{
         view::{
             common::{list::List, Pane},
             draw::{Draw, Generate},
-            event::{Event, EventHandler, UpdateContext},
+            event::{Event, EventHandler, EventQueue},
             state::{
                 persistence::{Persistable, Persistent, PersistentKey},
                 select::{Dynamic, SelectState},
@@ -39,9 +39,9 @@ struct RecipeListItem {
 impl RecipeListPane {
     pub fn new(recipes: &RecipeTree) -> Self {
         // When highlighting a new recipe, load it from the repo
-        fn on_select(context: &mut UpdateContext, _: &mut RecipeListItem) {
+        fn on_select(_: &mut RecipeListItem) {
             // If a recipe isn't selected, this will do nothing
-            context.queue_event(Event::HttpLoadRequest);
+            EventQueue::push(Event::HttpLoadRequest);
         }
 
         // Flatten the tree into a list

--- a/src/tui/view/component/recipe_pane.rs
+++ b/src/tui/view/component/recipe_pane.rs
@@ -16,7 +16,7 @@ use crate::{
                 Pane,
             },
             draw::{Draw, Generate, ToStringGenerate},
-            event::{Event, EventHandler, Update, UpdateContext},
+            event::{Event, EventHandler, EventQueue, Update},
             state::{
                 persistence::{Persistable, Persistent, PersistentKey},
                 select::{Dynamic, SelectState},
@@ -167,12 +167,12 @@ impl RecipePane {
 }
 
 impl EventHandler for RecipePane {
-    fn update(&mut self, context: &mut UpdateContext, event: Event) -> Update {
+    fn update(&mut self, event: Event) -> Update {
         match &event {
             Event::Input {
                 action: Some(Action::OpenActions),
                 ..
-            } => context.open_modal_default::<ActionsModal<MenuAction>>(),
+            } => EventQueue::open_modal_default::<ActionsModal<MenuAction>>(),
             Event::Other(callback) => {
                 match callback.downcast_ref::<MenuAction>() {
                     Some(action) => {
@@ -451,7 +451,7 @@ impl RowState {
     }
 
     /// Toggle row state on submit
-    fn on_submit(_: &mut UpdateContext, row: &mut Self) {
+    fn on_submit(row: &mut Self) {
         *row.enabled ^= true;
     }
 }

--- a/src/tui/view/component/record_body.rs
+++ b/src/tui/view/component/record_body.rs
@@ -7,7 +7,7 @@ use crate::{
         view::{
             common::{text_box::TextBox, text_window::TextWindow},
             draw::Draw,
-            event::{Event, EventHandler, Update, UpdateContext},
+            event::{Event, EventHandler, EventQueue, Update},
             state::StateCell,
             util::layout,
             Component,
@@ -70,8 +70,8 @@ impl Default for RecordBody {
                 .with_placeholder("'/' to filter body with JSONPath")
                 .with_validator(|text| JsonPath::parse(text).is_ok())
                 // Callback triggers an event, so we can modify our own state
-                .with_on_submit(|text_box, context| {
-                    context.queue_event(Event::other(QuerySubmit(
+                .with_on_submit(|text_box| {
+                    EventQueue::push(Event::other(QuerySubmit(
                         text_box.text().to_owned(),
                     )))
                 })
@@ -81,7 +81,7 @@ impl Default for RecordBody {
 }
 
 impl EventHandler for RecordBody {
-    fn update(&mut self, _context: &mut UpdateContext, event: Event) -> Update {
+    fn update(&mut self, event: Event) -> Update {
         match event {
             Event::Input {
                 action: Some(Action::Search),

--- a/src/tui/view/component/request_pane.rs
+++ b/src/tui/view/component/request_pane.rs
@@ -11,7 +11,7 @@ use crate::{
             },
             component::record_body::{RecordBody, RecordBodyProps},
             draw::{Draw, Generate, ToStringGenerate},
-            event::{Event, EventHandler, Update, UpdateContext},
+            event::{Event, EventHandler, EventQueue, Update},
             state::{persistence::PersistentKey, RequestState, StateCell},
             util::layout,
             Component,
@@ -181,12 +181,12 @@ enum Tab {
 }
 
 impl EventHandler for RenderedRequest {
-    fn update(&mut self, context: &mut UpdateContext, event: Event) -> Update {
+    fn update(&mut self, event: Event) -> Update {
         match event {
             Event::Input {
                 action: Some(Action::OpenActions),
                 ..
-            } => context.open_modal_default::<ActionsModal<MenuAction>>(),
+            } => EventQueue::open_modal_default::<ActionsModal<MenuAction>>(),
             Event::Other(ref other) => {
                 // Check for an action menu event
                 match other.downcast_ref::<MenuAction>() {

--- a/src/tui/view/component/response_pane.rs
+++ b/src/tui/view/component/response_pane.rs
@@ -11,7 +11,7 @@ use crate::{
             },
             component::record_body::{RecordBody, RecordBodyProps},
             draw::{Draw, Generate, ToStringGenerate},
-            event::{Event, EventHandler, Update, UpdateContext},
+            event::{Event, EventHandler, EventQueue, Update},
             state::{persistence::PersistentKey, RequestState, StateCell},
             util::layout,
             Component,
@@ -153,12 +153,12 @@ enum Tab {
 }
 
 impl EventHandler for CompleteResponseContent {
-    fn update(&mut self, context: &mut UpdateContext, event: Event) -> Update {
+    fn update(&mut self, event: Event) -> Update {
         match event {
             Event::Input {
                 action: Some(Action::OpenActions),
                 ..
-            } => context.open_modal_default::<ActionsModal<MenuAction>>(),
+            } => EventQueue::open_modal_default::<ActionsModal<MenuAction>>(),
             Event::Other(ref other) => {
                 // Check for an action menu event
                 match other.downcast_ref::<MenuAction>() {

--- a/src/tui/view/component/root.rs
+++ b/src/tui/view/component/root.rs
@@ -12,7 +12,7 @@ use crate::{
                 primary::{PrimaryView, PrimaryViewProps},
             },
             draw::Draw,
-            event::{Event, EventHandler, Update, UpdateContext},
+            event::{Event, EventHandler, Update},
             state::RequestState,
             util::layout,
             Component,
@@ -103,14 +103,8 @@ impl Root {
 }
 
 impl EventHandler for Root {
-    fn update(&mut self, context: &mut UpdateContext, event: Event) -> Update {
+    fn update(&mut self, event: Event) -> Update {
         match event {
-            Event::Init => {
-                // Tell PrimaryPane to load for whatever recipe is selected
-                // TODO make SelectState call on_select on startup instead
-                context.queue_event(Event::HttpLoadRequest);
-            }
-
             // Update state of HTTP request
             Event::HttpSetState {
                 profile_id,

--- a/src/tui/view/state/persistence.rs
+++ b/src/tui/view/state/persistence.rs
@@ -6,7 +6,7 @@ use crate::{
         context::TuiContext,
         view::{
             component::Component,
-            event::{Event, EventHandler, Update, UpdateContext},
+            event::{Event, EventHandler, Update},
         },
     },
 };
@@ -47,8 +47,8 @@ impl<T> EventHandler for Persistent<T>
 where
     T: EventHandler + PersistentContainer,
 {
-    fn update(&mut self, context: &mut UpdateContext, event: Event) -> Update {
-        self.container.update(context, event)
+    fn update(&mut self, event: Event) -> Update {
+        self.container.update(event)
     }
 
     fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {


### PR DESCRIPTION
This simplifies a lot of logic. Mostly it means callbacks no longer have to be passed a context.