### PR TITLE
Split SelectState into two types

### DIFF
--- a/src/tui/view/common/actions.rs
+++ b/src/tui/view/common/actions.rs
@@ -4,7 +4,7 @@ use crate::{
         component::Component,
         draw::{Draw, Generate, ToStringGenerate},
         event::{Event, EventHandler, EventQueue},
-        state::select::{Fixed, FixedSelect, SelectState},
+        state::fixed_select::{FixedSelect, FixedSelectState},
     },
     util::EnumChain,
 };
@@ -22,8 +22,7 @@ use strum::{EnumCount, EnumIter};
 #[derive(Debug)]
 pub struct ActionsModal<T: FixedSelect = EmptyAction> {
     /// Join the list of global actions into the given one
-    actions:
-        Component<SelectState<Fixed, EnumChain<GlobalAction, T>, ListState>>,
+    actions: Component<FixedSelectState<EnumChain<GlobalAction, T>, ListState>>,
 }
 
 impl<T: FixedSelect> Default for ActionsModal<T> {
@@ -40,7 +39,7 @@ impl<T: FixedSelect> Default for ActionsModal<T> {
         };
 
         Self {
-            actions: SelectState::fixed().on_submit(wrapper).into(),
+            actions: FixedSelectState::new().on_submit(wrapper).into(),
         }
     }
 }
@@ -76,7 +75,7 @@ where
     fn draw(&self, frame: &mut Frame, _: (), area: Rect) {
         let list = List {
             block: None,
-            list: &self.actions,
+            list: self.actions.items(),
         };
         frame.render_stateful_widget(
             list.generate(),

--- a/src/tui/view/common/list.rs
+++ b/src/tui/view/common/list.rs
@@ -1,27 +1,20 @@
 use crate::tui::{
     context::TuiContext,
-    view::{
-        common::Pane,
-        draw::Generate,
-        state::select::{SelectState, SelectStateKind},
-    },
+    view::{common::Pane, draw::Generate},
 };
-use ratatui::{
-    text::Span,
-    widgets::{ListItem, ListState},
-};
+use ratatui::{text::Span, widgets::ListItem};
 
 /// A list with optional border and title. Each item has to be convertible to
 /// text
-pub struct List<'a, Kind: SelectStateKind, Item> {
+pub struct List<'a, Item, Iter: 'a + IntoIterator<Item = Item>> {
     pub block: Option<Pane<'a>>,
-    pub list: &'a SelectState<Kind, Item, ListState>,
+    pub list: Iter,
 }
 
-impl<'a, Kind, Item> Generate for List<'a, Kind, Item>
+impl<'a, Item, Iter> Generate for List<'a, Item, Iter>
 where
-    Kind: SelectStateKind,
-    &'a Item: Generate<Output<'a> = Span<'a>>,
+    Item: 'a + Generate<Output<'a> = Span<'a>>,
+    Iter: 'a + IntoIterator<Item = Item>,
 {
     type Output<'this> = ratatui::widgets::List<'this> where Self: 'this;
 
@@ -34,8 +27,7 @@ where
         // Convert each list item into text
         let items: Vec<ListItem<'_>> = self
             .list
-            .items()
-            .iter()
+            .into_iter()
             .map(|i| ListItem::new(i.generate()))
             .collect();
 

--- a/src/tui/view/common/tabs.rs
+++ b/src/tui/view/common/tabs.rs
@@ -5,8 +5,8 @@ use crate::tui::{
         draw::Draw,
         event::{Event, EventHandler, Update},
         state::{
+            fixed_select::{FixedSelect, FixedSelectState},
             persistence::{Persistable, Persistent, PersistentKey},
-            select::{Fixed, FixedSelect, SelectState},
         },
     },
 };
@@ -17,20 +17,18 @@ use std::fmt::Debug;
 #[derive(Debug)]
 pub struct Tabs<T>
 where
-    T: FixedSelect + Persistable,
-    T::Persisted: PartialEq<T>,
+    T: FixedSelect + Persistable<Persisted = T>,
 {
-    tabs: Persistent<SelectState<Fixed, T, usize>>,
+    tabs: Persistent<FixedSelectState<T, usize>>,
 }
 
 impl<T> Tabs<T>
 where
-    T: FixedSelect + Persistable,
-    T::Persisted: PartialEq<T>,
+    T: FixedSelect + Persistable<Persisted = T>,
 {
     pub fn new(persistent_key: PersistentKey) -> Self {
         Self {
-            tabs: Persistent::new(persistent_key, SelectState::default()),
+            tabs: Persistent::new(persistent_key, Default::default()),
         }
     }
 
@@ -41,8 +39,7 @@ where
 
 impl<T> EventHandler for Tabs<T>
 where
-    T: FixedSelect + Persistable,
-    T::Persisted: PartialEq<T>,
+    T: FixedSelect + Persistable<Persisted = T>,
 {
     fn update(&mut self, event: Event) -> Update {
         match event {
@@ -68,8 +65,7 @@ where
 
 impl<T> Draw for Tabs<T>
 where
-    T: FixedSelect + Persistable,
-    T::Persisted: PartialEq<T>,
+    T: FixedSelect + Persistable<Persisted = T>,
 {
     fn draw(&self, frame: &mut Frame, _: (), area: Rect) {
         frame.render_widget(

--- a/src/tui/view/component/primary.rs
+++ b/src/tui/view/component/primary.rs
@@ -20,8 +20,8 @@ use crate::{
             draw::Draw,
             event::{Event, EventHandler, EventQueue, Update},
             state::{
+                fixed_select::FixedSelectState,
                 persistence::{Persistent, PersistentKey},
-                select::{Fixed, SelectState},
                 RequestState,
             },
             util::layout,
@@ -42,7 +42,7 @@ use strum::{EnumCount, EnumIter};
 #[derive(derive_more::Debug)]
 pub struct PrimaryView {
     // Own state
-    selected_pane: Persistent<SelectState<Fixed, PrimaryPane>>,
+    selected_pane: Persistent<FixedSelectState<PrimaryPane>>,
     fullscreen_mode: Persistent<Option<FullscreenMode>>,
 
     // Children
@@ -233,7 +233,7 @@ impl PrimaryView {
             // Make profile list as small as possible
             Constraint::Max(
                 // +2 to account for top/bottom border
-                self.profile_list_pane.profiles().len() as u16 + 2,
+                self.profile_list_pane.profiles().items().len() as u16 + 2,
             )
         } else {
             Constraint::Max(3)

--- a/src/tui/view/component/profile_list.rs
+++ b/src/tui/view/component/profile_list.rs
@@ -9,7 +9,7 @@ use crate::{
             event::{Event, EventHandler, EventQueue, Update},
             state::{
                 persistence::{Persistable, Persistent, PersistentKey},
-                select::{Dynamic, SelectState},
+                select::SelectState,
             },
             Component,
         },
@@ -24,7 +24,7 @@ use ratatui::{
 
 #[derive(Debug)]
 pub struct ProfileListPane {
-    profiles: Component<Persistent<SelectState<Dynamic, Profile>>>,
+    profiles: Component<Persistent<SelectState<Profile>>>,
 }
 
 pub struct ProfileListPaneProps {
@@ -47,7 +47,7 @@ impl ProfileListPane {
         }
     }
 
-    pub fn profiles(&self) -> &SelectState<Dynamic, Profile> {
+    pub fn profiles(&self) -> &SelectState<Profile> {
         &self.profiles
     }
 }
@@ -89,7 +89,7 @@ impl Draw<ProfileListPaneProps> for ProfileListPane {
             // Only show the full list if selected
             let list = List {
                 block: None,
-                list: &self.profiles,
+                list: self.profiles.items(),
             };
             frame.render_stateful_widget(
                 list.generate(),

--- a/src/tui/view/component/recipe_list.rs
+++ b/src/tui/view/component/recipe_list.rs
@@ -9,7 +9,7 @@ use crate::{
             event::{Event, EventHandler, EventQueue, Update},
             state::{
                 persistence::{Persistable, Persistent, PersistentKey},
-                select::{Dynamic, SelectState},
+                select::SelectState,
             },
             Component,
         },
@@ -38,7 +38,7 @@ pub struct RecipeListPane {
     /// The visible list of items is tracked using normal list state, so we can
     /// easily re-use existing logic. We'll rebuild this any time a folder is
     /// expanded/collapsed (i.e whenever the list of items changes)
-    select_state: Component<Persistent<SelectState<Dynamic, RecipeNode>>>,
+    select_state: Component<Persistent<SelectState<RecipeNode>>>,
     /// Set of all folders that are collapsed
     /// Invariant: No recipes, only folders
     collapsed: Persistent<Collapsed>,
@@ -267,7 +267,7 @@ impl Persistable for Collapsed {
 fn build_select_state(
     recipes: &RecipeTree,
     collapsed: &Collapsed,
-) -> SelectState<Dynamic, RecipeNode> {
+) -> SelectState<RecipeNode> {
     // When highlighting a new recipe, load it from the repo
     fn on_select(_: &mut RecipeNode) {
         // If a recipe isn't selected, this will do nothing

--- a/src/tui/view/component/recipe_pane.rs
+++ b/src/tui/view/component/recipe_pane.rs
@@ -19,7 +19,7 @@ use crate::{
             event::{Event, EventHandler, EventQueue, Update},
             state::{
                 persistence::{Persistable, Persistent, PersistentKey},
-                select::{Dynamic, SelectState},
+                select::SelectState,
                 StateCell,
             },
             util::layout,
@@ -72,8 +72,8 @@ struct RecipeStateKey {
 #[derive(Debug)]
 struct RecipeState {
     url: TemplatePreview,
-    query: Component<Persistent<SelectState<Dynamic, RowState, TableState>>>,
-    headers: Component<Persistent<SelectState<Dynamic, RowState, TableState>>>,
+    query: Component<Persistent<SelectState<RowState, TableState>>>,
+    headers: Component<Persistent<SelectState<RowState, TableState>>>,
     body: Option<Component<TextWindow<TemplatePreview>>>,
     authentication: Option<Component<AuthenticationDisplay>>,
 }
@@ -125,7 +125,7 @@ impl RecipePane {
         if let Some(state) = self.recipe_state.get() {
             /// Convert select state into the set of disabled keys
             fn to_disabled_set(
-                select_state: &SelectState<Dynamic, RowState, TableState>,
+                select_state: &SelectState<RowState, TableState>,
             ) -> HashSet<String> {
                 select_state
                     .items()
@@ -458,7 +458,7 @@ impl RowState {
 
 /// Convert table select state into a renderable table
 fn to_table<'a>(
-    state: &'a SelectState<Dynamic, RowState, TableState>,
+    state: &'a SelectState<RowState, TableState>,
     header: [&'a str; 3],
 ) -> Table<'a, 3, Row<'a>> {
     Table {

--- a/src/tui/view/state.rs
+++ b/src/tui/view/state.rs
@@ -1,5 +1,6 @@
 //! State types for the view.
 
+pub mod fixed_select;
 pub mod persistence;
 pub mod select;
 

--- a/src/tui/view/state/fixed_select.rs
+++ b/src/tui/view/state/fixed_select.rs
@@ -1,0 +1,185 @@
+use crate::tui::view::{
+    event::{Event, EventHandler, Update},
+    state::{
+        persistence::{Persistable, PersistentContainer},
+        select::{SelectState, SelectStateData},
+    },
+};
+use itertools::Itertools;
+use ratatui::widgets::ListState;
+use std::{
+    fmt::{Debug, Display},
+    ops::DerefMut,
+};
+use strum::{EnumCount, IntoEnumIterator};
+
+/// State manager for a static (AKA fixed) list of items. Fixed lists must be
+/// based on an iterable enum.  This supports a generic type for the state
+/// "backend", which is the ratatui type that stores the selection state.
+/// Typically you want `ListState` or `TableState`.
+/// Invariant: The fixed-size type cannot be empty
+#[derive(Debug)]
+pub struct FixedSelectState<Item, State = ListState>
+where
+    Item: FixedSelect,
+    State: SelectStateData,
+{
+    /// Re-use SelectState for state management. The only different is we
+    /// guarantee any value of the item type is in the list (because there's
+    /// a fixed number of values), so in a few places we'll unwrap options.
+    select: SelectState<Item, State>,
+}
+
+impl<Item, State> FixedSelectState<Item, State>
+where
+    Item: FixedSelect,
+    State: SelectStateData,
+{
+    /// Create a new fixed-size list, with options derived from a static enum.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the enum is empty.
+    pub fn new() -> Self {
+        let items = Item::iter().collect_vec();
+
+        if items.is_empty() {
+            // Wr run on the assumption that it's not empty, to prevent
+            // returning Options
+            panic!(
+                "Empty fixed-size collection not allow. \
+                Add a variant to your enum."
+            );
+        }
+
+        Self {
+            select: SelectState::new(items),
+        }
+    }
+
+    /// Get the index of the currently selected item
+    pub fn selected_index(&self) -> usize {
+        self.select
+            .selected_index()
+            .expect("Fixed-size list cannot be empty")
+    }
+
+    /// Get the currently selected item
+    pub fn selected(&self) -> &Item {
+        self.select
+            .selected()
+            .expect("Fixed-size list cannot be empty")
+    }
+
+    /// Set the callback to be called when the user hits enter on an item
+    pub fn on_submit(
+        mut self,
+        on_submit: impl 'static + Fn(&mut Item),
+    ) -> Self {
+        self.select = self.select.on_submit(on_submit);
+        self
+    }
+
+    /// Get all items in the list
+    pub fn items(&self) -> &[Item] {
+        self.select.items()
+    }
+
+    /// Is the given item selected?
+    pub fn is_selected(&self, item: &Item) -> bool
+    where
+        Item: PartialEq,
+    {
+        self.selected() == item
+    }
+
+    /// Get a mutable reference to state. This uses `RefCell` underneath so it
+    /// will panic if aliased. Only call this during the draw phase!
+    pub fn state_mut(&self) -> impl DerefMut<Target = State> + '_ {
+        self.select.state_mut()
+    }
+
+    /// Select an item by value. Context is required for callbacks. Generally
+    /// the given value will be the type `Item`, but it could be anything that
+    /// compares to `Item` (e.g. an ID type).
+    pub fn select<T>(&mut self, value: &T)
+    where
+        T: PartialEq<Item>,
+    {
+        self.select.select(value);
+    }
+
+    /// Select the previous item in the list
+    pub fn previous(&mut self) {
+        self.select.previous();
+    }
+
+    /// Select the next item in the list
+    pub fn next(&mut self) {
+        self.select.next();
+    }
+}
+
+impl<Item, State> Default for FixedSelectState<Item, State>
+where
+    Item: FixedSelect,
+    State: SelectStateData,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Handle input events to cycle between items
+impl<Item, State> EventHandler for FixedSelectState<Item, State>
+where
+    Item: FixedSelect,
+    State: Debug + SelectStateData,
+{
+    fn update(&mut self, event: Event) -> Update {
+        self.select.update(event)
+    }
+}
+
+impl<Item, State> PersistentContainer for FixedSelectState<Item, State>
+where
+    Item: FixedSelect + Persistable<Persisted = Item>,
+    State: SelectStateData,
+{
+    type Value = Item;
+
+    fn get(&self) -> Option<&Self::Value> {
+        Some(self.selected())
+    }
+
+    fn set(&mut self, value: <Self::Value as Persistable>::Persisted) {
+        // This will call the on_select callback if the item is in the list
+        self.select(&value);
+    }
+}
+
+/// Trait alias for a static list of items to be cycled through
+pub trait FixedSelect:
+    'static
+    + Copy
+    + Clone
+    + Debug
+    + Display
+    + EnumCount
+    + IntoEnumIterator
+    + PartialEq
+{
+}
+
+/// Auto-impl for anything we can
+impl<T> FixedSelect for T where
+    T: 'static
+        + Copy
+        + Clone
+        + Debug
+        + Display
+        + EnumCount
+        + IntoEnumIterator
+        + PartialEq
+{
+}


### PR DESCRIPTION
Split `SelectState` into two types, one for dynamic lists and one for fixed enums. This simplifies a some logic at the cost of a bit of duplication. 