### PR TITLE
Validate HTTP method on recipe during deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,14 @@
 
 ### Changed
 
-- Show `WARN`/`ERROR` log output for CLI commands
+- Folders can now be collapsed in the recipe list ([#155](https://github.com/LucasPickering/slumber/issues/155))
 - Improvements to Insomnia import ([#12](https://github.com/LucasPickering/slumber/issues/12))
 - Rename `import-experimental` command to `import`
   - It's official now! It's still going to get continuted improvement though
-- Folders can now be collapsed in the recipe list ([#155](https://github.com/LucasPickering/slumber/issues/155))
+- Show `WARN`/`ERROR` log output for CLI commands
+- Validate recipe `method` field during deserialization instead of on request init
+  - This means you'll get an error on startup if your method is invalid, instead of when you go to run the request
+  - This is not a breaking change because if you had an incorrect HTTP method, the request still didn't _work_ before, it just broke later
 
 ## [0.18.0] - 2024-04-18
 

--- a/src/collection/insomnia.rs
+++ b/src/collection/insomnia.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     collection::{
-        self, Collection, Folder, Profile, ProfileId, Recipe, RecipeId,
+        self, Collection, Folder, Method, Profile, ProfileId, Recipe, RecipeId,
         RecipeNode, RecipeTree,
     },
     template::Template,
@@ -139,7 +139,7 @@ struct Request {
     meta_sort_key: i64,
     name: String,
     url: Template,
-    method: String,
+    method: Method,
     #[serde(deserialize_with = "deserialize_shitty_option")]
     authentication: Option<Authentication>,
     headers: Vec<Header>,

--- a/src/template.rs
+++ b/src/template.rs
@@ -63,7 +63,7 @@ pub struct TemplateContext {
 #[derive(Clone, Debug, Deref, Display, Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq))]
 #[display("{template}")]
-#[serde(try_from = "String", into = "String")]
+#[serde(into = "String", try_from = "String")]
 pub struct Template {
     #[deref(forward)]
     template: String,
@@ -99,6 +99,7 @@ impl Template {
     }
 }
 
+/// For deserialization
 impl TryFrom<String> for Template {
     type Error = TemplateParseError;
 
@@ -107,6 +108,7 @@ impl TryFrom<String> for Template {
     }
 }
 
+/// For serialization
 impl From<Template> for String {
     fn from(value: Template) -> Self {
         value.template

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -44,7 +44,7 @@ factori!(Recipe, {
     default {
         id = "recipe1".into(),
         name = None,
-        method = "GET".into(),
+        method = "GET".parse().unwrap(),
         url = "http://localhost".into(),
         body = None,
         authentication = None,

--- a/src/tui/view/component/recipe_pane.rs
+++ b/src/tui/view/component/recipe_pane.rs
@@ -224,6 +224,8 @@ impl<'a> Draw<RecipePaneProps<'a>> for RecipePane {
 
         // Render request contents
         if let Some(recipe) = props.selected_recipe {
+            let method = recipe.method.to_string();
+
             let [metadata_area, tabs_area, content_area] = layout(
                 inner_area,
                 Direction::Vertical,
@@ -238,10 +240,7 @@ impl<'a> Draw<RecipePaneProps<'a>> for RecipePane {
                 metadata_area,
                 Direction::Horizontal,
                 // Method gets just as much as it needs, URL gets the rest
-                [
-                    Constraint::Max(recipe.method.len() as u16 + 1),
-                    Constraint::Min(0),
-                ],
+                [Constraint::Max(method.len() as u16 + 1), Constraint::Min(0)],
             );
 
             // Whenever the recipe or profile changes, generate a preview for
@@ -258,10 +257,7 @@ impl<'a> Draw<RecipePaneProps<'a>> for RecipePane {
             );
 
             // First line: Method + URL
-            frame.render_widget(
-                Paragraph::new(recipe.method.as_str()),
-                method_area,
-            );
+            frame.render_widget(Paragraph::new(method), method_area);
             frame.render_widget(&recipe_state.url, url_area);
 
             // Navigation tabs


### PR DESCRIPTION

## Description

_Describe the change. If there is an associated issue, please include the issue link (make sure to use a [resolving keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) so GitHub auto-links it). For UI changes, please also include screenshots._

Use an enum for HTTP method type on recipes. This means the method is now validated when the collection file is deserialized, rather than when we go to build a request. This should make it easier for users to debug issues with incorrect methods.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

This is a "breaking" change in that collection files that were previously accepted now are not. The recipe would have been broken anyway so I'm just considering it a bug fix. It's possible someone has a collection file with an invalid method though. Mitigated with a helpful error message.

## QA

_How did you test this?_

Put an invalid method in a collection file, verified I got a nice error message

## Checklist

- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
