### PR TITLE
Implicitly support cursor events in selects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - Exit fullscreen mode when changing panes
+- Support scrolling on more lists/tables
 
 ## [1.1.0] - 2024-05-05
 

--- a/src/tui/view.rs
+++ b/src/tui/view.rs
@@ -166,7 +166,7 @@ impl View {
         mut event: Event,
     ) -> Update {
         // If we have a child, send them the event. If not, eat it ourselves
-        for child in component.children() {
+        for child in component.data_mut().children() {
             if event.should_handle(&child) {
                 // RECURSION
                 let update = Self::update_all(messages_tx, child, event);
@@ -189,10 +189,10 @@ impl View {
         // Message is already traced in the parent span, so don't dupe it.
         let span = trace_span!(
             "Component handling",
-            component = ?component.inner(),
+            component = ?component.data(),
         );
         span.in_scope(|| {
-            let update = component.update(messages_tx, event);
+            let update = component.data_mut().update(messages_tx, event);
             trace!(?update);
             update
         })

--- a/src/tui/view/common/actions.rs
+++ b/src/tui/view/common/actions.rs
@@ -76,14 +76,14 @@ where
     for<'a> &'a T: Generate<Output<'a> = Span<'a>>,
 {
     fn draw(&self, frame: &mut Frame, _: (), area: Rect) {
-        let list = List {
-            block: None,
-            list: self.actions.items(),
-        };
-        frame.render_stateful_widget(
-            list.generate(),
+        self.actions.draw(
+            frame,
+            List {
+                block: None,
+                list: self.actions.data().items(),
+            }
+            .generate(),
             area,
-            &mut self.actions.state_mut(),
         );
     }
 }

--- a/src/tui/view/common/modal.rs
+++ b/src/tui/view/common/modal.rs
@@ -89,7 +89,7 @@ impl ModalQueue {
     /// Close the current modal, and return the closed modal if any
     pub fn close(&mut self) -> Option<Box<dyn Modal>> {
         trace!("Closing modal");
-        self.queue.pop_front().map(Component::into_inner)
+        self.queue.pop_front().map(Component::into_data)
     }
 }
 
@@ -137,7 +137,7 @@ impl Draw for ModalQueue {
     fn draw(&self, frame: &mut Frame, _: (), area: Rect) {
         if let Some(modal) = self.queue.front() {
             let styles = &TuiContext::get().styles;
-            let (width, height) = modal.dimensions();
+            let (width, height) = modal.data().dimensions();
 
             // The child gave us the content dimensions, we need to add one cell
             // of buffer for the border
@@ -148,7 +148,7 @@ impl Draw for ModalQueue {
             area.height += 2;
 
             let block = Block::default()
-                .title(modal.title())
+                .title(modal.data().title())
                 .borders(Borders::ALL)
                 .border_style(styles.modal.border)
                 .border_type(styles.modal.border_type);

--- a/src/tui/view/component.rs
+++ b/src/tui/view/component.rs
@@ -12,15 +12,8 @@ mod root;
 
 pub use root::Root;
 
-use crate::tui::{
-    message::MessageSender,
-    view::{
-        draw::Draw,
-        event::{Event, EventHandler, Update},
-    },
-};
+use crate::tui::view::{draw::Draw, event::EventHandler};
 use crossterm::event::MouseEvent;
-use derive_more::{Deref, DerefMut};
 use ratatui::{layout::Rect, Frame};
 use std::cell::Cell;
 
@@ -30,10 +23,13 @@ use std::cell::Cell;
 /// to have components automatically receive *only the cursor events* that
 /// occurred within the bounds of that component. Generally every layer in the
 /// component tree should be wrapped in one of these.
-#[derive(Debug, Default, Deref, DerefMut)]
+///
+/// This intentionally does *not* implement `Deref` because that has led to bugs
+/// in the past where the inner component is drawn without this pass through
+/// layer, which means the component area isn't tracked. That means cursor
+/// events aren't handled.
+#[derive(Debug, Default)]
 pub struct Component<T> {
-    #[deref]
-    #[deref_mut]
     inner: T,
     /// The area that this component was last rendered to. In most cases this
     /// is updated automatically by calling `draw`, but in some scenarios (such
@@ -53,17 +49,6 @@ impl<T> Component<T> {
     /// Get the visual area that this component was last drawn to.
     pub fn area(&self) -> Rect {
         self.area.get()
-    }
-
-    /// Manually set the area on this component. In most cases you don't need
-    /// to call this, because the area is automatically set in `[Self::draw]`.
-    /// But for components that aren't drawn (i.e. state-only components), we
-    /// may need to manually capture the area so we can still handle mouse
-    /// events.
-    ///
-    /// This isn't a great pattern, but it's easy and works for now.
-    pub fn set_area(&self, area: Rect) {
-        self.area.replace(area);
     }
 
     /// Get a mutable reference to the inner value, but as a trait object.
@@ -88,23 +73,29 @@ impl<T> Component<T> {
         })
     }
 
-    pub fn inner(&self) -> &T {
+    /// Get a reference to the inner component. This should only be used to
+    /// access the contained *data*. Drawing should be routed through the
+    /// wrapping component.
+    pub fn data(&self) -> &T {
         &self.inner
     }
 
+    /// Get a mutable reference to the inner component. This should only be used
+    /// to access the contained *data*. Drawing should be routed through the
+    /// wrapping component.
+    pub fn data_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+
     /// Move the inner component out
-    pub fn into_inner(self) -> T {
+    pub fn into_data(self) -> T {
         self.inner
     }
 }
 
-impl<T: EventHandler> EventHandler for Component<T> {
-    fn update(&mut self, messages_tx: &MessageSender, event: Event) -> Update {
-        self.inner.update(messages_tx, event)
-    }
-
-    fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {
-        self.inner.children()
+impl<T> From<T> for Component<T> {
+    fn from(inner: T) -> Self {
+        Self::new(inner)
     }
 }
 
@@ -112,11 +103,5 @@ impl<P, T: Draw<P>> Draw<P> for Component<T> {
     fn draw(&self, frame: &mut Frame, props: P, area: Rect) {
         self.area.set(area); // Cache the visual area, for event handling
         self.inner.draw(frame, props, area);
-    }
-}
-
-impl<T> From<T> for Component<T> {
-    fn from(inner: T) -> Self {
-        Self::new(inner)
     }
 }

--- a/src/tui/view/component/misc.rs
+++ b/src/tui/view/component/misc.rs
@@ -113,7 +113,7 @@ impl Modal for PromptModal {
     fn on_close(self: Box<Self>) {
         if self.submit.get() {
             // Return the user's value and close the prompt
-            self.channel.respond(self.text_box.into_inner().into_text());
+            self.channel.respond(self.text_box.into_data().into_text());
         }
     }
 }

--- a/src/tui/view/component/primary.rs
+++ b/src/tui/view/component/primary.rs
@@ -135,13 +135,13 @@ impl PrimaryView {
     /// Which recipe in the recipe list is selected? `None` iff the list is
     /// empty OR a folder is selected.
     pub fn selected_recipe(&self) -> Option<&Recipe> {
-        self.recipe_list_pane.selected_recipe()
+        self.recipe_list_pane.data().selected_recipe()
     }
 
     /// Which profile in the list is selected? `None` iff the list is empty.
     /// Exposing inner state is hacky but it's an easy shortcut
     pub fn selected_profile(&self) -> Option<&Profile> {
-        self.profile_list_pane.profiles().selected()
+        self.profile_list_pane.data().profiles().selected()
     }
 
     /// Draw the "normal" view, when nothing is full
@@ -240,7 +240,8 @@ impl PrimaryView {
             // Make profile list as small as possible
             Constraint::Max(
                 // +2 to account for top/bottom border
-                self.profile_list_pane.profiles().items().len() as u16 + 2,
+                self.profile_list_pane.data().profiles().items().len() as u16
+                    + 2,
             )
         } else {
             Constraint::Max(3)
@@ -294,7 +295,7 @@ impl EventHandler for PrimaryView {
                             profile_id: self
                                 .selected_profile()
                                 .map(|profile| profile.id.clone()),
-                            options: self.recipe_pane.recipe_options(),
+                            options: self.recipe_pane.data().recipe_options(),
                         },
                     ));
                 }

--- a/src/tui/view/component/profile_list.rs
+++ b/src/tui/view/component/profile_list.rs
@@ -49,7 +49,7 @@ impl ProfileListPane {
     }
 
     pub fn profiles(&self) -> &SelectState<Profile> {
-        &self.profiles
+        self.profiles.data()
     }
 }
 
@@ -71,7 +71,6 @@ impl EventHandler for ProfileListPane {
 
 impl Draw<ProfileListPaneProps> for ProfileListPane {
     fn draw(&self, frame: &mut Frame, props: ProfileListPaneProps, area: Rect) {
-        self.profiles.set_area(area); // Needed for tracking cursor events
         let title = TuiContext::get()
             .input_engine
             .add_hint("Profiles", Action::SelectProfileList);
@@ -85,14 +84,14 @@ impl Draw<ProfileListPaneProps> for ProfileListPane {
 
         if props.is_selected {
             // Only show the full list if selected
-            let list = List {
-                block: None,
-                list: self.profiles.items(),
-            };
-            frame.render_stateful_widget(
-                list.generate(),
+            self.profiles.draw(
+                frame,
+                List {
+                    block: None,
+                    list: self.profiles.data().items(),
+                }
+                .generate(),
                 inner_area,
-                &mut self.profiles.state_mut(),
             );
         } else {
             // Pane is not selected - just show the selected profile

--- a/src/tui/view/component/recipe_pane.rs
+++ b/src/tui/view/component/recipe_pane.rs
@@ -140,8 +140,8 @@ impl RecipePane {
             }
 
             RecipeOptions {
-                disabled_headers: to_disabled_set(&state.headers),
-                disabled_query_parameters: to_disabled_set(&state.query),
+                disabled_headers: to_disabled_set(state.headers.data()),
+                disabled_query_parameters: to_disabled_set(state.query.data()),
             }
         } else {
             // Shouldn't be possible, because state is initialized on first
@@ -195,7 +195,7 @@ impl EventHandler for RecipePane {
     }
 
     fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {
-        let selected_tab = *self.tabs.selected();
+        let selected_tab = *self.tabs.data().selected();
         let mut children = vec![self.tabs.as_child()];
 
         // Send events to the tab pane as well
@@ -274,23 +274,29 @@ impl<'a> Draw<RecipePaneProps<'a>> for RecipePane {
             self.tabs.draw(frame, (), tabs_area);
 
             // Request content
-            match self.tabs.selected() {
+            match self.tabs.data().selected() {
                 Tab::Body => {
                     if let Some(body) = &recipe_state.body {
                         body.draw(frame, (), content_area);
                     }
                 }
-                Tab::Query => frame.render_stateful_widget(
-                    to_table(&recipe_state.query, ["", "Parameter", "Value"])
-                        .generate(),
+                Tab::Query => recipe_state.query.draw(
+                    frame,
+                    to_table(
+                        recipe_state.query.data(),
+                        ["", "Parameter", "Value"],
+                    )
+                    .generate(),
                     content_area,
-                    &mut recipe_state.query.state_mut(),
                 ),
-                Tab::Headers => frame.render_stateful_widget(
-                    to_table(&recipe_state.headers, ["", "Header", "Value"])
-                        .generate(),
+                Tab::Headers => recipe_state.headers.draw(
+                    frame,
+                    to_table(
+                        recipe_state.headers.data(),
+                        ["", "Header", "Value"],
+                    )
+                    .generate(),
                     content_area,
-                    &mut recipe_state.headers.state_mut(),
                 ),
                 Tab::Authentication => {
                     if let Some(authentication) = &recipe_state.authentication {

--- a/src/tui/view/component/record_body.rs
+++ b/src/tui/view/component/record_body.rs
@@ -54,7 +54,7 @@ impl RecordBody {
     pub fn text(&self) -> Option<String> {
         self.text_window
             .get()
-            .map(|text_window| text_window.inner().text().to_owned())
+            .map(|text_window| text_window.data().text().to_owned())
     }
 }
 
@@ -85,7 +85,9 @@ impl EventHandler for RecordBody {
             Event::Input {
                 action: Some(Action::Search),
                 ..
-            } if self.query_available.get() => self.query_text_box.focus(),
+            } if self.query_available.get() => {
+                self.query_text_box.data_mut().focus()
+            }
             Event::Other(ref other) => {
                 match other.downcast_ref::<QuerySubmit>() {
                     Some(QuerySubmit(text)) => {
@@ -107,7 +109,7 @@ impl EventHandler for RecordBody {
     }
 
     fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {
-        if self.query_text_box.is_focused() {
+        if self.query_text_box.data().is_focused() {
             vec![self.query_text_box.as_child()]
         } else if let Some(text_window) = self.text_window.get_mut() {
             vec![text_window.as_child()]

--- a/src/tui/view/component/request_pane.rs
+++ b/src/tui/view/component/request_pane.rs
@@ -197,8 +197,10 @@ impl EventHandler for RenderedRequest {
                         // Copy exactly what the user sees. Currently requests
                         // don't support formatting/querying but that could
                         // change
-                        if let Some(body) =
-                            self.state.get().and_then(|state| state.body.text())
+                        if let Some(body) = self
+                            .state
+                            .get()
+                            .and_then(|state| state.body.data().text())
                         {
                             messages_tx.send(Message::CopyText(body));
                         }
@@ -212,7 +214,7 @@ impl EventHandler for RenderedRequest {
     }
 
     fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {
-        let selected_tab = *self.tabs.selected();
+        let selected_tab = *self.tabs.data().selected();
         let mut children = vec![];
         match selected_tab {
             Tab::Url | Tab::Headers => {}
@@ -244,7 +246,7 @@ impl Draw<RenderedRequestProps> for RenderedRequest {
         self.tabs.draw(frame, (), tabs_area);
 
         // Main content for the response
-        match self.tabs.selected() {
+        match self.tabs.data().selected() {
             Tab::Url => {
                 frame.render_widget(
                     Paragraph::new(props.request.url.to_string())

--- a/src/tui/view/component/response_pane.rs
+++ b/src/tui/view/component/response_pane.rs
@@ -162,8 +162,10 @@ impl EventHandler for CompleteResponseContent {
             match action {
                 MenuAction::CopyBody => {
                     // Use whatever text is visible to the user
-                    if let Some(body) =
-                        self.state.get().and_then(|state| state.body.text())
+                    if let Some(body) = self
+                        .state
+                        .get()
+                        .and_then(|state| state.body.data().text())
                     {
                         messages_tx.send(Message::CopyText(body));
                     }
@@ -179,7 +181,12 @@ impl EventHandler for CompleteResponseContent {
                         // all querying to the main data storage, so the main
                         // loop can access it directly to be written.
                         let data = if state.response.body.parsed().is_some() {
-                            state.body.text().unwrap_or_default().into_bytes()
+                            state
+                                .body
+                                .data()
+                                .text()
+                                .unwrap_or_default()
+                                .into_bytes()
                         } else {
                             state.response.body.bytes().to_vec()
                         };
@@ -199,7 +206,7 @@ impl EventHandler for CompleteResponseContent {
     }
 
     fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {
-        let selected_tab = *self.tabs.selected();
+        let selected_tab = *self.tabs.data().selected();
         let mut children = vec![];
         match selected_tab {
             Tab::Body => {
@@ -254,7 +261,7 @@ impl<'a> Draw<CompleteResponseContentProps<'a>> for CompleteResponseContent {
         self.tabs.draw(frame, (), tabs_area);
 
         // Main content for the response
-        match self.tabs.selected() {
+        match self.tabs.data().selected() {
             Tab::Body => {
                 state.body.draw(
                     frame,

--- a/src/tui/view/component/root.rs
+++ b/src/tui/view/component/root.rs
@@ -64,12 +64,12 @@ impl Root {
 
     /// Get the request state to be displayed
     fn active_request(&self) -> Option<&RequestState> {
+        let primary_view = self.primary_view.data();
         // "No Profile" _is_ a profile
-        let profile_id = self
-            .primary_view
+        let profile_id = primary_view
             .selected_profile()
             .map(|profile| profile.id.clone());
-        let recipe_id = self.primary_view.selected_recipe()?.id.clone();
+        let recipe_id = primary_view.selected_recipe()?.id.clone();
         self.active_requests.get(&(profile_id, recipe_id))
     }
 
@@ -150,7 +150,7 @@ impl EventHandler for Root {
     }
 
     fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {
-        let modal_open = self.modal_queue.is_open();
+        let modal_open = self.modal_queue.data().is_open();
         let mut children: Vec<Component<&mut dyn EventHandler>> =
             vec![self.modal_queue.as_child()];
 

--- a/src/tui/view/draw.rs
+++ b/src/tui/view/draw.rs
@@ -2,7 +2,7 @@
 
 use crate::util::EnumChain;
 use ratatui::{layout::Rect, text::Span, Frame};
-use std::fmt::Display;
+use std::{fmt::Display, ops::Deref};
 
 /// Something that can be drawn onto screen as one or more TUI widgets.
 ///
@@ -19,6 +19,17 @@ use std::fmt::Display;
 /// object very difficult (maybe impossible?). This is an easy shortcut.
 pub trait Draw<Props = ()> {
     fn draw(&self, frame: &mut Frame, props: Props, area: Rect);
+}
+
+/// Allow transparenting drawing through Deref impls
+impl<T, Props> Draw<Props> for T
+where
+    T: Deref,
+    T::Target: Draw<Props>,
+{
+    fn draw(&self, frame: &mut Frame, props: Props, area: Rect) {
+        self.deref().draw(frame, props, area)
+    }
 }
 
 /// A helper for building a UI. It can be converted into some UI element to be

--- a/src/tui/view/state/select.rs
+++ b/src/tui/view/state/select.rs
@@ -2,13 +2,18 @@ use crate::tui::{
     input::Action,
     message::MessageSender,
     view::{
+        draw::Draw,
         event::{Event, EventHandler, Update},
         state::persistence::{Persistable, PersistentContainer},
     },
 };
 use itertools::Itertools;
-use ratatui::widgets::{ListState, TableState};
-use std::{cell::RefCell, fmt::Debug, marker::PhantomData, ops::DerefMut};
+use ratatui::{
+    layout::Rect,
+    widgets::{ListState, StatefulWidget, TableState},
+    Frame,
+};
+use std::{cell::RefCell, fmt::Debug, marker::PhantomData};
 
 /// State manager for a dynamic list of items.
 ///
@@ -117,12 +122,6 @@ impl<Item, State: SelectStateData> SelectState<Item, State> {
     /// Get the currently selected item (if any)
     pub fn selected(&self) -> Option<&Item> {
         self.items.get(self.state.borrow().selected()?)
-    }
-
-    /// Get a mutable reference to state. This uses `RefCell` underneath so it
-    /// will panic if aliased. Only call this during the draw phase!
-    pub fn state_mut(&self) -> impl DerefMut<Target = State> + '_ {
-        self.state.borrow_mut()
     }
 
     /// Select an item by value. Context is required for callbacks. Generally
@@ -239,6 +238,20 @@ where
             _ => return Update::Propagate(event),
         }
         Update::Consumed
+    }
+}
+
+/// Support rendering if the parent tells us exactly what to draw. This makes it
+/// easy to track the area that a component is drawn to, so we always receive
+/// the appropriate cursor events. It's impossible to draw the select component
+/// in another way because of the restricted access to the inner state.
+impl<Item, State, W> Draw<W> for SelectState<Item, State>
+where
+    State: SelectStateData,
+    W: StatefulWidget<State = State>,
+{
+    fn draw(&self, frame: &mut Frame, props: W, area: Rect) {
+        frame.render_stateful_widget(props, area, &mut self.state.borrow_mut());
     }
 }
 


### PR DESCRIPTION
Previously, you had to manually call set_area for components that wrapped SelectState or FixedSelectState in order for cursor events to work with them. This is because they are only data containers and not responsible for rendering, but the view needs to know their screen area in order to pass them events. If you forgot to call set_area, they'd never receive cursor events.

This adds a Draw impl on SelectState and FixedSelectState, and removes state_mut() for both. This forces you to call draw on the select, which means the screen area will be tracked correctly. Since each usage of select can have a different display method (list, table, etc.), the draw prop is just a widget ready to be rendered. This allows the parent to do the presentation, but forces it to be routed through the child.

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
