### PR TITLE
Exit fullscreen mode when changing panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+- Exit fullscreen mode when changing panes
+
 ## [1.1.0] - 2024-05-05
 
 ### Added

--- a/src/tui/view/state/fixed_select.rs
+++ b/src/tui/view/state/fixed_select.rs
@@ -39,6 +39,15 @@ pub struct FixedSelectStateBuilder<Item, State> {
 }
 
 impl<Item, State> FixedSelectStateBuilder<Item, State> {
+    /// Set the callback to be called when the user highlights a new item
+    pub fn on_select(
+        mut self,
+        on_select: impl 'static + Fn(&mut Item),
+    ) -> Self {
+        self.select = self.select.on_select(on_select);
+        self
+    }
+
     /// Set the callback to be called when the user hits enter on an item
     pub fn on_submit(
         mut self,


### PR DESCRIPTION
Little UI tweak to prevent getting stuck on a pane in the background. I experimented with the opposite fix of preventing pane change while in fullscreen, but I liked this version better because it's less restrictive. It allows the user to change panes without an initial action to leave fullscreen. Could lead to people accidentally quitting fullscreen, but I think it would be intuitive why that happened and easy to get back into fullscreen. 