### PR TITLE
Add collapsible folder tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Improvements to Insomnia import ([#12](https://github.com/LucasPickering/slumber/issues/12))
 - Rename `import-experimental` command to `import`
   - It's official now! It's still going to get continuted improvement though
+- Folders can now be collapsed in the recipe list ([#155](https://github.com/LucasPickering/slumber/issues/155))
 
 ## [0.18.0] - 2024-04-18
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Slumber is a TUI (terminal user interface) HTTP client. Define, execute, and sha
 ## Features
 
 - Usable as a TUI or CLI
+- Source-first configuration, for easy persistence and sharing
 - [Import from external formats (e.g. Insomnia)](https://slumber.lucaspickering.me/book/user_guide/import.html)
 - [Build requests dynamically from other requests, files, and shell commands](https://slumber.lucaspickering.me/book/user_guide/templates.html)
 - [Browse response data using JSONPath selectors](https://slumber.lucaspickering.me/book/user_guide/filter_query.html)

--- a/src/collection/recipe_tree.rs
+++ b/src/collection/recipe_tree.rs
@@ -64,6 +64,11 @@ impl RecipeTree {
         Ok(new)
     }
 
+    /// Get a recipe/folder's tree lookup key by is unique ID
+    pub fn get_lookup_key(&self, id: &RecipeId) -> Option<&RecipeLookupKey> {
+        self.nodes_by_id.get(id)
+    }
+
     /// Get a folder/recipe by ID
     pub fn get(&self, id: &RecipeId) -> Option<&RecipeNode> {
         let lookup_key = self.nodes_by_id.get(id)?;
@@ -198,6 +203,14 @@ impl RecipeNode {
         match self {
             RecipeNode::Recipe(recipe) => Some(recipe),
             RecipeNode::Folder(_) => None,
+        }
+    }
+
+    /// If this node is a folder, return it. Otherwise return `None`
+    pub fn folder(&self) -> Option<&Folder> {
+        match self {
+            RecipeNode::Recipe(_) => None,
+            RecipeNode::Folder(folder) => Some(folder),
         }
     }
 }

--- a/src/tui/view/common/tabs.rs
+++ b/src/tui/view/common/tabs.rs
@@ -15,11 +15,19 @@ use std::fmt::Debug;
 
 /// Multi-tab display. Generic parameter defines the available tabs.
 #[derive(Debug)]
-pub struct Tabs<T: FixedSelect + Persistable> {
+pub struct Tabs<T>
+where
+    T: FixedSelect + Persistable,
+    T::Persisted: PartialEq<T>,
+{
     tabs: Persistent<SelectState<Fixed, T, usize>>,
 }
 
-impl<T: FixedSelect + Persistable> Tabs<T> {
+impl<T> Tabs<T>
+where
+    T: FixedSelect + Persistable,
+    T::Persisted: PartialEq<T>,
+{
     pub fn new(persistent_key: PersistentKey) -> Self {
         Self {
             tabs: Persistent::new(persistent_key, SelectState::default()),
@@ -31,7 +39,11 @@ impl<T: FixedSelect + Persistable> Tabs<T> {
     }
 }
 
-impl<T: FixedSelect + Persistable> EventHandler for Tabs<T> {
+impl<T> EventHandler for Tabs<T>
+where
+    T: FixedSelect + Persistable,
+    T::Persisted: PartialEq<T>,
+{
     fn update(&mut self, event: Event) -> Update {
         match event {
             Event::Input {
@@ -54,7 +66,11 @@ impl<T: FixedSelect + Persistable> EventHandler for Tabs<T> {
     }
 }
 
-impl<T: FixedSelect + Persistable> Draw for Tabs<T> {
+impl<T> Draw for Tabs<T>
+where
+    T: FixedSelect + Persistable,
+    T::Persisted: PartialEq<T>,
+{
     fn draw(&self, frame: &mut Frame, _: (), area: Rect) {
         frame.render_widget(
             ratatui::widgets::Tabs::new(T::iter().map(|e| e.to_string()))

--- a/src/tui/view/component/recipe_list.rs
+++ b/src/tui/view/component/recipe_list.rs
@@ -1,14 +1,12 @@
-//! Recipe list
-
 use crate::{
-    collection::{Recipe, RecipeId, RecipeNode, RecipeTree},
+    collection::{Recipe, RecipeId, RecipeLookupKey, RecipeNode, RecipeTree},
     tui::{
         context::TuiContext,
         input::Action,
         view::{
-            common::{list::List, Pane},
+            common::Pane,
             draw::{Draw, Generate},
-            event::{Event, EventHandler, EventQueue},
+            event::{Event, EventHandler, EventQueue, Update},
             state::{
                 persistence::{Persistable, Persistent, PersistentKey},
                 select::{Dynamic, SelectState},
@@ -17,127 +15,270 @@ use crate::{
         },
     },
 };
+use derive_more::{Deref, DerefMut};
 use itertools::Itertools;
-use ratatui::{prelude::Rect, text::Span, Frame};
+use ratatui::{prelude::Rect, Frame};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 
+/// List/tree of recipes and folders. This is mostly just a list, but with some
+/// extra logic to allow expanding/collapsing nodes. This could be made into a
+/// more generic component, but that adds abstraction that's not necessary
+/// because this is the only tree in the app. For similar reasons, we don't use
+/// the library tui-tree-widget, because it requires more abstraction that it
+/// saves us in code.
+///
+/// This implementation leans heavily on the fact that all nodes in the tree
+/// have a unique ID, which is another reason why it deserves its own
+/// implementation.
 #[derive(Debug)]
 pub struct RecipeListPane {
-    recipes: Component<Persistent<SelectState<Dynamic, RecipeListItem>>>,
+    /// A clone of the recipe tree
+    recipes: RecipeTree,
+    /// The visible list of items is tracked using normal list state, so we can
+    /// easily re-use existing logic. We'll rebuild this any time a folder is
+    /// expanded/collapsed (i.e whenever the list of items changes)
+    select_state: Component<Persistent<SelectState<Dynamic, RecipeNode>>>,
+    /// Set of all folders that are collapsed
+    /// Invariant: No recipes, only folders
+    collapsed: Persistent<Collapsed>,
 }
 
 pub struct RecipeListPaneProps {
     pub is_selected: bool,
 }
 
-/// Each folder/recipe in the list, plus metadata
-#[derive(Debug)]
-struct RecipeListItem {
-    node: RecipeNode,
-    depth: usize,
+/// Set of collapsed folders. This newtype is really only necessary so we can
+/// implement [Persistable] on it
+#[derive(Debug, Default, Deref, DerefMut, Serialize, Deserialize)]
+#[serde(transparent)]
+struct Collapsed(HashSet<RecipeId>);
+
+/// Ternary state for modifying node collapse state
+enum CollapseState {
+    Expand,
+    Collapse,
+    Toggle,
 }
 
 impl RecipeListPane {
     pub fn new(recipes: &RecipeTree) -> Self {
-        // When highlighting a new recipe, load it from the repo
-        fn on_select(_: &mut RecipeListItem) {
-            // If a recipe isn't selected, this will do nothing
-            EventQueue::push(Event::HttpLoadRequest);
-        }
-
-        // Flatten the tree into a list
-        let recipes = recipes
-            .iter()
-            .map(|(lookup_key, node)| RecipeListItem {
-                node: node.clone(),
-                depth: lookup_key.len() - 1,
-            })
-            .collect_vec();
-
+        // This clone is unfortunate, but we can't hold onto a reference to the
+        // recipes
+        let collapsed = Persistent::new(
+            PersistentKey::RecipeCollapsed,
+            Collapsed::default(),
+        );
+        let persistent = Persistent::new(
+            PersistentKey::RecipeId,
+            build_select_state(recipes, &collapsed),
+        );
         Self {
-            recipes: Persistent::new(
-                PersistentKey::RecipeId,
-                SelectState::new(recipes).on_select(on_select),
-            )
-            .into(),
+            recipes: recipes.clone(),
+            select_state: persistent.into(),
+            collapsed,
         }
     }
 
     /// Which recipe in the recipe list is selected? `None` iff the list is
     /// empty OR a folder is selected.
     pub fn selected_recipe(&self) -> Option<&Recipe> {
-        self.recipes
-            .selected()
-            .and_then(|list_item| list_item.node.recipe())
+        self.select_state.selected().and_then(RecipeNode::recipe)
+    }
+
+    /// Set the currently selected folder as expanded/collapsed (or toggle it).
+    /// If a folder is not selected, do nothing. Returns whether a change was
+    /// made.
+    fn set_selected_collapsed(&mut self, state: CollapseState) -> bool {
+        let folder = self.select_state.selected().and_then(RecipeNode::folder);
+        let changed = if let Some(folder) = folder {
+            let collapsed = &mut self.collapsed;
+            match state {
+                CollapseState::Expand => collapsed.remove(&folder.id),
+                CollapseState::Collapse => collapsed.insert(folder.id.clone()),
+                CollapseState::Toggle => {
+                    if collapsed.contains(&folder.id) {
+                        collapsed.remove(&folder.id);
+                    } else {
+                        collapsed.insert(folder.id.clone());
+                    }
+                    true
+                }
+            }
+        } else {
+            false
+        };
+
+        // If we changed the set of what is visible, rebuild the list state
+        if changed {
+            let mut new_select_state =
+                build_select_state(&self.recipes, &self.collapsed);
+            // Carry over the selection
+            if let Some(selected) = self.select_state.selected() {
+                new_select_state.select(selected.id());
+            }
+            **self.select_state = new_select_state;
+        }
+
+        changed
     }
 }
 
 impl EventHandler for RecipeListPane {
+    fn update(&mut self, event: Event) -> Update {
+        if let Event::Input {
+            action: Some(action),
+            ..
+        } = event
+        {
+            match action {
+                Action::Left => {
+                    self.set_selected_collapsed(CollapseState::Collapse);
+                }
+                Action::Right => {
+                    self.set_selected_collapsed(CollapseState::Expand);
+                }
+                Action::Submit => {
+                    if !self.set_selected_collapsed(CollapseState::Toggle) {
+                        // Propgate submit event for recipes, so it launches a
+                        // request
+                        return Update::Propagate(event);
+                    }
+                }
+                _ => return Update::Propagate(event),
+            };
+        } else {
+            return Update::Propagate(event);
+        }
+        Update::Consumed
+    }
+
     fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {
-        vec![self.recipes.as_child()]
+        vec![self.select_state.as_child()]
     }
 }
 
 impl Draw<RecipeListPaneProps> for RecipeListPane {
     fn draw(&self, frame: &mut Frame, props: RecipeListPaneProps, area: Rect) {
-        self.recipes.set_area(area); // Needed for tracking cursor events
-        let title = TuiContext::get()
+        let context = TuiContext::get();
+        self.select_state.set_area(area); // Needed for tracking cursor events
+
+        let title = context
             .input_engine
             .add_hint("Recipes", Action::SelectRecipeList);
-        let list = List {
-            block: Some(Pane {
-                title: &title,
-                is_focused: props.is_selected,
-            }),
-            list: &self.recipes,
+        let pane = Pane {
+            title: &title,
+            is_focused: props.is_selected,
         };
+
+        // We have to build this manually instead of using our own List type,
+        // because we need outside context during the render
+        let items = self
+            .select_state
+            .items()
+            .iter()
+            .map(|node| {
+                let (icon, name) = match node {
+                    RecipeNode::Folder(folder) => {
+                        let icon = if self.collapsed.is_collapsed(&folder.id) {
+                            "▶"
+                        } else {
+                            "▼"
+                        };
+                        (icon, folder.name())
+                    }
+                    RecipeNode::Recipe(recipe) => ("", recipe.name()),
+                };
+                let depth = self
+                    .recipes
+                    .get_lookup_key(node.id())
+                    .unwrap_or_else(|| {
+                        panic!("Recipe node {} is not in tree", node.id())
+                    })
+                    .len()
+                    - 1;
+
+                // Apply indentation
+                format!(
+                    "{indent:width$}{icon}{name}",
+                    indent = "",
+                    width = depth
+                )
+            })
+            .collect_vec();
+        let list = ratatui::widgets::List::new(items)
+            .block(pane.generate())
+            .highlight_style(context.theme.list.highlight);
+
         frame.render_stateful_widget(
-            list.generate(),
+            list,
             area,
-            &mut self.recipes.state_mut(),
-        )
+            &mut self.select_state.state_mut(),
+        );
+    }
+}
+
+impl Collapsed {
+    /// Is this specific folder collapsed?
+    fn is_collapsed(&self, folder_id: &RecipeId) -> bool {
+        self.0.contains(folder_id)
+    }
+
+    /// Is the given node visible? This takes lookup key so it can check all
+    /// ancestors for visibility too.
+    fn is_visible(&self, lookup_key: &RecipeLookupKey) -> bool {
+        // If any ancestors are collapsed, this is *not* visible
+        let [ancestors @ .., _] = lookup_key.as_slice() else {
+            panic!("Recipe lookup key cannot be empty")
+        };
+        !ancestors.iter().any(|id| self.is_collapsed(id))
     }
 }
 
 /// Persist recipe by ID
-impl Persistable for RecipeListItem {
+impl Persistable for RecipeNode {
     type Persisted = RecipeId;
 
     fn get_persistent(&self) -> &Self::Persisted {
-        self.node.id()
+        self.id()
     }
 }
 
 /// Needed for persistence loading
-impl PartialEq<RecipeListItem> for RecipeId {
-    fn eq(&self, other: &RecipeListItem) -> bool {
-        self == other.node.id()
+impl PartialEq<RecipeNode> for RecipeId {
+    fn eq(&self, node: &RecipeNode) -> bool {
+        self == node.id()
     }
 }
 
-impl Generate for &RecipeListItem {
-    type Output<'this> = Span<'this> where Self: 'this;
+/// Persistence for collapsed set of folders. Technically this can accrue
+/// removed folders over time (if they were collapsed at the time of deletion).
+/// That isn't really an issue though, it just means it'll be pre-collapsed if
+/// the user ever adds the folder back. Not worth working around.
+impl Persistable for Collapsed {
+    type Persisted = Self;
 
-    fn generate<'this>(self) -> Self::Output<'this>
-    where
-        Self: 'this,
-    {
-        // Apply indentation based on folder depth
-        let content = format!(
-            "{indent:width$}{name}",
-            indent = "",
-            name = self.node.name(),
-            width = self.depth
-        );
-
-        let theme = &TuiContext::get().theme;
-        let style = match self.node {
-            RecipeNode::Folder(_) => theme.recipe_list.folder,
-            RecipeNode::Recipe(_) => theme.recipe_list.recipe,
-        };
-
-        Span {
-            content: content.into(),
-            style,
-        }
+    fn get_persistent(&self) -> &Self::Persisted {
+        self
     }
+}
+
+/// Construct select list based on which nodes are currently visible
+fn build_select_state(
+    recipes: &RecipeTree,
+    collapsed: &Collapsed,
+) -> SelectState<Dynamic, RecipeNode> {
+    // When highlighting a new recipe, load it from the repo
+    fn on_select(_: &mut RecipeNode) {
+        // If a recipe isn't selected, this will do nothing
+        EventQueue::push(Event::HttpLoadRequest);
+    }
+
+    let items = recipes
+        .iter()
+        // Filter out hidden nodes
+        .filter(|(lookup_key, _)| collapsed.is_visible(lookup_key))
+        .map(|(_, node)| node.clone())
+        .collect();
+    SelectState::new(items).on_select(on_select)
 }

--- a/src/tui/view/state/persistence.rs
+++ b/src/tui/view/state/persistence.rs
@@ -67,25 +67,26 @@ impl<T: PersistentContainer> Drop for Persistent<T> {
 
 #[derive(Clone, Debug, Serialize)]
 pub enum PersistentKey {
+    /// Which pane is selected?
     PrimaryPane,
+    /// Which pane (if any) is fullscreened?
     FullscreenMode,
+    /// Selected profile in the list
     ProfileId,
+    /// Selected recipe/folder in the tree
     RecipeId,
+    /// Set of folders that are collapsed in the recipe tree
+    RecipeCollapsed,
+    /// Selected tab in the recipe pane
     RecipeTab,
     /// Selected query param, per recipe. Value is the query param name
     RecipeSelectedQuery(RecipeId),
     /// Toggle state for a single recipe+query param
-    RecipeQuery {
-        recipe: RecipeId,
-        param: String,
-    },
+    RecipeQuery { recipe: RecipeId, param: String },
     /// Selected header, per recipe. Value is the header name
     RecipeSelectedHeader(RecipeId),
     /// Toggle state for a single recipe+header
-    RecipeHeader {
-        recipe: RecipeId,
-        header: String,
-    },
+    RecipeHeader { recipe: RecipeId, header: String },
     /// Selected tab in Request pane
     RequestTab,
     /// Selected tab in Response pane
@@ -96,7 +97,7 @@ pub enum PersistentKey {
 pub trait Persistable {
     /// The type of the value that's actually persisted to the database. In most
     /// cases this is the value itself, but some types use others (e.g. an ID).
-    type Persisted: Debug + Serialize + DeserializeOwned + PartialEq<Self>;
+    type Persisted: Debug + Serialize + DeserializeOwned;
 
     /// Get the value that should be persisted to the DB
     fn get_persistent(&self) -> &Self::Persisted;

--- a/src/tui/view/state/select.rs
+++ b/src/tui/view/state/select.rs
@@ -35,8 +35,10 @@ where
     state: RefCell<State>,
     #[debug(skip)]
     items: Vec<Item>,
+    /// Callback when an item is highlighted
     #[debug(skip)]
     on_select: Option<Callback<Item>>,
+    /// Callback when the Submit action is performed on an item
     #[debug(skip)]
     on_submit: Option<Callback<Item>>,
     #[debug(skip)]
@@ -246,6 +248,7 @@ where
     }
 }
 
+/// Fixed set of items
 impl<Item, State> Default for SelectState<Fixed, Item, State>
 where
     Item: FixedSelect,
@@ -253,6 +256,16 @@ where
 {
     fn default() -> Self {
         Self::fixed()
+    }
+}
+
+/// Empty dynamic list
+impl<Item, State> Default for SelectState<Dynamic, Item, State>
+where
+    State: SelectStateData,
+{
+    fn default() -> Self {
+        Self::new(Vec::new())
     }
 }
 

--- a/src/tui/view/state/select.rs
+++ b/src/tui/view/state/select.rs
@@ -309,6 +309,8 @@ impl<Kind, Item, State> PersistentContainer for SelectState<Kind, Item, State>
 where
     Kind: SelectStateKind,
     Item: Persistable,
+    // Whatever is persisted in the DB needs to be comparable to the items in
+    // the list, so we can select by equality
     Item::Persisted: PartialEq<Item>,
     State: SelectStateData,
 {

--- a/src/tui/view/theme.rs
+++ b/src/tui/view/theme.rs
@@ -6,7 +6,6 @@ use ratatui::style::{Color, Modifier, Style};
 pub struct Theme {
     pub pane: ThemePane,
     pub list: ThemeList,
-    pub recipe_list: ThemeRecipeList,
     pub tab: ThemeTab,
     pub table: ThemeTable,
     pub template_preview: ThemeTemplatePreview,
@@ -27,14 +26,6 @@ impl Theme {
 pub struct ThemeList {
     /// Highlighted item in a list
     pub highlight: Style,
-}
-
-#[derive(Debug)]
-pub struct ThemeRecipeList {
-    /// Folders in recipe list
-    pub folder: Style,
-    /// Recipes in recipe list
-    pub recipe: Style,
 }
 
 /// Styles for Pane component
@@ -109,10 +100,6 @@ impl Default for Theme {
                     .bg(Self::PRIMARY_COLOR)
                     .fg(Color::Black)
                     .add_modifier(Modifier::BOLD),
-            },
-            recipe_list: ThemeRecipeList {
-                folder: Style::default().fg(Color::Blue),
-                recipe: Style::default().fg(Self::PRIMARY_COLOR),
             },
             tab: ThemeTab {
                 highlight: Style::default()


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (make sure to use a [resolving keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) so GitHub auto-links it). For UI changes, please also include screenshots._

Folders in the recipe list are now collapsible. Right arrow expands, left arrow collapses, enter toggles between the two. Collapsed state is persisted.

Also, I removed the `PartialEq<Self>` bound on `Persistable::Persisted`. It's only needed in the case of `SelectState`, so it's only there now.

<img width="281" alt="image" src="https://github.com/LucasPickering/slumber/assets/2382935/6258e896-499a-4800-b204-d0ca85cf5604">

<img width="285" alt="image" src="https://github.com/LucasPickering/slumber/assets/2382935/69479502-0685-445f-aeb1-fc83d7e13e06">

Closes #155 

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

## QA

_How did you test this?_

## Checklist

- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
