### PR TITLE
Refactor main TUI loop to reduce latency in handling messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased] - ReleaseDate
+
+### Changed
+
+- Reduce UI latency under certain scenarios
+  - Previously some actions would feel laggy because of an inherent 250ms delay in processing some events
+
+### Fixed
+
+- Fix Slumber going into zombie mode and CPU spiking to 100% under certain closure scenarios ([#136](https://github.com/LucasPickering/slumber/issues/136))
+
 ## [1.0.1] - 2024-04-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,6 +370,7 @@ checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
  "bitflags 2.5.0",
  "crossterm_winapi",
+ "futures-core",
  "libc",
  "mio",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ bytesize = {version = "1.3.0", default-features = false}
 chrono = {version = "^0.4.31", default-features = false, features = ["clock", "serde", "std"]}
 clap = {version = "^4.4.2", features = ["derive"]}
 cli-clipboard = "0.4.0"
-crossterm = "^0.27.0"
+crossterm = {version = "^0.27.0", features = ["event-stream"]}
 derive_more = {version = "1.0.0-beta.6", features = ["debug", "deref", "deref_mut", "display", "from", "from_str"]}
 dialoguer = {version = "^0.11.0", default-features = false, features = ["password"]}
 dirs = "^5.0.1"

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -101,6 +101,22 @@ impl InputEngine {
         // ^^^^^ If making changes, make sure to update the docs ^^^^^
     ]);
 
+    /// Should this event immediately be killed? This means it will never be
+    /// handled by a component. This is used to filter out junk events that we
+    /// don't care about, to prevent clogging up the message queue
+    pub fn should_kill(event: &Event) -> bool {
+        matches!(
+            event,
+            Event::FocusGained
+                | Event::FocusLost
+                | Event::Resize(_, _)
+                | Event::Mouse(MouseEvent {
+                    kind: MouseEventKind::Moved,
+                    ..
+                })
+        )
+    }
+
     pub fn new(user_bindings: IndexMap<Action, InputBinding>) -> Self {
         let mut new = Self::default();
         // User bindings should overwrite any default ones

--- a/src/tui/message.rs
+++ b/src/tui/message.rs
@@ -7,6 +7,7 @@ use crate::{
         RecipeOptions, Request, RequestBuildError, RequestError, RequestRecord,
     },
     template::{Prompt, Prompter, Template, TemplateChunk},
+    tui::input::Action,
     util::ResultExt,
 };
 use anyhow::Context;
@@ -88,6 +89,14 @@ pub enum Message {
     /// recipe ID here because it's in the inner container already. Combining
     /// these two cases saves a bit of boilerplate.
     HttpComplete(Result<RequestRecord, RequestError>),
+
+    /// User input from the terminal
+    Input {
+        /// Raw input event
+        event: crossterm::event::Event,
+        /// Action mapped via input bindings. This is what most consumers use
+        action: Option<Action>,
+    },
 
     /// Show a prompt to the user, asking for some input. Use the included
     /// channel to return the value.

--- a/src/tui/view.rs
+++ b/src/tui/view.rs
@@ -112,12 +112,6 @@ impl View {
     pub fn handle_events(&mut self) {
         // It's possible for components to queue additional events
         while let Some(event) = EventQueue::pop() {
-            // Certain events *just don't matter*, AT ALL. They're not even
-            // supposed to be around, like, in the area
-            if event.should_kill() {
-                continue;
-            }
-
             trace_span!("View event", ?event).in_scope(|| {
                 match Self::update_all(self.root.as_child(), event) {
                     Update::Consumed => {

--- a/src/tui/view/event.rs
+++ b/src/tui/view/event.rs
@@ -12,7 +12,6 @@ use crate::{
         },
     },
 };
-use crossterm::event::{MouseEvent, MouseEventKind};
 use std::{any::Any, cell::RefCell, collections::VecDeque, fmt::Debug};
 use tracing::trace;
 
@@ -155,26 +154,6 @@ impl Event {
 }
 
 impl Event {
-    /// Should this event immediately be killed, meaning it will never be
-    /// handled by a component. This is used to filter out junk events that will
-    /// never be handled, mostly to make debug logging cleaner.
-    pub fn should_kill(&self) -> bool {
-        use crossterm::event::Event;
-        matches!(
-            self,
-            Self::Input {
-                event: Event::FocusGained
-                    | Event::FocusLost
-                    | Event::Resize(_, _)
-                    | Event::Mouse(MouseEvent {
-                        kind: MouseEventKind::Moved,
-                        ..
-                    }),
-                ..
-            }
-        )
-    }
-
     /// Is this event pertinent to the component? Most events should be handled,
     /// but some (e.g. cursor events) need to be selectively filtered
     pub fn should_handle<T>(&self, component: &Component<T>) -> bool {


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Previously, the main loop was rate-limited by the terminal input poll() call. This means when no user input was present, it would block for 250ms before handling any async messages. This could cause some annoying UI delays for changes triggered by background IO (e.g. HTTP responses could take up to 250ms *extra* to appear). By breaking the input loop into a separate task, and having the main loop block directly on the message queue, we ensure that every message is handled immediately and we update the UI immediately.

I measured CPU usage on this, and it's the same as master. Locally I see ~5% usage whlie running in debug and ~0.7% while running with --release. This makes sense because the CPU is doing all the same work, just rearranged slightly.

This has the added benefit that it accidentally fixed #136, which is great because I really didn't want to debug that anymore.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Both high and low. This is the main loop so obviously if something is wrong it would be very bad, but that means it's very easy to check if it's working. Basic TUI functionality (accepting input, sending requests) works so I'm confident the loop is doing it's thing. I never fully understood the 100% CPU bug so there's a risk it still exists in some form, but I wasn't able to reproduce it anymore.

## QA

_How did you test this?_

Run some requests in the TUI, measure CPU usage. To test the fixed bug, I ran `cargo run` from inside a `zellij` session, then quit zellij as a whole (with ctrl-q) and watched the Slumber process die. The exact same steps previously would leave the Slumber process behind and it would spike to 100% CPU usage.

## Checklist

- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
