### PR TITLE
Add stdin option to command chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Add action to save response body to file ([#183](https://github.com/LucasPickering/slumber/issues/183))
 - Add `theme` field to the config, to configure colors ([#193](https://github.com/LucasPickering/slumber/issues/193))
   - [See docs](https://slumber.lucaspickering.me/book/api/configuration/theme.html) for more info
+- Add `stdin` option to command chains ([#190](https://github.com/LucasPickering/slumber/issues/190))
 
 ### Changed
 

--- a/docs/src/api/request_collection/chain_source.md
+++ b/docs/src/api/request_collection/chain_source.md
@@ -107,6 +107,7 @@ Execute a command and use its stdout as the rendered value.
 | Field     | Type         | Description                                                 | Default  |
 | --------- | ------------ | ----------------------------------------------------------- | -------- |
 | `command` | `Template[]` | Command to execute, in the format `[program, ...arguments]` | Required |
+| `stdin`   | `Template`   | Standard input which will be piped into the command         | None     |
 
 ### File
 

--- a/docs/src/user_guide/chains.md
+++ b/docs/src/user_guide/chains.md
@@ -99,7 +99,8 @@ chains:
       recipe: login
   auth_token:
     source: !command
-      command: [sh, -c, "echo '{{chains.auth_token_raw}}' | cut -d':' -f2"]
+      command: [ "cut", "-d':'", "-f2" ]
+      stdin: "{{chains.auth_token_raw}}"
 
 requests:
   login: !request

--- a/docs/src/user_guide/filter_query.md
+++ b/docs/src/user_guide/filter_query.md
@@ -77,7 +77,8 @@ chains:
       recipe: login
   auth_token:
     source: !command
-      command: [sh, -c, "echo '{{chains.auth_token_raw}}' | jq .token"]
+      command: [ "jq", ".token" ]
+      stdin: "{{chains.auth_token_raw}}
 
 requests:
   login: !request

--- a/src/collection/models.rs
+++ b/src/collection/models.rs
@@ -244,7 +244,10 @@ pub enum ChainSource {
         section: ChainRequestSection,
     },
     /// Run an external command to get a result
-    Command { command: Vec<Template> },
+    Command {
+        command: Vec<Template>,
+        stdin: Option<Template>,
+    },
     /// Load data from a file
     File { path: Template },
     /// Prompt the user for a value

--- a/src/template/render.rs
+++ b/src/template/render.rs
@@ -19,9 +19,10 @@ use futures::future;
 use std::{
     env,
     path::PathBuf,
+    process::Stdio,
     sync::{atomic::Ordering, Arc},
 };
-use tokio::{fs, process::Command, sync::oneshot};
+use tokio::{fs, io::AsyncWriteExt, process::Command, sync::oneshot};
 use tracing::{debug, debug_span, instrument, trace};
 
 /// Outcome of rendering a single chunk. This allows attaching some metadata to
@@ -284,9 +285,13 @@ impl<'a> TemplateSource<'a> for ChainTemplateSource<'a> {
                 ChainSource::File { path } => {
                     self.render_file(context, path).await?
                 }
-                ChainSource::Command { command } => {
+                ChainSource::Command { command, stdin } => {
                     // No way to guess content type on this
-                    (self.render_command(context, command).await?, None)
+                    (
+                        self.render_command(context, command, stdin.as_ref())
+                            .await?,
+                        None,
+                    )
                 }
                 ChainSource::Prompt { message, default } => (
                     self.render_prompt(
@@ -484,6 +489,7 @@ impl<'a> ChainTemplateSource<'a> {
         &self,
         context: &TemplateContext,
         command: &[Template],
+        stdin: Option<&Template>,
     ) -> Result<Vec<u8>, ChainError> {
         // Render each arg in the command
         let command = future::try_join_all(command.iter().enumerate().map(
@@ -501,26 +507,69 @@ impl<'a> ChainTemplateSource<'a> {
         let [program, args @ ..] = command.as_slice() else {
             return Err(ChainError::CommandMissing);
         };
-        debug_span!("Executing command", ?command)
-            .in_scope(|| async {
-                let output = Command::new(program)
-                    .args(args)
-                    .output()
-                    .await
-                    .map_err(|error| ChainError::Command {
-                        command: command.to_owned(),
-                        error,
-                    })
-                    .traced()?;
 
-                debug!(
-                    stdout = %String::from_utf8_lossy(&output.stdout),
-                    stderr = %String::from_utf8_lossy(&output.stderr),
-                    "Command success"
-                );
-                Ok(output.stdout)
+        let _ = debug_span!("Executing command", ?command).entered();
+
+        // Render the stdin template, if present
+        let input = if let Some(template) = stdin {
+            let input =
+                template.render_stitched(context).await.map_err(|error| {
+                    ChainError::Nested {
+                        field: "stdin".into(),
+                        error: error.into(),
+                    }
+                })?;
+
+            Some(input)
+        } else {
+            None
+        };
+
+        // Spawn the command process
+        let mut process = Command::new(program)
+            .args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|error| ChainError::Command {
+                command: command.to_owned(),
+                error,
             })
+            .traced()?;
+
+        // Write the stdin to the process
+        if let Some(input) = input {
+            process
+                .stdin
+                .as_mut()
+                .expect("Process missing stdin")
+                .write_all(input.as_bytes())
+                .await
+                .map_err(|error| ChainError::Command {
+                    command: command.to_owned(),
+                    error,
+                })
+                .traced()?;
+        }
+
+        // Wait for the process to finish
+        let output = process
+            .wait_with_output()
             .await
+            .map_err(|error| ChainError::Command {
+                command: command.to_owned(),
+                error,
+            })
+            .traced()?;
+
+        debug!(
+            stdout = %String::from_utf8_lossy(&output.stdout),
+            stderr = %String::from_utf8_lossy(&output.stderr),
+            "Command success"
+        );
+
+        Ok(output.stdout)
     }
 
     /// Render a value by asking the user to provide it


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Added ```stdin``` field on the !command variant. Stdin is now piped into command using ```ChildStdin```. It is still compatible with previous command variant.

Closes  #190

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Calling command may be unsafe, but I don't think it carries any new threat.

## QA

_How did you test this?_

Added one unit test. Probably need to add more.

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
