### PR TITLE
Use double border for selected panes and modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Reduce UI latency under certain scenarios
   - Previously some actions would feel laggy because of an inherent 250ms delay in processing some events
 - Search parent directories for collection file ([#194](https://github.com/LucasPickering/slumber/issues/194))
+- Use thicker borders for selected pane and modals
 
 ### Fixed
 

--- a/src/tui/view/common.rs
+++ b/src/tui/view/common.rs
@@ -25,7 +25,7 @@ use chrono::{DateTime, Duration, Local, Utc};
 use itertools::Itertools;
 use ratatui::{
     text::{Span, Text},
-    widgets::Borders,
+    widgets::{Block, Borders},
 };
 use reqwest::header::HeaderValue;
 
@@ -36,17 +36,18 @@ pub struct Pane<'a> {
 }
 
 impl<'a> Generate for Pane<'a> {
-    type Output<'this> = ratatui::widgets::Block<'this> where Self: 'this;
+    type Output<'this> = Block<'this> where Self: 'this;
 
     fn generate<'this>(self) -> Self::Output<'this>
     where
         Self: 'this,
     {
-        ratatui::widgets::Block::default()
+        let (border_type, border_style) =
+            TuiContext::get().theme.pane.border(self.is_focused);
+        Block::default()
             .borders(Borders::ALL)
-            .border_style(
-                TuiContext::get().theme.pane.border_style(self.is_focused),
-            )
+            .border_type(border_type)
+            .border_style(border_style)
             .title(self.title)
     }
 }

--- a/src/tui/view/common/modal.rs
+++ b/src/tui/view/common/modal.rs
@@ -1,4 +1,5 @@
 use crate::tui::{
+    context::TuiContext,
     input::Action,
     message::MessageSender,
     view::{
@@ -10,7 +11,7 @@ use crate::tui::{
 };
 use ratatui::{
     prelude::{Constraint, Rect},
-    widgets::{Block, BorderType, Borders, Clear},
+    widgets::{Block, Borders, Clear},
     Frame,
 };
 use std::{collections::VecDeque, ops::DerefMut};
@@ -135,6 +136,7 @@ impl EventHandler for ModalQueue {
 impl Draw for ModalQueue {
     fn draw(&self, frame: &mut Frame, _: (), area: Rect) {
         if let Some(modal) = self.queue.front() {
+            let theme = &TuiContext::get().theme;
             let (width, height) = modal.dimensions();
 
             // The child gave us the content dimensions, we need to add one cell
@@ -148,7 +150,8 @@ impl Draw for ModalQueue {
             let block = Block::default()
                 .title(modal.title())
                 .borders(Borders::ALL)
-                .border_type(BorderType::Thick);
+                .border_style(theme.modal.border)
+                .border_type(theme.modal.border_type);
             let inner_area = block.inner(area);
 
             // Draw the outline of the modal

--- a/src/tui/view/theme.rs
+++ b/src/tui/view/theme.rs
@@ -1,11 +1,15 @@
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::{
+    style::{Color, Modifier, Style},
+    widgets::BorderType,
+};
 
 /// Configurable visual settings for the UI. Styles are grouped into sub-structs
 /// generally by component.
 #[derive(Debug)]
 pub struct Theme {
-    pub pane: ThemePane,
     pub list: ThemeList,
+    pub modal: ThemeModal,
+    pub pane: ThemePane,
     pub tab: ThemeTab,
     pub table: ThemeTable,
     pub template_preview: ThemeTemplatePreview,
@@ -28,6 +32,13 @@ pub struct ThemeList {
     pub highlight: Style,
 }
 
+/// Styles for the Modal component
+#[derive(Debug)]
+pub struct ThemeModal {
+    pub border: Style,
+    pub border_type: BorderType,
+}
+
 /// Styles for Pane component
 #[derive(Debug)]
 pub struct ThemePane {
@@ -35,6 +46,10 @@ pub struct ThemePane {
     pub border: Style,
     /// Pane border when selected/focused
     pub border_selected: Style,
+    /// Pane border characters used when not selected/focused
+    pub border_type: BorderType,
+    /// Pane border characters used when selected/focused
+    pub border_type_selected: BorderType,
 }
 
 /// Styles for Tab component
@@ -89,17 +104,23 @@ pub struct ThemeTextWindow {
 impl Default for Theme {
     fn default() -> Self {
         Self {
-            pane: ThemePane {
-                border: Style::default(),
-                border_selected: Style::default()
-                    .fg(Self::PRIMARY_COLOR)
-                    .add_modifier(Modifier::BOLD),
-            },
             list: ThemeList {
                 highlight: Style::default()
                     .bg(Self::PRIMARY_COLOR)
                     .fg(Color::Black)
                     .add_modifier(Modifier::BOLD),
+            },
+            modal: ThemeModal {
+                border: Style::default().fg(Self::PRIMARY_COLOR),
+                border_type: BorderType::Double,
+            },
+            pane: ThemePane {
+                border: Style::default(),
+                border_selected: Style::default()
+                    .fg(Self::PRIMARY_COLOR)
+                    .add_modifier(Modifier::BOLD),
+                border_type: BorderType::Plain,
+                border_type_selected: BorderType::Double,
             },
             tab: ThemeTab {
                 highlight: Style::default()
@@ -144,11 +165,12 @@ impl Default for Theme {
 }
 
 impl ThemePane {
-    pub fn border_style(&self, is_focused: bool) -> Style {
+    /// Get the type and style of the border for a pane
+    pub fn border(&self, is_focused: bool) -> (BorderType, Style) {
         if is_focused {
-            self.border_selected
+            (self.border_type_selected, self.border_selected)
         } else {
-            self.border
+            (self.border_type, self.border)
         }
     }
 }


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Use thicker borders for selected panes and modals, to make them stand out more. I played around with adding a margin to the modal too but it felt weird.

![image](https://github.com/LucasPickering/slumber/assets/2382935/de21b9bf-18a8-4f52-bde8-e8bbf8b3e1cd)

![image](https://github.com/LucasPickering/slumber/assets/2382935/a30d5d22-f92a-4094-852a-ce4bccab31fd)

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

People hate it?

## QA

_How did you test this?_

Ran TUI manually

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
