### PR TITLE
Improve error chain display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- Use colored background for status codes
+  - This includes a new theme field, `success_color`
+
 ### Fixed
 
 - Exit fullscreen mode when changing panes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Use colored background for status codes
   - This includes a new theme field, `success_color`
+- Improve hierarchy presentation of errors
 
 ### Fixed
 

--- a/docs/src/api/configuration/theme.md
+++ b/docs/src/api/configuration/theme.md
@@ -15,6 +15,7 @@ theme:
 | `primary_color`      | `Color` | Color of most emphasized content                                     |
 | `primary_text_color` | `Color` | Color of text on top of the primary color (generally white or black) |
 | `secondary_color`    | `Color` | Color of secondary notable content                                   |
+| `success_color`      | `Color` | Color representing successful events                                 |
 | `error_color`        | `Color` | Color representing error messages                                    |
 
 ## Color Format

--- a/src/tui/view/common.rs
+++ b/src/tui/view/common.rs
@@ -27,7 +27,7 @@ use ratatui::{
     text::{Span, Text},
     widgets::{Block, Borders},
 };
-use reqwest::header::HeaderValue;
+use reqwest::{header::HeaderValue, StatusCode};
 
 /// A container with a title and border
 pub struct Pane<'a> {
@@ -167,6 +167,26 @@ impl Generate for Option<Duration> {
             // For incomplete requests typically
             None => "???".into(),
         }
+    }
+}
+
+impl Generate for StatusCode {
+    type Output<'this> = Span<'this> where Self: 'this;
+
+    fn generate<'this>(self) -> Self::Output<'this>
+    where
+        Self: 'this,
+    {
+        let styles = &TuiContext::get().styles.status_code;
+        let is_error = self.is_client_error() || self.is_server_error();
+        Span::styled(
+            self.to_string(),
+            if is_error {
+                styles.error
+            } else {
+                styles.success
+            },
+        )
     }
 }
 

--- a/src/tui/view/common.rs
+++ b/src/tui/view/common.rs
@@ -24,7 +24,7 @@ use crate::{
 use chrono::{DateTime, Duration, Local, Utc};
 use itertools::Itertools;
 use ratatui::{
-    text::{Span, Text},
+    text::{Line, Span, Text},
     widgets::{Block, Borders},
 };
 use reqwest::{header::HeaderValue, StatusCode};
@@ -210,7 +210,27 @@ impl Generate for &anyhow::Error {
     where
         Self: 'this,
     {
-        self.chain().map(|err| err.to_string()).join("\n").into()
+        let chain = self.chain();
+        let len = chain.len();
+        chain
+            .enumerate()
+            .map::<Line, _>(|(i, error)| {
+                let icon = if i == 0 {
+                    "" // First
+                } else if i < len - 1 {
+                    "└┬" // Intermediate
+                } else {
+                    "└─" // Last
+                };
+                format!(
+                    "{indent:width$}{icon}{error}",
+                    indent = "",
+                    width = i.saturating_sub(1)
+                )
+                .into()
+            })
+            .collect_vec()
+            .into()
     }
 }
 

--- a/src/tui/view/component/response_pane.rs
+++ b/src/tui/view/component/response_pane.rs
@@ -239,10 +239,7 @@ impl<'a> Draw<CompleteResponseContentProps<'a>> for CompleteResponseContent {
         .areas(area);
 
         // Metadata
-        frame.render_widget(
-            Paragraph::new(response.status.to_string()),
-            header_area,
-        );
+        frame.render_widget(response.status.generate(), header_area);
         frame.render_widget(
             Paragraph::new(Line::from(vec![
                 props.record.response.body.size().to_string_as(false).into(),

--- a/src/tui/view/theme.rs
+++ b/src/tui/view/theme.rs
@@ -16,6 +16,7 @@ pub struct Theme {
     /// fallible to just have the user specify it.
     pub primary_text_color: Color,
     pub secondary_color: Color,
+    pub success_color: Color,
     pub error_color: Color,
 }
 
@@ -25,6 +26,7 @@ impl Default for Theme {
             primary_color: Color::Blue,
             primary_text_color: Color::White,
             secondary_color: Color::Yellow,
+            success_color: Color::Green,
             error_color: Color::Red,
         }
     }
@@ -39,6 +41,7 @@ pub struct Styles {
     pub list: ListStyles,
     pub modal: ModalStyles,
     pub pane: PaneStyles,
+    pub status_code: StatusCodeStyles,
     pub tab: TabStyles,
     pub table: TableStyles,
     pub template_preview: TemplatePreviewStyles,
@@ -67,6 +70,12 @@ impl Styles {
                     .add_modifier(Modifier::BOLD),
                 border_type: BorderType::Plain,
                 border_type_selected: BorderType::Double,
+            },
+            status_code: StatusCodeStyles {
+                success: Style::default()
+                    .fg(Color::Black)
+                    .bg(theme.success_color),
+                error: Style::default().bg(theme.error_color),
             },
             tab: TabStyles {
                 highlight: Style::default()
@@ -146,6 +155,13 @@ impl PaneStyles {
             (self.border_type, self.border)
         }
     }
+}
+
+/// Styles for HTTP status code display
+#[derive(Debug)]
+pub struct StatusCodeStyles {
+    pub success: Style,
+    pub error: Style,
 }
 
 /// Styles for Tab component


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

- Improve error chain display in UI to show hierarchy
- Add `ResultExt::reported`, which makes it easier to report an error to the user in the TUI
- Use colored background for status codes
  - This included adding a new field to the theme, `success_color`

### Before

<img width="347" alt="Screenshot 2024-05-06 at 10 52 19 AM" src="https://github.com/LucasPickering/slumber/assets/2382935/ba57c390-1058-4552-bab0-9ecca3f2365e">

![image](https://github.com/LucasPickering/slumber/assets/2382935/fd6b8611-d777-40b7-bf88-7f5c427bf004)

### After

<img width="367" alt="Screenshot 2024-05-06 at 10 51 46 AM" src="https://github.com/LucasPickering/slumber/assets/2382935/f1fbeac4-fb13-4c7b-9dd4-9b1cb0f5f2c5">

![image](https://github.com/LucasPickering/slumber/assets/2382935/29ffd2fa-f9c0-4273-a722-38e5915fd4e5)


## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Longer errors will now have more trouble fitting on the screen

## QA

_How did you test this?_

Manually in TUI

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
