### PR TITLE
Add trim options to !command chain

### DIFF
--- a/docs/src/api/request_collection/chain.md
+++ b/docs/src/api/request_collection/chain.md
@@ -12,8 +12,20 @@ To use a chain in a template, reference it as `{{chains.<id>}}`.
 | `sensitive`    | `boolean`                                                                              | Should the value be hidden in the UI?                                                                                                  | `false`  |
 | `selector`     | [`JSONPath`](https://www.ietf.org/archive/id/draft-goessner-dispatch-jsonpath-00.html) | Selector to transform/narrow down results in a chained value. See [Filtering & Querying](../../user_guide/filter_query.md)             | `null`   |
 | `content_type` | [`ContentType`](./content_type.md)                                                     | Force content type. Not required for `request` and `file` chains, as long as the `Content-Type` header/file extension matches the data |          |
+| `trim`         | [`ChainOutputTrim`](#chain-output-trim)                                                | Trim whitespace from the rendered output                                                                                               | `none`   |
 
 See the [`ChainSource`](./chain_source.md) docs for detail on the different types of chainable values.
+
+## Chain Output Trim
+
+This defines how leading/trailing whitespace should be trimmed from the resolved output of a chain.
+
+| Variant | Description                               |
+| ------- | ----------------------------------------- |
+| `none`  | Do not modify the resolved string         |
+| `start` | Trim from just the start of the string    |
+| `end`   | Trim from just the end of the string      |
+| `both`  | Trim from the start and end of the string |
 
 ## Examples
 
@@ -35,4 +47,10 @@ auth_token:
   source: !request
     recipe: login
   selector: $.token
+---
+# Use the output of an external command
+username:
+  source: !command
+    command: [whoami]
+    trim: both # Shell commands often include an unwanted trailing newline
 ```

--- a/docs/src/api/request_collection/chain_source.md
+++ b/docs/src/api/request_collection/chain_source.md
@@ -40,7 +40,7 @@ Chain a value from the body of another response. This can reference either
 | `trigger` | [`ChainRequestTrigger`](#chain-request-trigger) | When the upstream recipe should be executed, as opposed to loaded from memory | `!never` |
 | `section` | [`ChainRequestSection`](#chain-request-section) | The section (header or body) of the request from which to chain a value       | `Body`   |
 
-### Chain Request Trigger
+#### Chain Request Trigger
 
 This defines when a chained request should be triggered (i.e. when to execute a new request) versus when to use the most recent from history.
 
@@ -86,11 +86,10 @@ trigger: !always
 
 This defines which section of the response (headers or body) should be used to load the value from.
 
-| Variant      | Type       | Description                                                                                                                  |
-| ------------ | ---------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `body`       | None       | The body of the response                                                                                                     |
-| `header`     | `string`   | A specific header from the response. If the header appears multiple times in the response, only the first value will be used |
-
+| Variant  | Type     | Description                                                                                                                  |
+| -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `body`   | None     | The body of the response                                                                                                     |
+| `header` | `string` | A specific header from the response. If the header appears multiple times in the response, only the first value will be used |
 
 #### Examples
 

--- a/slumber.yml
+++ b/slumber.yml
@@ -18,7 +18,8 @@ profiles:
 chains:
   username:
     source: !command
-      command: ["sh", "-c", "whoami | tr -d '\n'"]
+      command: [whoami]
+    trim: both
   password:
     source: !prompt
       message: Password

--- a/src/collection/models.rs
+++ b/src/collection/models.rs
@@ -191,6 +191,8 @@ pub struct Chain {
     /// response (e.g. a file) **or** if the response's `Content-Type` header
     /// is incorrect.
     pub content_type: Option<ContentType>,
+    #[serde(default)]
+    pub trim: ChainOutputTrim,
 }
 
 /// Unique ID for a chain. Takes a generic param so we can create these during
@@ -287,6 +289,22 @@ pub enum ChainRequestTrigger {
     Expire(#[serde(with = "cereal::serde_duration")] Duration),
     /// Trigger the request every time the dependent request is rendered
     Always,
+}
+
+/// Trim whitespace from rendered output
+#[derive(Copy, Clone, Debug, Default, Serialize, Deserialize)]
+#[cfg_attr(test, derive(PartialEq))]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub enum ChainOutputTrim {
+    /// Do not trim the output
+    #[default]
+    None,
+    /// Trim the start of the output
+    Start,
+    /// Trim the end of the output
+    End,
+    /// Trim the start and end of the output
+    Both,
 }
 
 impl Profile {

--- a/src/template/render.rs
+++ b/src/template/render.rs
@@ -2,8 +2,8 @@
 
 use crate::{
     collection::{
-        ChainId, ChainRequestSection, ChainRequestTrigger, ChainSource,
-        RecipeId,
+        ChainId, ChainOutputTrim, ChainRequestSection, ChainRequestTrigger,
+        ChainSource, RecipeId,
     },
     http::{ContentType, RequestBuilder, RequestRecord, Response},
     template::{
@@ -326,7 +326,7 @@ impl<'a> TemplateSource<'a> for ChainTemplateSource<'a> {
             };
 
             Ok(RenderedChunk {
-                value,
+                value: chain.trim.apply(value),
                 sensitive: chain.sensitive,
             })
         }
@@ -632,5 +632,17 @@ impl<'a> TemplateSource<'a> for EnvironmentTemplateSource<'a> {
             value,
             sensitive: false,
         })
+    }
+}
+
+impl ChainOutputTrim {
+    /// Apply whitespace trimming
+    fn apply(self, value: String) -> String {
+        match self {
+            Self::None => value,
+            Self::Start => value.trim_start().into(),
+            Self::End => value.trim_end().into(),
+            Self::Both => value.trim().into(),
+        }
     }
 }

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,7 +1,7 @@
 use crate::{
     collection::{
-        Chain, ChainSource, Collection, Folder, Profile, ProfileId, Recipe,
-        RecipeId, RecipeNode, RecipeTree,
+        Chain, ChainOutputTrim, ChainSource, Collection, Folder, Profile,
+        ProfileId, Recipe, RecipeId, RecipeNode, RecipeTree,
     },
     config::Config,
     db::CollectionDatabase,
@@ -116,6 +116,7 @@ factori!(Chain, {
         sensitive = false,
         selector = None,
         content_type = None,
+        trim = ChainOutputTrim::default(),
     }
 });
 


### PR DESCRIPTION
Closes #153  by adding trim options to the !command chain type.

## QA

Tests added and QAed with simple chain:
```yaml

chains:
  auth_token:
    source: !command
      command: ["sh", -c, "echo 'hi'"]
      trim: start
```

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
