### PR TITLE
Enable Access of Header Values from a Chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Add option to chain values from response header rather than body ([#184](https://github.com/LucasPickering/slumber/issues/184))
+
 ### Changed
 
 - Reduce UI latency under certain scenarios

--- a/docs/src/api/request_collection/chain_source.md
+++ b/docs/src/api/request_collection/chain_source.md
@@ -38,6 +38,7 @@ Chain a value from the body of another response. This can reference either
 | --------- | ----------------------------------------------- | ----------------------------------------------------------------------------- | -------- |
 | `recipe`  | `string`                                        | Recipe to load value from                                                     | Required |
 | `trigger` | [`ChainRequestTrigger`](#chain-request-trigger) | When the upstream recipe should be executed, as opposed to loaded from memory | `!never` |
+| `section` | [`ChainRequestSection`](#chain-request-section) | The section (header or body) of the request from which to chain a value       | `Body`   |
 
 ### Chain Request Trigger
 
@@ -79,6 +80,24 @@ trigger: !expire 30s
 !request
 recipe: login
 trigger: !always
+```
+
+### Chain Request Section
+
+This defines which section of the response (headers or body) should be used to load the value from.
+
+| Variant      | Type       | Description                                                                                                                  |
+| ------------ | ---------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `body`       | None       | The body of the response                                                                                                     |
+| `header`     | `string`   | A specific header from the response. If the header appears multiple times in the response, only the first value will be used |
+
+
+#### Examples
+
+```yaml
+!request
+recipe: login
+section: !header Token # This will take the value of the 'Token' header
 ```
 
 ### Command

--- a/src/collection/models.rs
+++ b/src/collection/models.rs
@@ -240,6 +240,8 @@ pub enum ChainSource {
         /// When should this request be automatically re-executed?
         #[serde(default)]
         trigger: ChainRequestTrigger,
+        #[serde(default)]
+        section: ChainRequestSection,
     },
     /// Run an external command to get a result
     Command { command: Vec<Template> },
@@ -252,6 +254,16 @@ pub enum ChainSource {
         /// Default value for the shown textbox
         default: Option<Template>,
     },
+}
+
+/// The component of the response to use as the chain source
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[cfg_attr(test, derive(PartialEq))]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub enum ChainRequestSection {
+    #[default]
+    Body,
+    Header(String),
 }
 
 /// Define when a recipe with a chained request should auto-execute the

--- a/src/template.rs
+++ b/src/template.rs
@@ -179,7 +179,10 @@ impl<T> TemplateKey<T> {
 mod tests {
     use super::*;
     use crate::{
-        collection::{Chain, ChainRequestTrigger, ChainSource, RecipeId},
+        collection::{
+            Chain, ChainRequestSection, ChainRequestTrigger, ChainSource,
+            RecipeId,
+        },
         config::Config,
         http::{ContentType, RequestRecord},
         test_util::*,
@@ -305,16 +308,19 @@ mod tests {
     #[rstest]
     #[case::no_selector(
         None,
-        r#"{"array":[1,2],"bool":false,"number":6,"object":{"a":1},"string":"Hello World!"}"#,
+        ChainRequestSection::Body,
+        r#"{"array":[1,2],"bool":false,"number":6,"object":{"a":1},"string":"Hello World!"}"#
     )]
-    #[case::string(Some("$.string"), "Hello World!")]
-    #[case::number(Some("$.number"), "6")]
-    #[case::bool(Some("$.bool"), "false")]
-    #[case::array(Some("$.array"), "[1,2]")]
-    #[case::object(Some("$.object"), "{\"a\":1}")]
+    #[case::string(Some("$.string"), ChainRequestSection::Body, "Hello World!")]
+    #[case::number(Some("$.number"), ChainRequestSection::Body, "6")]
+    #[case::bool(Some("$.bool"), ChainRequestSection::Body, "false")]
+    #[case::array(Some("$.array"), ChainRequestSection::Body, "[1,2]")]
+    #[case::object(Some("$.object"), ChainRequestSection::Body, "{\"a\":1}")]
+    #[case::header(None, ChainRequestSection::Header("Token".into()), "Secret Value")]
     #[tokio::test]
     async fn test_chain_request(
         #[case] selector: Option<&str>,
+        #[case] section: ChainRequestSection,
         #[case] expected_value: &str,
     ) {
         let recipe_id: RecipeId = "recipe1".into();
@@ -326,9 +332,10 @@ mod tests {
             "array": [1,2],
             "object": {"a": 1},
         });
+        let response_headers =
+            header_map(indexmap! {"Token" => "Secret Value"});
         let request = create!(Request, recipe_id: recipe_id.clone());
-        let response =
-            create!(Response, body: response_body.to_string().into());
+        let response = create!(Response, body: response_body.to_string().into(), headers: response_headers);
         database
             .insert_request(&create!(
                 RequestRecord,
@@ -343,6 +350,7 @@ mod tests {
             source: ChainSource::Request {
                 recipe: recipe_id.clone(),
                 trigger: Default::default(),
+                section,
             },
             selector: selector,
             content_type: Some(ContentType::Json),
@@ -376,6 +384,7 @@ mod tests {
             source: ChainSource::Request {
                 recipe: "unknown".into(),
                 trigger: Default::default(),
+                section: Default::default(),
             }
         ),
         None,
@@ -390,6 +399,7 @@ mod tests {
             source: ChainSource::Request {
                 recipe: "recipe1".into(),
                 trigger: Default::default(),
+                section: Default::default(),
             }
         ),
         Some("recipe1"),
@@ -404,6 +414,7 @@ mod tests {
             source: ChainSource::Request {
                 recipe: "recipe1".into(),
                 trigger: ChainRequestTrigger::Always,
+                section: Default::default(),
             }
         ),
         Some("recipe1"),
@@ -418,6 +429,7 @@ mod tests {
             source: ChainSource::Request {
                 recipe: "recipe1".into(),
                 trigger: Default::default(),
+                section: Default::default(),
             },
             selector: Some("$.message".parse().unwrap()),
         ),
@@ -436,6 +448,7 @@ mod tests {
             source: ChainSource::Request {
                 recipe: "recipe1".into(),
                 trigger: Default::default(),
+                section: Default::default(),
             },
             selector: Some("$.message".parse().unwrap()),
             content_type: Some(ContentType::Json),
@@ -455,6 +468,7 @@ mod tests {
             source: ChainSource::Request {
                 recipe: "recipe1".into(),
                 trigger: Default::default(),
+                section:Default::default()
             },
             selector: Some("$.*".parse().unwrap()),
             content_type: Some(ContentType::Json),
@@ -546,6 +560,7 @@ mod tests {
             source: ChainSource::Request {
                 recipe: recipe.id.clone(),
                 trigger,
+                section:Default::default(),
             },
         );
         let http_engine = HttpEngine::new(&Config::default(), database.clone());

--- a/src/template/error.rs
+++ b/src/template/error.rs
@@ -168,6 +168,10 @@ pub enum ChainError {
         #[source]
         error: Box<TemplateError>,
     },
+
+    /// Specified !header did not exist in the response
+    #[error("Header `{header}` not in response")]
+    MissingHeader { header: String },
 }
 
 /// Error occurred while trying to build/execute a triggered request

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -98,6 +98,7 @@ factori!(Chain, {
         source = ChainSource::Request {
             recipe: RecipeId::default(),
             trigger: Default::default(),
+            section: Default::default(),
         },
         sensitive = false,
         selector = None,


### PR DESCRIPTION
Closes https://github.com/LucasPickering/slumber/issues/184#issuecomment-2081204155

This MR adds an additional `component` enum to the chain request variant. This allows users to pull a certain header value and use it in other requests.

Currently this is limited to a _single_ header retrieval

Tested with the following collection:

```yaml
chains:
  auth_token:
    source: !request
      recipe: login
      section: !header Token

requests:
  login: !request
    # This returns headers with {"token": "abc123"} 
    method: POST
    url: "http://localhost:5000/login"
    body: |
      {}

  send_header_token_from_chain: !request
    method: POST
    url: "http://localhost:5000/test"
    body: |
      {}
    headers:
      Token: "{{chains.auth_token}}"

```

## Checklist

- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked

## Current todos:

- [x] Decide on naming for component, is something more specific needed
- [x] Add tests