### PR TITLE
Add parent-directory lookup for collection files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+ - Add support for detection of collection files ie `slumber.yml` in parent directories
+
 ### Changed
 
 - Reduce UI latency under certain scenarios

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,8 @@ struct Args {
 #[derive(Debug, Parser)]
 struct GlobalArgs {
     /// Collection file, which defines profiles, recipes, etc. If omitted,
-    /// check the current directory for the following files (in this order):
+    /// check the current directory and all parent directories for the
+    /// following files (in this order):
     /// slumber.yml, slumber.yaml, .slumber.yml, .slumber.yaml
     #[clap(long, short)]
     file: Option<PathBuf>,

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -95,7 +95,7 @@ impl Tui {
         // `Tui`.
         let terminal = initialize_terminal()?;
 
-        let app = Tui {
+        let mut app = Tui {
             terminal,
             messages_rx,
 
@@ -104,6 +104,11 @@ impl Tui {
 
             view: Replaceable::new(view),
         };
+
+        app.view.notify(format!(
+            "Loaded collection from {}",
+            app.collection_file.path().to_string_lossy()
+        ));
 
         app.run().await
     }


### PR DESCRIPTION
## Description

Addresses the feature request described in [this issue](https://github.com/LucasPickering/slumber/issues/194): improves the discovery mechanism for the `slumber.yaml` collection file.

## Known Risks

No known risks.

## QA

### Test Case 1: Existing Behavior Unchanged (`slumber.yml` Exists)
From within a directory containing a `slumber.yml` file, issue the command `slumber`, with no arguments. Observe that slumber loads the collection file from the current directory. 

### Test Case 2: Existing Behavior Unchanged (`slumber.yml` Does Not Exist)
From within a directory which does not contain a collection file, and for where there is no parent directory that contains a collection file, issue the command `slumber`, with no arguments. Observe that slumber fails to start and prints an error message claiming that no collection file was found.

### Test Case 3: `slumber.yml` Detected In Parent Directory
From within a directory containing a `slumber.yml` file, navigate into any directory within the current directory. Issue the command `slumber`, with no arguments. Observe that slumber loads the collection file from the parent directory.

### Test Case 4: slumber Uses The First Detected Collection File
From within a directory which contains no `slumber.yml` file, but whose parent directories at two or more differing levels in the heirarchy each contain a `slumber.yml` file, issue the command `slumber`, with no arguments, and observe that slumber chooses the file which is nearest and above the current directory in the heirarchy.
Example: 
- pwd `/a/b/c` contains no collection files.
- file `a/b/slumber.yml` exists
- file `a/slumber.yml` exists
From within `/a/b/c/`, issue the command `slumber`, with no arguments, and observe that the chosen collection file is `a/b/slumber.yml`

## Checklist

- [X] Have you read `CONTRIBUTING.md` already?
- [X] Did you update `CHANGELOG.md`?