### PR TITLE
feat: make primary and error color configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Add option to chain values from response header rather than body ([#184](https://github.com/LucasPickering/slumber/issues/184))
 - Add action to save response body to file ([#183](https://github.com/LucasPickering/slumber/issues/183))
+- Add option to customize TUI theme ([#193](https://github.com/LucasPickering/slumber/issues/193))
 
 ### Changed
 

--- a/docs/src/api/configuration/index.md
+++ b/docs/src/api/configuration/index.md
@@ -21,8 +21,9 @@ If the root directory doesn't exist yet, you can create it yourself or have Slum
 
 ## Fields
 
-| Field                      | Type                                | Description                                                                                       | Default |
-| -------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------- | ------- |
-| `preview_templates`        | `boolean`                           | Render template values in the TUI? If false, the raw template will be shown.                      | `true`  |
-| `ignore_certificate_hosts` | `string[]`                          | Hostnames whose TLS certificate errors will be ignored. [More info](../../troubleshooting/tls.md) | `[]`    |
-| `input_bindings`           | `mapping[Action, KeyCombination[]]` | Override default input bindings. [More info](./input_bindings.md)                                 | `{}`    |
+| Field                      | Type                                | Description                                                                                                     | Default                                              |
+| -------------------------- | ----------------------------------- | --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `preview_templates`        | `boolean`                           | Render template values in the TUI? If false, the raw template will be shown.                                    | `true`                                               |
+| `ignore_certificate_hosts` | `string[]`                          | Hostnames whose TLS certificate errors will be ignored. [More info](../../troubleshooting/tls.md)               | `[]`                                                 |
+| `input_bindings`           | `mapping[Action, KeyCombination[]]` | Override default input bindings. [More info](./input_bindings.md)                                               | `{}`                                                 |
+| `theme`                    | `mapping[ThemeElement, Color]`      | Set color theme. Currently supports `primary_color` and `error_color`. Values can be CSS color codes or strings | `{ primary_color: "LightGreen", error_color: "Red" }`|

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use crate::{
     tui::input::{Action, InputBinding},
+    tui::view::Theme,
     util::{
         parse_yaml,
         paths::{DataDirectory, FileGuard},
@@ -28,6 +29,9 @@ pub struct Config {
 
     /// Overrides for default key bindings
     pub input_bindings: IndexMap<Action, InputBinding>,
+
+    /// Set colors of the TUI
+    pub theme: Theme,
 }
 
 impl Config {
@@ -70,6 +74,7 @@ impl Default for Config {
             ignore_certificate_hosts: Vec::new(),
             preview_templates: true,
             input_bindings: IndexMap::default(),
+            theme: Theme::default(),
         }
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2,7 +2,7 @@ pub mod context;
 pub mod input;
 pub mod message;
 mod util;
-mod view;
+pub mod view;
 
 use crate::{
     collection::{Collection, CollectionFile, ProfileId, RecipeId},

--- a/src/tui/context.rs
+++ b/src/tui/context.rs
@@ -2,7 +2,7 @@ use crate::{
     config::Config,
     db::CollectionDatabase,
     http::HttpEngine,
-    tui::{input::InputEngine, view::Theme},
+    tui::{input::InputEngine, view::Styles},
 };
 use std::sync::OnceLock;
 
@@ -23,7 +23,7 @@ pub struct TuiContext {
     /// App-level configuration
     pub config: Config,
     /// Visual theme. Colors!
-    pub theme: Theme,
+    pub styles: Styles,
     /// Input:action bindings
     pub input_engine: InputEngine,
     /// For sending HTTP requests
@@ -38,10 +38,11 @@ impl TuiContext {
     pub fn init(config: Config, database: CollectionDatabase) {
         let input_engine = InputEngine::new(config.input_bindings.clone());
         let http_engine = HttpEngine::new(&config, database.clone());
+        let styles = Styles::from_theme(&config.theme);
         CONTEXT
             .set(Self {
                 config,
-                theme: Theme::default(),
+                styles,
                 input_engine,
                 http_engine,
                 database,

--- a/src/tui/view.rs
+++ b/src/tui/view.rs
@@ -8,6 +8,7 @@ mod util;
 
 pub use common::modal::{IntoModal, ModalPriority};
 pub use state::RequestState;
+pub use theme::Styles;
 pub use theme::Theme;
 pub use util::{Confirm, PreviewPrompter};
 

--- a/src/tui/view/common.rs
+++ b/src/tui/view/common.rs
@@ -43,7 +43,7 @@ impl<'a> Generate for Pane<'a> {
         Self: 'this,
     {
         let (border_type, border_style) =
-            TuiContext::get().theme.pane.border(self.is_focused);
+            TuiContext::get().styles.pane.border(self.is_focused);
         Block::default()
             .borders(Borders::ALL)
             .border_type(border_type)

--- a/src/tui/view/common/button.rs
+++ b/src/tui/view/common/button.rs
@@ -33,11 +33,11 @@ impl<'a> Generate for Button<'a> {
     where
         Self: 'this,
     {
-        let theme = &TuiContext::get().theme;
+        let styles = &TuiContext::get().styles;
         Span {
             content: self.text.into(),
             style: if self.is_focused {
-                theme.text.highlight
+                styles.text.highlight
             } else {
                 Default::default()
             },

--- a/src/tui/view/common/list.rs
+++ b/src/tui/view/common/list.rs
@@ -33,6 +33,6 @@ where
 
         ratatui::widgets::List::new(items)
             .block(block)
-            .highlight_style(TuiContext::get().theme.list.highlight)
+            .highlight_style(TuiContext::get().styles.list.highlight)
     }
 }

--- a/src/tui/view/common/modal.rs
+++ b/src/tui/view/common/modal.rs
@@ -136,7 +136,7 @@ impl EventHandler for ModalQueue {
 impl Draw for ModalQueue {
     fn draw(&self, frame: &mut Frame, _: (), area: Rect) {
         if let Some(modal) = self.queue.front() {
-            let theme = &TuiContext::get().theme;
+            let theme = &TuiContext::get().styles;
             let (width, height) = modal.dimensions();
 
             // The child gave us the content dimensions, we need to add one cell

--- a/src/tui/view/common/table.rs
+++ b/src/tui/view/common/table.rs
@@ -75,30 +75,32 @@ impl<'a, const COLS: usize> Generate for Table<'a, COLS, Row<'a>> {
     where
         Self: 'this,
     {
-        let theme = &TuiContext::get().theme;
+        let styles = &TuiContext::get().styles;
         let rows = self.rows.into_iter().enumerate().map(|(i, row)| {
             // Apply theme styles, but let the row's individual styles override
             let base_style = if self.alternate_row_style && i % 2 == 1 {
-                theme.table.alt
+                styles.table.alt
             } else {
-                theme.table.text
+                styles.table.text
             };
             let row_style = Styled::style(&row);
             row.set_style(base_style.patch(row_style))
         });
         let mut table = ratatui::widgets::Table::new(rows, self.column_widths)
-            .highlight_style(theme.table.highlight);
+            .highlight_style(styles.table.highlight);
 
         // Add title
         if let Some(title) = self.title {
             table = table.block(
-                Block::default().title(title).title_style(theme.table.title),
+                Block::default()
+                    .title(title)
+                    .title_style(styles.table.title),
             );
         }
 
         // Add optional header if given
         if let Some(header) = self.header {
-            table = table.header(Row::new(header).style(theme.table.header));
+            table = table.header(Row::new(header).style(styles.table.header));
         }
 
         table
@@ -139,7 +141,7 @@ where
     where
         Self: 'this,
     {
-        let theme = &TuiContext::get().theme;
+        let styles = &TuiContext::get().styles;
         // Include the given cells, then tack on the checkbox for enabled state
         Row::new(
             iter::once(
@@ -152,9 +154,9 @@ where
             .chain(self.cells.into_iter().map(Cell::from)),
         )
         .style(if self.enabled {
-            theme.table.text
+            styles.table.text
         } else {
-            theme.table.disabled
+            styles.table.disabled
         })
     }
 }

--- a/src/tui/view/common/tabs.rs
+++ b/src/tui/view/common/tabs.rs
@@ -63,7 +63,7 @@ where
         frame.render_widget(
             ratatui::widgets::Tabs::new(T::iter().map(|e| e.to_string()))
                 .select(self.tabs.selected_index())
-                .highlight_style(TuiContext::get().theme.tab.highlight),
+                .highlight_style(TuiContext::get().styles.tab.highlight),
             area,
         )
     }

--- a/src/tui/view/common/template_preview.rs
+++ b/src/tui/view/common/template_preview.rs
@@ -110,7 +110,7 @@ impl<'a> TextStitcher<'a> {
         template: &'a Template,
         chunks: &'a [TemplateChunk],
     ) -> Text<'a> {
-        let theme = &TuiContext::get().theme;
+        let styles = &TuiContext::get().styles;
 
         // Each chunk will get its own styling, but we can't just make each
         // chunk a Span, because one chunk might have multiple lines. And we
@@ -122,8 +122,8 @@ impl<'a> TextStitcher<'a> {
             let chunk_text = Self::get_chunk_text(template, chunk);
             let style = match &chunk {
                 TemplateChunk::Raw(_) => Style::default(),
-                TemplateChunk::Rendered { .. } => theme.template_preview.text,
-                TemplateChunk::Error(_) => theme.template_preview.error,
+                TemplateChunk::Rendered { .. } => styles.template_preview.text,
+                TemplateChunk::Error(_) => styles.template_preview.error,
             };
 
             stitcher.add_chunk(chunk_text, style);

--- a/src/tui/view/common/text_box.rs
+++ b/src/tui/view/common/text_box.rs
@@ -215,12 +215,12 @@ impl EventHandler for TextBox {
 
 impl Draw for TextBox {
     fn draw(&self, frame: &mut Frame, _: (), area: Rect) {
-        let theme = &TuiContext::get().theme;
+        let styles = &TuiContext::get().styles;
 
         // Hide top secret data
         let text: Text = if self.state.text.is_empty() {
             Line::from(self.placeholder_text.as_str())
-                .style(theme.text_box.placeholder)
+                .style(styles.text_box.placeholder)
                 .into()
         } else if self.sensitive {
             Masked::new(&self.state.text, '•').into()
@@ -230,9 +230,9 @@ impl Draw for TextBox {
 
         // Draw the text
         let style = if self.is_valid() {
-            theme.text_box.text
+            styles.text_box.text
         } else {
-            theme.text_box.invalid
+            styles.text_box.invalid
         };
         frame.render_widget(Paragraph::new(text).style(style), area);
 
@@ -246,7 +246,7 @@ impl Draw for TextBox {
             };
             frame
                 .buffer_mut()
-                .set_style(cursor_area, theme.text_box.cursor);
+                .set_style(cursor_area, styles.text_box.cursor);
         }
     }
 }

--- a/src/tui/view/common/text_window.rs
+++ b/src/tui/view/common/text_window.rs
@@ -117,7 +117,7 @@ where
     for<'a> &'a T: Generate<Output<'a> = Text<'a>>,
 {
     fn draw(&self, frame: &mut Frame, _: (), area: Rect) {
-        let theme = &TuiContext::get().theme;
+        let styles = &TuiContext::get().styles;
         let text = Paragraph::new(self.text.generate());
         // Assume no line wrapping when calculating line count
         let text_height = text.line_count(u16::MAX) as u16;
@@ -146,7 +146,7 @@ where
                     .collect::<Vec<Line>>(),
             )
             .alignment(Alignment::Right)
-            .style(theme.text_window.line_number),
+            .style(styles.text_window.line_number),
             gutter_area,
         );
 

--- a/src/tui/view/component/help.rs
+++ b/src/tui/view/component/help.rs
@@ -41,7 +41,7 @@ impl Draw for HelpFooter {
         frame.render_widget(
             Paragraph::new(text)
                 .alignment(Alignment::Right)
-                .style(tui_context.theme.text.highlight),
+                .style(tui_context.styles.text.highlight),
             area,
         );
     }

--- a/src/tui/view/component/recipe_list.rs
+++ b/src/tui/view/component/recipe_list.rs
@@ -203,7 +203,7 @@ impl Draw<RecipeListPaneProps> for RecipeListPane {
             .collect_vec();
         let list = ratatui::widgets::List::new(items)
             .block(pane.generate())
-            .highlight_style(context.theme.list.highlight);
+            .highlight_style(context.styles.list.highlight);
 
         frame.render_stateful_widget(
             list,

--- a/src/tui/view/theme.rs
+++ b/src/tui/view/theme.rs
@@ -37,8 +37,10 @@ pub struct Styles {
 
 impl Styles {
     pub fn from_theme(theme: &Theme) -> Self {
-        let primary_color = Color::from_str(&theme.primary_color).unwrap();
-        let error_color = Color::from_str(&theme.error_color).unwrap();
+        let primary_color =
+            Color::from_str(&theme.primary_color).unwrap_or(Color::LightGreen);
+        let error_color =
+            Color::from_str(&theme.error_color).unwrap_or(Color::Red);
 
         Self {
             list: ThemeList {

--- a/src/tui/view/theme.rs
+++ b/src/tui/view/theme.rs
@@ -2,11 +2,28 @@ use ratatui::{
     style::{Color, Modifier, Style},
     widgets::BorderType,
 };
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Theme {
+    pub primary_color: String,
+    pub error_color: String,
+}
+
+impl Default for Theme {
+    fn default() -> Self {
+        Theme {
+            primary_color: Color::LightGreen.to_string(),
+            error_color: Color::Red.to_string(),
+        }
+    }
+}
 
 /// Configurable visual settings for the UI. Styles are grouped into sub-structs
 /// generally by component.
 #[derive(Debug)]
-pub struct Theme {
+pub struct Styles {
     pub list: ThemeList,
     pub modal: ThemeModal,
     pub pane: ThemePane,
@@ -18,11 +35,68 @@ pub struct Theme {
     pub text_window: ThemeTextWindow,
 }
 
-impl Theme {
-    // Ideally these should be part of the theme, but that requires some sort of
-    // two-stage themeing
-    pub const PRIMARY_COLOR: Color = Color::LightGreen;
-    pub const ERROR_COLOR: Color = Color::Red;
+impl Styles {
+    pub fn from_theme(theme: &Theme) -> Self {
+        let primary_color = Color::from_str(&theme.primary_color).unwrap();
+        let error_color = Color::from_str(&theme.error_color).unwrap();
+
+        Self {
+            list: ThemeList {
+                highlight: Style::default()
+                    .bg(primary_color)
+                    .fg(Color::Black)
+                    .add_modifier(Modifier::BOLD),
+            },
+            modal: ThemeModal {
+                border: Style::default().fg(primary_color),
+                border_type: BorderType::Double,
+            },
+            pane: ThemePane {
+                border: Style::default(),
+                border_selected: Style::default()
+                    .fg(primary_color)
+                    .add_modifier(Modifier::BOLD),
+                border_type: BorderType::Plain,
+                border_type_selected: BorderType::Double,
+            },
+            tab: ThemeTab {
+                highlight: Style::default()
+                    .fg(primary_color)
+                    .add_modifier(Modifier::BOLD)
+                    .add_modifier(Modifier::UNDERLINED),
+            },
+            table: ThemeTable {
+                header: Style::default()
+                    .add_modifier(Modifier::BOLD)
+                    .add_modifier(Modifier::UNDERLINED),
+                text: Style::default(),
+                alt: Style::default().bg(Color::DarkGray),
+                disabled: Style::default().add_modifier(Modifier::DIM),
+                highlight: Style::default()
+                    .bg(primary_color)
+                    .fg(Color::Black)
+                    .add_modifier(Modifier::BOLD)
+                    .add_modifier(Modifier::UNDERLINED),
+                title: Style::default().add_modifier(Modifier::BOLD),
+            },
+            template_preview: ThemeTemplatePreview {
+                text: Style::default().fg(Color::Blue),
+                error: Style::default().bg(error_color),
+            },
+            text: ThemeText {
+                highlight: Style::default().fg(Color::Black).bg(primary_color),
+            },
+            text_box: ThemeTextBox {
+                text: Style::default().bg(Color::DarkGray),
+                cursor: Style::default().bg(Color::White).fg(Color::Black),
+                placeholder: Style::default().fg(Color::Black),
+                invalid: Style::default().bg(Color::LightRed),
+            },
+            text_window: ThemeTextWindow {
+                line_number: Style::default().fg(Color::DarkGray),
+            },
+        }
+    }
 }
 
 /// Styles for List component
@@ -99,69 +173,6 @@ pub struct ThemeTextBox {
 pub struct ThemeTextWindow {
     /// Line numbers on large text areas
     pub line_number: Style,
-}
-
-impl Default for Theme {
-    fn default() -> Self {
-        Self {
-            list: ThemeList {
-                highlight: Style::default()
-                    .bg(Self::PRIMARY_COLOR)
-                    .fg(Color::Black)
-                    .add_modifier(Modifier::BOLD),
-            },
-            modal: ThemeModal {
-                border: Style::default().fg(Self::PRIMARY_COLOR),
-                border_type: BorderType::Double,
-            },
-            pane: ThemePane {
-                border: Style::default(),
-                border_selected: Style::default()
-                    .fg(Self::PRIMARY_COLOR)
-                    .add_modifier(Modifier::BOLD),
-                border_type: BorderType::Plain,
-                border_type_selected: BorderType::Double,
-            },
-            tab: ThemeTab {
-                highlight: Style::default()
-                    .fg(Self::PRIMARY_COLOR)
-                    .add_modifier(Modifier::BOLD)
-                    .add_modifier(Modifier::UNDERLINED),
-            },
-            table: ThemeTable {
-                header: Style::default()
-                    .add_modifier(Modifier::BOLD)
-                    .add_modifier(Modifier::UNDERLINED),
-                text: Style::default(),
-                alt: Style::default().bg(Color::DarkGray),
-                disabled: Style::default().add_modifier(Modifier::DIM),
-                highlight: Style::default()
-                    .bg(Self::PRIMARY_COLOR)
-                    .fg(Color::Black)
-                    .add_modifier(Modifier::BOLD)
-                    .add_modifier(Modifier::UNDERLINED),
-                title: Style::default().add_modifier(Modifier::BOLD),
-            },
-            template_preview: ThemeTemplatePreview {
-                text: Style::default().fg(Color::Blue),
-                error: Style::default().bg(Self::ERROR_COLOR),
-            },
-            text: ThemeText {
-                highlight: Style::default()
-                    .fg(Color::Black)
-                    .bg(Self::PRIMARY_COLOR),
-            },
-            text_box: ThemeTextBox {
-                text: Style::default().bg(Color::DarkGray),
-                cursor: Style::default().bg(Color::White).fg(Color::Black),
-                placeholder: Style::default().fg(Color::Black),
-                invalid: Style::default().bg(Color::LightRed),
-            },
-            text_window: ThemeTextWindow {
-                line_number: Style::default().fg(Color::DarkGray),
-            },
-        }
-    }
 }
 
 impl ThemePane {


### PR DESCRIPTION
I'm quite new to rust, so posting this as a draft first, please check if I'm on the right track.

Things I still plan to do:
- [x] fallback to default if color config is unparsable
- [ ] add tests
- [x] add documentation
- [x] add changelog entry

## Description

Making the primary and the error colors configurable.

Closes https://github.com/LucasPickering/slumber/issues/193

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

## QA

_How did you test this?_

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
