### PR TITLE
Fix missing preloaded request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - Fix Slumber going into zombie mode and CPU spiking to 100% under certain closure scenarios ([#136](https://github.com/LucasPickering/slumber/issues/136))
+- Fix historical request/response no loading on first render ([#199](https://github.com/LucasPickering/slumber/issues/199))
 
 ## [1.0.1] - 2024-04-27
 

--- a/src/tui/view/common/actions.rs
+++ b/src/tui/view/common/actions.rs
@@ -39,7 +39,10 @@ impl<T: FixedSelect> Default for ActionsModal<T> {
         };
 
         Self {
-            actions: FixedSelectState::new().on_submit(wrapper).into(),
+            actions: FixedSelectState::builder()
+                .on_submit(wrapper)
+                .build()
+                .into(),
         }
     }
 }

--- a/src/tui/view/component/profile_list.rs
+++ b/src/tui/view/component/profile_list.rs
@@ -42,7 +42,7 @@ impl ProfileListPane {
         Self {
             profiles: Persistent::new(
                 PersistentKey::ProfileId,
-                SelectState::new(profiles).on_select(on_select),
+                SelectState::builder(profiles).on_select(on_select).build(),
             )
             .into(),
         }

--- a/src/tui/view/component/recipe_list.rs
+++ b/src/tui/view/component/recipe_list.rs
@@ -275,5 +275,5 @@ fn build_select_state(
         .filter(|(lookup_key, _)| collapsed.is_visible(lookup_key))
         .map(|(_, node)| node.clone())
         .collect();
-    SelectState::new(items).on_select(on_select)
+    SelectState::builder(items).on_select(on_select).build()
 }

--- a/src/tui/view/component/recipe_pane.rs
+++ b/src/tui/view/component/recipe_pane.rs
@@ -353,12 +353,16 @@ impl RecipeState {
             ),
             query: Persistent::new(
                 PersistentKey::RecipeSelectedQuery(recipe.id.clone()),
-                SelectState::new(query_items).on_submit(RowState::on_submit),
+                SelectState::builder(query_items)
+                    .on_submit(RowState::on_submit)
+                    .build(),
             )
             .into(),
             headers: Persistent::new(
                 PersistentKey::RecipeSelectedHeader(recipe.id.clone()),
-                SelectState::new(header_items).on_submit(RowState::on_submit),
+                SelectState::builder(header_items)
+                    .on_submit(RowState::on_submit)
+                    .build(),
             )
             .into(),
             body: recipe.body.as_ref().map(|body| {


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Fix the latest request/response not showing up when the app is first started, or after a collection reload. This was only happening if the first recipe in the list was selected (index 0). The problem was we weren't calling on_select when the default value (0) was selected. When it was loaded from the DB it still wasn't pre-selected because it detected no change.

Fixed by adding a builder pattern so we can define on_select then call select_index in the constructor.

Closes #199

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

## QA

_How did you test this?_

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
