### PR TITLE
Fix windows build and add to releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased] - ReleaseDate
+
+### Added
+
+- Add two new build targets to releases: `x86_64-pc-windows-msvc` and `x86_64-unknown-linux-musl`
+
+### Fixed
+
+- Fix build on Windows ([#180](https://github.com/LucasPickering/slumber/issues/180))
+  - I can't guarantee it _works_ on Windows since I don't have a machine to test on, but it at least compiles now
+
 ## [1.0.0] - 2024-04-25
 
 ### Breaking

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1962,7 +1962,6 @@ dependencies = [
  "serde_json_path",
  "serde_test",
  "serde_yaml",
- "signal-hook",
  "strum",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,10 +42,9 @@ serde = {version = "^1.0.188", features = ["derive"]}
 serde_json = {version = "^1.0.107", default-features = false}
 serde_json_path = "^0.6.3"
 serde_yaml = {version = "^0.9.25", default-features = false}
-signal-hook = "^0.3.17"
 strum = {version = "^0.26.0", default-features = false, features = ["derive"]}
 thiserror = "^1.0.48"
-tokio = {version = "^1.32.0", default-features = false, features = ["fs", "macros", "process", "rt", "rt-multi-thread"]}
+tokio = {version = "^1.32.0", default-features = false, features = ["fs", "macros", "process", "rt", "rt-multi-thread", "signal"]}
 tracing = "^0.1.37"
 tracing-subscriber = {version = "^0.3.17", default-features = false, features = ["ansi", "env-filter", "fmt", "registry"]}
 url = {version = "^2.5.0", features = ["serde"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,11 +75,17 @@ cargo-dist-version = "0.13.3"
 # CI backends to support
 ci = ["github"]
 # The installers to generate for each app
-installers = ["shell", "homebrew"]
+installers = ["shell", "homebrew", "powershell"]
 # A GitHub repo to push Homebrew formulas to
 tap = "LucasPickering/homebrew-tap"
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl"]
+targets = [
+  "aarch64-apple-darwin",
+  "x86_64-apple-darwin",
+  "x86_64-unknown-linux-gnu",
+  "x86_64-unknown-linux-musl",
+  "x86_64-pc-windows-msvc",
+]
 # Publish jobs to run in CI
 publish-jobs = ["homebrew"]
 # Publish jobs to run in CI

--- a/src/tui/signal.rs
+++ b/src/tui/signal.rs
@@ -1,0 +1,50 @@
+//! Utilities for handling signals to the process
+
+use futures::{future, FutureExt};
+use tracing::info;
+
+/// Listen for any exit signals, and return `Ok(())` when any signal is
+/// received. This can only fail during initialization.
+#[cfg(unix)]
+pub async fn signals() -> anyhow::Result<()> {
+    use anyhow::Context;
+    use itertools::Itertools;
+    use tokio::signal::unix::{signal, Signal, SignalKind};
+
+    let signals: Vec<(Signal, SignalKind)> = [
+        SignalKind::interrupt(),
+        SignalKind::hangup(),
+        SignalKind::terminate(),
+        SignalKind::quit(),
+    ]
+    .into_iter()
+    .map::<anyhow::Result<_>, _>(|kind| {
+        let signal = signal(kind).with_context(|| {
+            format!("Error initializing listener for signal `{kind:?}`")
+        })?;
+        Ok((signal, kind))
+    })
+    .try_collect()?;
+    let futures = signals
+        .into_iter()
+        .map(|(mut signal, kind)| async move {
+            signal.recv().await;
+            info!(?kind, "Received signal");
+        })
+        .map(FutureExt::boxed);
+    future::select_all(futures).await;
+    Ok(())
+}
+
+/// Listen for any exit signals, and return `Ok(())` when any signal is
+/// received. This can only fail during initialization.
+#[cfg(windows)]
+pub async fn signals() -> anyhow::Result<()> {
+    use tokio::signal::windows::{ctrl_break, ctrl_c, ctrl_close};
+
+    let (mut s1, mut s2, mut s3) = (ctrl_c()?, ctrl_break()?, ctrl_close()?);
+    let futures = vec![s1.recv().boxed(), s2.recv().boxed(), s3.recv().boxed()];
+    future::select_all(futures).await;
+    info!("Received exit signal");
+    Ok(())
+}


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

- Add windows build to release (`x86_64-pc-windows-msvc`)
- Fix Windows build by replacing signal-hook with tokio's signal module
- Enable release builds on PR CI, meaning any error in the build (on any supported platform) will show up on PRs now

Closes #180 

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

- Signal handling is finicky, this could introduce a bug on Unix. Tested quitting via all 4 trapped signals manually
- I haven't actually tested on Windows since I don't have a Windows machine, so it could still be broken at runtime

## QA

_How did you test this?_

Manually ran Slumber and tested that sending it signals killed it

## Checklist

- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
