### PR TITLE
Fix profile not being selected on first startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+- Fix profile not being selected on initial startup
+
 ## [1.2.0] - 2024-05-10
 
 ### Added

--- a/src/collection/models.rs
+++ b/src/collection/models.rs
@@ -308,6 +308,11 @@ pub enum ChainOutputTrim {
 }
 
 impl Profile {
+    /// For combinators
+    pub fn id(&self) -> &ProfileId {
+        &self.id
+    }
+
     /// Get a presentable name for this profile
     pub fn name(&self) -> &str {
         self.name.as_deref().unwrap_or(&self.id)

--- a/src/tui/view/component/profile_select.rs
+++ b/src/tui/view/component/profile_select.rs
@@ -47,11 +47,13 @@ pub struct ProfilePane {
 
 impl ProfilePane {
     pub fn new(profiles: Vec<Profile>) -> Self {
+        // If there's no selected profile in the DB, default to the first
+        let selected_profile = profiles.first().map(Profile::id).cloned();
         Self {
             profiles,
             selected_profile: Persistent::new(
                 PersistentKey::ProfileId,
-                Default::default(),
+                selected_profile.into(),
             ),
         }
     }

--- a/static/demo.gif
+++ b/static/demo.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8d9c3929ff233dbbd29e2787f628aa7e7269d63ae727bfbe9c71a119cf26cf64
-size 343035
+oid sha256:00e1292f5818e016287b396fe7c9e4b42eece0555877ce06f481bc824dcfcaa3
+size 355083


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

The first time you load a collection with a profile, it should be preselected but it wasn't. This led to the demo gif being messed up.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

If you delete a known profile it should preselect the first in the list but it still doesn't. That'll be fixed later.

## QA

_How did you test this?_

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
