### PR TITLE
Support booleans and numbers for query values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Support booleans and numbers for query values ([#141](https://github.com/LucasPickering/slumber/issues/141))
+
 ### Changed
 
 - Show `WARN`/`ERROR` log output for CLI commands

--- a/docs/src/api/request_collection/request_recipe.md
+++ b/docs/src/api/request_collection/request_recipe.md
@@ -60,5 +60,5 @@ fish: !folder
       method: GET
       url: "{{host}}/fishes"
       query:
-        big: "true"
+        big: true
 ```

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -50,7 +50,7 @@ requests:
     method: GET
     url: "{{host}}/fishes"
     query:
-      big: "true"
+      big: true
 ```
 
 This request collection uses [templates](./user_guide//templates.md) and [profiles](./api/request_collection/profile.md) allow you to dynamically change the target host.

--- a/docs/src/user_guide/cli.md
+++ b/docs/src/user_guide/cli.md
@@ -27,7 +27,7 @@ requests:
     method: GET
     url: "{{host}}/fishes"
     query:
-      big: "true"
+      big: true
 ```
 
 You can use the `request` subcommand:

--- a/docs/src/user_guide/inheritance.md
+++ b/docs/src/user_guide/inheritance.md
@@ -21,7 +21,7 @@ requests:
     method: GET
     url: "{{host}}/fishes"
     query:
-      big: "true"
+      big: true
     headers:
       Accept: application/json
     authentication: !bearer "{{chains.token}}"
@@ -63,7 +63,7 @@ requests:
     method: GET
     url: "{{host}}/fishes"
     query:
-      big: "true"
+      big: true
 
   get_fish: !request
     <<: *request_base
@@ -100,7 +100,7 @@ requests:
     method: GET
     url: "{{host}}/fishes"
     query:
-      big: "true"
+      big: true
 
   get_fish: !request
     <<: *request_base

--- a/docs/src/user_guide/templates.md
+++ b/docs/src/user_guide/templates.md
@@ -28,7 +28,7 @@ requests:
     method: GET
     url: "{{host}}/fishes"
     query:
-      big: "true"
+      big: true
 ```
 
 Now you can easily select which host to hit. In the TUI, this is done via the Profile list. In the CLI, use the `--profile` option:

--- a/src/collection/cereal.rs
+++ b/src/collection/cereal.rs
@@ -89,17 +89,6 @@ impl<'de> Deserialize<'de> for Template {
             };
         }
 
-        macro_rules! visit_null {
-            ($func:ident) => {
-                fn $func<E>(self) -> Result<Self::Value, E>
-                where
-                    E: Error,
-                {
-                    Template::try_from("null".to_string()).map_err(E::custom)
-                }
-            };
-        }
-
         impl<'de> Visitor<'de> for TemplateVisitor {
             type Value = Template;
 
@@ -108,7 +97,7 @@ impl<'de> Deserialize<'de> for Template {
                 formatter: &mut std::fmt::Formatter,
             ) -> std::fmt::Result {
                 formatter.write_str(
-                    "Invalid type, must be a string, number, boolean, or null",
+                    "Invalid type, must be a string, number or boolean",
                 )
             }
 
@@ -117,9 +106,6 @@ impl<'de> Deserialize<'de> for Template {
             visit_primitive!(visit_i64, i64);
             visit_primitive!(visit_f64, f64);
             visit_primitive!(visit_str, &str);
-
-            visit_null!(visit_none);
-            visit_null!(visit_unit);
         }
 
         deserializer.deserialize_any(TemplateVisitor)
@@ -278,9 +264,6 @@ mod tests {
     #[case(Token::I64(-1000), "-1000")]
     #[case(Token::F64(10.1), "10.1")]
     #[case(Token::F64(-10.1), "-10.1")]
-    // null
-    #[case(Token::None, "null")]
-    #[case(Token::Unit, "null")]
     // string
     #[case(Token::Str("hello"), "hello")]
     #[case(Token::Str("null"), "null")]

--- a/src/collection/cereal.rs
+++ b/src/collection/cereal.rs
@@ -96,9 +96,7 @@ impl<'de> Deserialize<'de> for Template {
                 &self,
                 formatter: &mut std::fmt::Formatter,
             ) -> std::fmt::Result {
-                formatter.write_str(
-                    "Invalid type, must be a string, number or boolean",
-                )
+                formatter.write_str("string, number, or boolean")
             }
 
             visit_primitive!(visit_bool, bool);

--- a/src/collection/cereal.rs
+++ b/src/collection/cereal.rs
@@ -258,3 +258,31 @@ pub mod serde_duration {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::template::Template;
+    use rstest::rstest;
+    use serde_test::{assert_de_tokens, Token};
+
+    #[rstest]
+    // boolean
+    #[case(Token::Bool(true), "true")]
+    #[case(Token::Bool(false), "false")]
+    // numeric
+    #[case(Token::U64(1000), "1000")]
+    #[case(Token::I64(-1000), "-1000")]
+    #[case(Token::F64(10.1), "10.1")]
+    #[case(Token::F64(-10.1), "-10.1")]
+    // null
+    #[case(Token::None, "null")]
+    #[case(Token::Unit, "null")]
+    // string
+    #[case(Token::Str("hello"), "hello")]
+    #[case(Token::Str("null"), "null")]
+    #[case(Token::Str("true"), "true")]
+    #[case(Token::Str("false"), "false")]
+    fn test_deserialize_template(#[case] token: Token, #[case] expected: &str) {
+        assert_de_tokens(&Template::from(expected), &[token]);
+    }
+}

--- a/src/collection/cereal.rs
+++ b/src/collection/cereal.rs
@@ -1,11 +1,15 @@
 //! Serialization/deserialization helpers for various types
 
-use crate::collection::{
-    recipe_tree::RecipeNode, Chain, ChainId, Profile, ProfileId, RecipeId,
+use crate::{
+    collection::{
+        recipe_tree::RecipeNode, Chain, ChainId, Profile, ProfileId, RecipeId,
+    },
+    template::Template,
 };
-use crate::template::Template;
-use serde::de::Visitor;
-use serde::{de::Error, Deserialize, Deserializer};
+use serde::{
+    de::{Error, Visitor},
+    Deserialize, Deserializer,
+};
 use std::hash::Hash;
 
 /// A type that has an `id` field. This is ripe for a derive macro, maybe a fun

--- a/src/template.rs
+++ b/src/template.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 use derive_more::{Deref, Display};
 use indexmap::IndexMap;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use std::{fmt::Debug, sync::atomic::AtomicU8};
 
 /// Maximum number of layers of nested templates
@@ -58,9 +58,9 @@ pub struct TemplateContext {
     pub recursion_count: AtomicU8,
 }
 
-/// A immutable string that can contain templated content. The string is parsed
+/// An immutable string that can contain templated content. The string is parsed
 /// during creation to identify template keys, hence the immutability.
-#[derive(Clone, Debug, Deref, Display, Serialize, Deserialize)]
+#[derive(Clone, Debug, Deref, Display, Serialize)]
 #[cfg_attr(test, derive(PartialEq))]
 #[display("{template}")]
 #[serde(try_from = "String", into = "String")]


### PR DESCRIPTION
## Description

Booleans, numeric and nulls are now supported for query values.

#### Changes:
- Implemented ```Deserialize``` manually for ```Template``` using ~~```serde_yaml::value::Value```~~ ```TemplateVisitor```
- Adjusted documentation, although  ```"true"``` is still supported I replaced it with ```true```
- Updated ```CHANGELOG.md``` (twice 😅)

## QA
- Added Template deserialization tests inside ```cereal.rs```

Closes #141