### PR TITLE
Refactor component logic to track visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- Mouse events (e.g. scrolling) are now sent to unfocused elements
+
 ## [1.2.1] - 2024-05-11
 
 ### Fixed

--- a/src/tui/view/common.rs
+++ b/src/tui/view/common.rs
@@ -32,7 +32,7 @@ use reqwest::{header::HeaderValue, StatusCode};
 /// A container with a title and border
 pub struct Pane<'a> {
     pub title: &'a str,
-    pub is_focused: bool,
+    pub has_focus: bool,
 }
 
 impl<'a> Generate for Pane<'a> {
@@ -43,7 +43,7 @@ impl<'a> Generate for Pane<'a> {
         Self: 'this,
     {
         let (border_type, border_style) =
-            TuiContext::get().styles.pane.border(self.is_focused);
+            TuiContext::get().styles.pane.border(self.has_focus);
         Block::default()
             .borders(Borders::ALL)
             .border_type(border_type)

--- a/src/tui/view/common/actions.rs
+++ b/src/tui/view/common/actions.rs
@@ -2,19 +2,14 @@ use crate::{
     tui::view::{
         common::{list::List, modal::Modal},
         component::Component,
-        draw::{Draw, Generate, ToStringGenerate},
+        draw::{Draw, DrawMetadata, Generate, ToStringGenerate},
         event::{Event, EventHandler, EventQueue},
         state::fixed_select::{FixedSelectState, FixedSelectWithoutDefault},
     },
     util::EnumChain,
 };
 use derive_more::Display;
-use ratatui::{
-    layout::{Constraint, Rect},
-    text::Span,
-    widgets::ListState,
-    Frame,
-};
+use ratatui::{layout::Constraint, text::Span, widgets::ListState, Frame};
 use strum::{EnumCount, EnumIter};
 
 /// Modal to list and trigger arbitrary actions. The list of available actions
@@ -75,7 +70,7 @@ where
     T: 'static + FixedSelectWithoutDefault,
     for<'a> &'a T: Generate<Output<'a> = Span<'a>>,
 {
-    fn draw(&self, frame: &mut Frame, _: (), area: Rect) {
+    fn draw(&self, frame: &mut Frame, _: (), metadata: DrawMetadata) {
         self.actions.draw(
             frame,
             List {
@@ -83,7 +78,8 @@ where
                 list: self.actions.data().items(),
             }
             .generate(),
-            area,
+            metadata.area(),
+            true,
         );
     }
 }

--- a/src/tui/view/common/button.rs
+++ b/src/tui/view/common/button.rs
@@ -5,13 +5,13 @@ use crate::tui::{
     input::Action,
     message::MessageSender,
     view::{
-        draw::{Draw, Generate},
+        draw::{Draw, DrawMetadata, Generate},
         event::{Event, EventHandler, EventQueue, Update},
         state::fixed_select::{FixedSelect, FixedSelectState},
     },
 };
 use ratatui::{
-    layout::{Constraint, Flex, Layout, Rect},
+    layout::{Constraint, Flex, Layout},
     text::Span,
     Frame,
 };
@@ -21,7 +21,7 @@ use ratatui::{
 /// enforce.
 pub struct Button<'a> {
     text: &'a str,
-    is_focused: bool,
+    has_focus: bool,
 }
 
 impl<'a> Generate for Button<'a> {
@@ -36,7 +36,7 @@ impl<'a> Generate for Button<'a> {
         let styles = &TuiContext::get().styles;
         Span {
             content: self.text.into(),
-            style: if self.is_focused {
+            style: if self.has_focus {
                 styles.text.highlight
             } else {
                 Default::default()
@@ -75,7 +75,7 @@ impl<T: FixedSelect> EventHandler for ButtonGroup<T> {
 }
 
 impl<T: FixedSelect> Draw for ButtonGroup<T> {
-    fn draw(&self, frame: &mut Frame, _: (), area: Rect) {
+    fn draw(&self, frame: &mut Frame, _: (), metadata: DrawMetadata) {
         let items = self.select.items();
         // The button width is based on the longest button
         let width = items
@@ -86,13 +86,13 @@ impl<T: FixedSelect> Draw for ButtonGroup<T> {
         let (areas, _) =
             Layout::horizontal(items.iter().map(|_| Constraint::Length(width)))
                 .flex(Flex::SpaceAround)
-                .split_with_spacers(area);
+                .split_with_spacers(metadata.area());
 
         for (button, area) in items.iter().zip(areas.iter()) {
             frame.render_widget(
                 Button {
                     text: &button.to_string(),
-                    is_focused: self.select.is_selected(button),
+                    has_focus: self.select.is_selected(button),
                 }
                 .generate(),
                 *area,

--- a/src/tui/view/common/tabs.rs
+++ b/src/tui/view/common/tabs.rs
@@ -3,7 +3,7 @@ use crate::tui::{
     input::Action,
     message::MessageSender,
     view::{
-        draw::Draw,
+        draw::{Draw, DrawMetadata},
         event::{Event, EventHandler, Update},
         state::{
             fixed_select::{FixedSelect, FixedSelectState},
@@ -11,7 +11,7 @@ use crate::tui::{
         },
     },
 };
-use ratatui::{prelude::Rect, Frame};
+use ratatui::Frame;
 use std::fmt::Debug;
 
 /// Multi-tab display. Generic parameter defines the available tabs.
@@ -59,12 +59,12 @@ impl<T> Draw for Tabs<T>
 where
     T: FixedSelect + Persistable<Persisted = T>,
 {
-    fn draw(&self, frame: &mut Frame, _: (), area: Rect) {
+    fn draw(&self, frame: &mut Frame, _: (), metadata: DrawMetadata) {
         frame.render_widget(
             ratatui::widgets::Tabs::new(T::iter().map(|e| e.to_string()))
                 .select(self.tabs.selected_index())
                 .highlight_style(TuiContext::get().styles.tab.highlight),
-            area,
+            metadata.area(),
         )
     }
 }

--- a/src/tui/view/common/text_box.rs
+++ b/src/tui/view/common/text_box.rs
@@ -5,7 +5,7 @@ use crate::tui::{
     input::Action,
     message::MessageSender,
     view::{
-        draw::Draw,
+        draw::{Draw, DrawMetadata},
         event::{Event, EventHandler, Update},
     },
 };
@@ -110,7 +110,7 @@ impl TextBox {
         self
     }
 
-    pub fn is_focused(&self) -> bool {
+    pub fn has_focus(&self) -> bool {
         self.focused
     }
 
@@ -214,7 +214,7 @@ impl EventHandler for TextBox {
 }
 
 impl Draw for TextBox {
-    fn draw(&self, frame: &mut Frame, _: (), area: Rect) {
+    fn draw(&self, frame: &mut Frame, _: (), metadata: DrawMetadata) {
         let styles = &TuiContext::get().styles;
 
         // Hide top secret data
@@ -234,13 +234,13 @@ impl Draw for TextBox {
         } else {
             styles.text_box.invalid
         };
-        frame.render_widget(Paragraph::new(text).style(style), area);
+        frame.render_widget(Paragraph::new(text).style(style), metadata.area());
 
         if self.focused {
             // Apply cursor styling on type
             let cursor_area = Rect {
-                x: area.x + self.state.cursor_offset() as u16,
-                y: area.y,
+                x: metadata.area().x + self.state.cursor_offset() as u16,
+                y: metadata.area().y,
                 width: 1,
                 height: 1,
             };

--- a/src/tui/view/common/text_window.rs
+++ b/src/tui/view/common/text_window.rs
@@ -3,13 +3,13 @@ use crate::tui::{
     input::Action,
     message::MessageSender,
     view::{
-        draw::{Draw, Generate},
+        draw::{Draw, DrawMetadata, Generate},
         event::{Event, EventHandler, Update},
     },
 };
 use ratatui::{
     layout::Layout,
-    prelude::{Alignment, Constraint, Rect},
+    prelude::{Alignment, Constraint},
     text::{Line, Text},
     widgets::Paragraph,
     Frame,
@@ -116,7 +116,7 @@ where
     T: 'static,
     for<'a> &'a T: Generate<Output<'a> = Text<'a>>,
 {
-    fn draw(&self, frame: &mut Frame, _: (), area: Rect) {
+    fn draw(&self, frame: &mut Frame, _: (), metadata: DrawMetadata) {
         let styles = &TuiContext::get().styles;
         let text = Paragraph::new(self.text.generate());
         // Assume no line wrapping when calculating line count
@@ -128,7 +128,7 @@ where
             Constraint::Length(1), // Spacer
             Constraint::Min(0),
         ])
-        .areas(area);
+        .areas(metadata.area());
 
         // Store text and window sizes for calculations in the update code
         self.text_width.set(text.line_width() as u16);

--- a/src/tui/view/component.rs
+++ b/src/tui/view/component.rs
@@ -1,4 +1,5 @@
 mod help;
+mod internal;
 mod misc;
 mod primary;
 mod profile_select;
@@ -9,98 +10,5 @@ mod request_pane;
 mod response_pane;
 mod root;
 
+pub use internal::Component;
 pub use root::Root;
-
-use crate::tui::view::{draw::Draw, event::EventHandler};
-use crossterm::event::MouseEvent;
-use ratatui::{layout::Rect, Frame};
-use std::cell::Cell;
-
-/// A wrapper around the various component types. The main job of this is to
-/// automatically track the area that a component is drawn to, so that it can
-/// be used during event handling to filter cursor events. This makes it easy
-/// to have components automatically receive *only the cursor events* that
-/// occurred within the bounds of that component. Generally every layer in the
-/// component tree should be wrapped in one of these.
-///
-/// This intentionally does *not* implement `Deref` because that has led to bugs
-/// in the past where the inner component is drawn without this pass through
-/// layer, which means the component area isn't tracked. That means cursor
-/// events aren't handled.
-#[derive(Debug, Default)]
-pub struct Component<T> {
-    inner: T,
-    /// The area that this component was last rendered to. In most cases this
-    /// is updated automatically by calling `draw`, but in some scenarios (such
-    /// as headless components) we may need to manually set this via
-    /// [Self::set_area].
-    area: Cell<Rect>,
-}
-
-impl<T> Component<T> {
-    pub fn new(inner: T) -> Self {
-        Self {
-            inner,
-            area: Cell::default(),
-        }
-    }
-
-    /// Get the visual area that this component was last drawn to.
-    pub fn area(&self) -> Rect {
-        self.area.get()
-    }
-
-    /// Get a mutable reference to the inner value, but as a trait object.
-    /// Useful for returning from `[EventHandler::children]`.
-    pub fn as_child(&mut self) -> Component<&mut dyn EventHandler>
-    where
-        T: EventHandler,
-    {
-        Component {
-            inner: &mut self.inner,
-            area: self.area.clone(),
-        }
-    }
-
-    /// Did the given mouse event occur over/on this component?
-    pub fn intersects(&self, mouse_event: &MouseEvent) -> bool {
-        self.area().intersects(Rect {
-            x: mouse_event.column,
-            y: mouse_event.row,
-            width: 1,
-            height: 1,
-        })
-    }
-
-    /// Get a reference to the inner component. This should only be used to
-    /// access the contained *data*. Drawing should be routed through the
-    /// wrapping component.
-    pub fn data(&self) -> &T {
-        &self.inner
-    }
-
-    /// Get a mutable reference to the inner component. This should only be used
-    /// to access the contained *data*. Drawing should be routed through the
-    /// wrapping component.
-    pub fn data_mut(&mut self) -> &mut T {
-        &mut self.inner
-    }
-
-    /// Move the inner component out
-    pub fn into_data(self) -> T {
-        self.inner
-    }
-}
-
-impl<T> From<T> for Component<T> {
-    fn from(inner: T) -> Self {
-        Self::new(inner)
-    }
-}
-
-impl<P, T: Draw<P>> Draw<P> for Component<T> {
-    fn draw(&self, frame: &mut Frame, props: P, area: Rect) {
-        self.area.set(area); // Cache the visual area, for event handling
-        self.inner.draw(frame, props, area);
-    }
-}

--- a/src/tui/view/component/help.rs
+++ b/src/tui/view/component/help.rs
@@ -5,16 +5,15 @@ use crate::{
         input::{Action, InputBinding},
         view::{
             common::{modal::Modal, table::Table},
-            draw::{Draw, Generate},
+            draw::{Draw, DrawMetadata, Generate},
             event::EventHandler,
         },
     },
 };
 use itertools::Itertools;
 use ratatui::{
-    layout::{Alignment, Constraint, Layout, Rect},
-    text::Line,
-    widgets::Paragraph,
+    layout::{Alignment, Constraint, Layout},
+    text::{Line, Text},
     Frame,
 };
 
@@ -24,8 +23,15 @@ const CRATE_VERSION: &str = env!("CARGO_PKG_VERSION");
 #[derive(Debug)]
 pub struct HelpFooter;
 
-impl Draw for HelpFooter {
-    fn draw(&self, frame: &mut Frame, _: (), area: Rect) {
+impl Generate for HelpFooter {
+    type Output<'this> = Text<'this>
+    where
+        Self: 'this;
+
+    fn generate<'this>(self) -> Self::Output<'this>
+    where
+        Self: 'this,
+    {
         let actions = [Action::OpenActions, Action::OpenHelp, Action::Quit];
 
         let tui_context = TuiContext::get();
@@ -38,12 +44,7 @@ impl Draw for HelpFooter {
             })
             .join(" / ");
 
-        frame.render_widget(
-            Paragraph::new(text)
-                .alignment(Alignment::Right)
-                .style(tui_context.styles.text.highlight),
-            area,
-        );
+        Text::styled(text, tui_context.styles.text.highlight)
     }
 }
 
@@ -83,7 +84,7 @@ impl Modal for HelpModal {
 impl EventHandler for HelpModal {}
 
 impl Draw for HelpModal {
-    fn draw(&self, frame: &mut Frame, _: (), area: Rect) {
+    fn draw(&self, frame: &mut Frame, _: (), metadata: DrawMetadata) {
         let tui_context = TuiContext::get();
 
         // Create layout
@@ -92,7 +93,7 @@ impl Draw for HelpModal {
             Constraint::Length(1),
             Constraint::Min(0),
         ])
-        .areas(area);
+        .areas(metadata.area());
 
         // Collection metadata
         let collection_metadata = Table {

--- a/src/tui/view/component/internal.rs
+++ b/src/tui/view/component/internal.rs
@@ -1,0 +1,538 @@
+//! Internal state for the [Component] struct. This defines common logic for
+//! components., and exposes a small API for accessing both local and global
+//! component state.
+
+use crate::tui::{
+    message::MessageSender,
+    view::{
+        draw::{Draw, DrawMetadata},
+        event::{Event, EventHandler, Update},
+    },
+};
+use crossterm::event::MouseEvent;
+use derive_more::Display;
+use ratatui::{layout::Rect, Frame};
+use std::{
+    cell::{Cell, RefCell},
+    collections::HashSet,
+};
+use tracing::{trace, trace_span, warn};
+use uuid::Uuid;
+
+thread_local! {
+    /// All components that were drawn during the last draw phase. The purpose
+    /// of this is to allow each component to return an exhaustive list of its
+    /// children during event handling, then we can automatically filter that
+    /// list down to just the ones that are visible. This prevents the need to
+    /// duplicate visibility logic in both the draw and the children getters.
+    ///
+    /// This is cleared at the start of each draw, then retained through the
+    /// next draw.
+    static VISIBLE_COMPONENTS: RefCell<HashSet<ComponentId>> =
+        Default::default();
+
+    /// Track whichever components are *currently* being drawn. Whenever we
+    /// draw a child, push it onto the stack. Pop off when done drawing it. This
+    /// makes it easy to track when we're done with a draw phase.
+    static STACK: RefCell<Vec<ComponentId>> = Default::default();
+}
+
+/// A wrapper around the various component types. The main job of this is to
+/// automatically track the area that a component is drawn to, so that it can
+/// be used during event handling to filter cursor events. This makes it easy
+/// to have components automatically receive *only the cursor events* that
+/// occurred within the bounds of that component. Generally every layer in the
+/// component tree should be wrapped in one of these.
+///
+/// This intentionally does *not* implement `Deref` because that has led to bugs
+/// in the past where the inner component is drawn without this pass through
+/// layer, which means the component area isn't tracked. That means cursor
+/// events aren't handled.
+#[derive(Debug, Default)]
+pub struct Component<T> {
+    /// Unique random identifier for this component, to reference it in global
+    /// state
+    id: ComponentId,
+    inner: T,
+    /// Draw metadata that affects event handling. This is updated on each draw
+    /// call, hence the need for interior mutability.
+    metadata: Cell<DrawMetadata>,
+}
+
+impl<T> Component<T> {
+    pub fn new(inner: T) -> Self {
+        Self {
+            id: ComponentId::new(),
+            inner,
+            metadata: Cell::default(),
+        }
+    }
+
+    /// Handle an event for this component *or* its children, starting at the
+    /// lowest descendant. Recursively walk up the tree until a component
+    /// consumes the event.
+    pub fn update_all(
+        &mut self,
+        messages_tx: &MessageSender,
+        mut event: Event,
+    ) -> Update
+    where
+        T: EventHandler,
+    {
+        // If we have a child, send them the event. If not, eat it ourselves
+        for mut child in self.data_mut().children() {
+            // Don't propgate to children that aren't visible or not in focus
+            if child.should_handle(&event) {
+                // RECURSION
+                let update = child.update_all(messages_tx, event);
+                match update {
+                    Update::Propagate(returned) => {
+                        // Keep going to the next child. The propgated event
+                        // *should* just be whatever we passed in, but we have
+                        // no way of verifying that
+                        event = returned;
+                    }
+                    Update::Consumed => {
+                        return update;
+                    }
+                }
+            }
+        }
+
+        // None of our children handled it, we'll take it ourselves. Event is
+        // already traced in the root span, so don't dupe it.
+        if self.should_handle(&event) {
+            let span = trace_span!("Component handling", component = ?self);
+            span.in_scope(|| {
+                let update = self.data_mut().update(messages_tx, event);
+                trace!(?update);
+                update
+            })
+        } else {
+            Update::Propagate(event)
+        }
+    }
+
+    /// Should this component handle the given event? This is based on a few
+    /// criteria:
+    /// - Am I currently visible? I.e. was I drawn on the last draw phase?
+    /// - If it's a non-mouse event, do I have focus?
+    /// - If it's a mouse event, was it over me? Mouse events should always go
+    /// to the clicked element, even when unfocused, because that's intuitive.
+    fn should_handle(&self, event: &Event) -> bool {
+        // If this component isn't currently in the visible tree, it shouldn't
+        // handle any events
+        if !self.is_visible() {
+            return false;
+        }
+
+        use crossterm::event::Event::*;
+        if let Event::Input { event, .. } = event {
+            match event {
+                Key(_) | Paste(_) => self.metadata.get().has_focus(),
+
+                Mouse(mouse_event) => {
+                    // Check if the mouse is over the component
+                    self.intersects(mouse_event)
+                }
+
+                // We expect everything else to have already been killed
+                _ => {
+                    warn!(?event, "Unexpected event kind");
+                    false
+                }
+            }
+        } else {
+            true
+        }
+    }
+
+    /// Was this component drawn to the screen during the previous draw phase?
+    fn is_visible(&self) -> bool {
+        VISIBLE_COMPONENTS.with_borrow(|tree| tree.contains(&self.id))
+    }
+
+    /// Did the given mouse event occur over/on this component?
+    fn intersects(&self, mouse_event: &MouseEvent) -> bool {
+        self.is_visible()
+            && self.metadata.get().area().intersects(Rect {
+                x: mouse_event.column,
+                y: mouse_event.row,
+                width: 1,
+                height: 1,
+            })
+    }
+
+    /// Get a mutable reference to the inner value, but as a trait object.
+    /// Useful for returning from `[EventHandler::children]`.
+    pub fn as_child(&mut self) -> Component<&mut dyn EventHandler>
+    where
+        T: EventHandler,
+    {
+        Component {
+            id: self.id,
+            inner: &mut self.inner,
+            metadata: self.metadata.clone(),
+        }
+    }
+
+    /// Get a reference to the inner component. This should only be used to
+    /// access the contained *data*. Drawing should be routed through the
+    /// wrapping component.
+    pub fn data(&self) -> &T {
+        &self.inner
+    }
+
+    /// Get a mutable reference to the inner component. This should only be used
+    /// to access the contained *data*. Drawing should be routed through the
+    /// wrapping component.
+    pub fn data_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+
+    /// Move the inner component out
+    pub fn into_data(self) -> T {
+        self.inner
+    }
+
+    /// Draw the component to the frame. This will update global state, then
+    /// defer to the component's [Draw] implementation for the actual draw.
+    pub fn draw<Props>(
+        &self,
+        frame: &mut Frame,
+        props: Props,
+        area: Rect,
+        has_focus: bool,
+    ) where
+        T: Draw<Props>,
+    {
+        let guard = DrawGuard::new(self.id);
+
+        // Update internal state for event handling
+        let metadata = DrawMetadata::new_dangerous(area, has_focus);
+        self.metadata.set(metadata);
+
+        self.inner.draw(frame, props, metadata);
+        drop(guard); // Make sure guard stays alive until here
+    }
+}
+
+impl<T> From<T> for Component<T> {
+    fn from(inner: T) -> Self {
+        Self::new(inner)
+    }
+}
+
+/// Unique ID to refer to a single component. Generally components are persisent
+/// throughout the lifespan of the view so this will be too, but it's only
+/// *necessary* for it to be consistent from one draw phase to the next event
+/// phase, because that's how we track if each component is visible or not.
+#[derive(Copy, Clone, Debug, Display, Eq, Hash, PartialEq)]
+struct ComponentId(Uuid);
+
+impl ComponentId {
+    fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+}
+
+/// Generate a new random ID
+impl Default for ComponentId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A RAII guard to ensure the mutable thread-global state is updated correctly
+/// throughout the span of a draw. This should be created at the start of each
+/// component's draw, and dropped at the finish of that draw.
+struct DrawGuard {
+    id: ComponentId,
+    is_root: bool,
+}
+
+impl DrawGuard {
+    fn new(id: ComponentId) -> Self {
+        // Push onto the render stack, so children know about their parent
+        let is_root = STACK.with_borrow_mut(|stack| {
+            stack.push(id);
+            stack.len() == 1
+        });
+
+        VISIBLE_COMPONENTS.with_borrow_mut(|visible_components| {
+            // If we're the root component, then anything in the visibility list
+            // is from the previous draw, so we want to clear it out
+            if is_root {
+                visible_components.clear();
+            }
+            visible_components.insert(id);
+        });
+        Self { id, is_root }
+    }
+}
+
+impl Drop for DrawGuard {
+    fn drop(&mut self) {
+        let popped = STACK.with_borrow_mut(|stack| stack.pop());
+
+        // Do some sanity checks here
+        match popped {
+            Some(popped) if popped == self.id => {}
+            Some(popped) => panic!(
+                "Popped incorrect component off render stack; \
+                expected `{expected}`, got `{popped}`",
+                expected = self.id
+            ),
+            None => panic!(
+                "Failed to pop component `{expected}` off render stack; \
+                stack is empty",
+                expected = self.id
+            ),
+        }
+        if self.is_root {
+            assert!(
+                STACK.with_borrow(|stack| stack.is_empty()),
+                "Render stack is not empty after popping root component"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        test_util::*,
+        tui::{input::Action, message::MessageSender, view::event::Update},
+    };
+    use crossterm::event::{
+        KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers,
+        MouseButton, MouseEventKind,
+    };
+    use ratatui::{backend::TestBackend, layout::Layout, Terminal};
+    use rstest::rstest;
+
+    #[derive(Debug, Default)]
+    struct Branch {
+        /// How many events have we consumed *ourselves*?
+        count: u32,
+        a: Component<Leaf>,
+        b: Component<Leaf>,
+        c: Component<Leaf>,
+    }
+
+    struct Props {
+        a: Mode,
+        b: Mode,
+        c: Mode,
+    }
+
+    enum Mode {
+        Focused,
+        Visible,
+        Hidden,
+    }
+
+    impl Branch {
+        fn reset(&mut self) {
+            self.count = 0;
+            self.a.data_mut().reset();
+            self.b.data_mut().reset();
+            self.c.data_mut().reset();
+        }
+    }
+
+    impl EventHandler for Branch {
+        fn update(&mut self, _: &MessageSender, _: Event) -> Update {
+            self.count += 1;
+            Update::Consumed
+        }
+
+        fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {
+            vec![self.a.as_child(), self.b.as_child(), self.c.as_child()]
+        }
+    }
+
+    impl Draw<Props> for Branch {
+        fn draw(
+            &self,
+            frame: &mut Frame,
+            props: Props,
+            metadata: DrawMetadata,
+        ) {
+            let [a_area, b_area, c_area] =
+                Layout::vertical([1, 1, 1]).areas(metadata.area());
+
+            for (component, area, mode) in [
+                (&self.a, a_area, props.a),
+                (&self.b, b_area, props.b),
+                (&self.c, c_area, props.c),
+            ] {
+                if !matches!(mode, Mode::Hidden) {
+                    component.draw(
+                        frame,
+                        (),
+                        area,
+                        matches!(mode, Mode::Focused),
+                    );
+                }
+            }
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct Leaf {
+        /// How many events have we consumed?
+        count: u32,
+    }
+
+    impl Leaf {
+        fn reset(&mut self) {
+            self.count = 0;
+        }
+    }
+
+    impl EventHandler for Leaf {
+        fn update(&mut self, _: &MessageSender, _: Event) -> Update {
+            self.count += 1;
+            Update::Consumed
+        }
+    }
+
+    impl Draw for Leaf {
+        fn draw(&self, frame: &mut Frame, _: (), metadata: DrawMetadata) {
+            frame.render_widget("hello!", metadata.area());
+        }
+    }
+
+    #[rstest]
+    fn test_render_component_tree(
+        messages: MessageQueue,
+        mut terminal: Terminal<TestBackend>,
+    ) {
+        // One level of nesting
+        let mut component: Component<Branch> = Component::default();
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 10,
+            height: 3,
+        };
+        let a_coords = (0, 0);
+        let b_coords = (0, 1);
+        let c_coords = (0, 2);
+
+        let assert_events =
+            |component: &mut Component<Branch>, expected_counts: [u32; 4]| {
+                let events = [
+                    keyboard_event(),
+                    mouse_event(a_coords),
+                    mouse_event(b_coords),
+                    mouse_event(c_coords),
+                ];
+                // Now visible components get events
+                for event in events {
+                    component.update_all(messages.tx(), event);
+                }
+                let [expected_root, expected_a, expected_b, expected_c] =
+                    expected_counts;
+                assert_eq!(
+                    component.data().count,
+                    expected_root,
+                    "count mismatch on root component"
+                );
+                assert_eq!(
+                    component.data().a.data().count,
+                    expected_a,
+                    "count mismatch on component a"
+                );
+                assert_eq!(
+                    component.data().b.data().count,
+                    expected_b,
+                    "count mismatch on component b"
+                );
+                assert_eq!(
+                    component.data().c.data().count,
+                    expected_c,
+                    "count mismatch on component c"
+                );
+
+                // Reset state for the next assertion
+                component.data_mut().reset();
+            };
+
+        // Initial event handling - nothing is visible so nothing should consume
+        assert_events(&mut component, [0, 0, 0, 0]);
+
+        // Visible components get events
+        component.draw(
+            &mut terminal.get_frame(),
+            Props {
+                a: Mode::Focused,
+                b: Mode::Visible,
+                c: Mode::Hidden,
+            },
+            area,
+            true,
+        );
+        // Root - inherited mouse event from c, which is hidden
+        // a - keyboard + mouse
+        // b - mouse
+        // c - hidden
+        assert_events(&mut component, [1, 2, 1, 0]);
+
+        // Switch things up, make sure new state is reflected
+        component.draw(
+            &mut terminal.get_frame(),
+            Props {
+                a: Mode::Visible,
+                b: Mode::Hidden,
+                c: Mode::Focused,
+            },
+            area,
+            true,
+        );
+        // Root - inherited mouse event from b, which is hidden
+        // a - mouse
+        // b - hidden
+        // c - keyboard + mouse
+        assert_events(&mut component, [1, 1, 0, 2]);
+
+        // Hide all children, root should eat everything
+        component.draw(
+            &mut terminal.get_frame(),
+            Props {
+                a: Mode::Hidden,
+                b: Mode::Hidden,
+                c: Mode::Hidden,
+            },
+            area,
+            true,
+        );
+        assert_events(&mut component, [4, 0, 0, 0]);
+    }
+
+    fn keyboard_event() -> Event {
+        Event::Input {
+            event: crossterm::event::Event::Key(KeyEvent {
+                code: KeyCode::Enter,
+                modifiers: KeyModifiers::NONE,
+                kind: KeyEventKind::Press,
+                state: KeyEventState::NONE,
+            }),
+            action: Some(Action::Submit),
+        }
+    }
+
+    fn mouse_event((x, y): (u16, u16)) -> Event {
+        Event::Input {
+            event: crossterm::event::Event::Mouse(MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Left),
+                column: x,
+                row: y,
+                modifiers: KeyModifiers::NONE,
+            }),
+            action: Some(Action::LeftClick),
+        }
+    }
+}

--- a/src/tui/view/component/misc.rs
+++ b/src/tui/view/component/misc.rs
@@ -12,7 +12,7 @@ use crate::{
                 text_box::TextBox,
             },
             component::Component,
-            draw::{Draw, Generate},
+            draw::{Draw, DrawMetadata, Generate},
             event::{Event, EventHandler, EventQueue, Update},
             state::Notification,
             Confirm,
@@ -21,7 +21,7 @@ use crate::{
 };
 use derive_more::Display;
 use ratatui::{
-    prelude::{Constraint, Rect},
+    prelude::Constraint,
     widgets::{Paragraph, Wrap},
     Frame,
 };
@@ -44,10 +44,10 @@ impl Modal for ErrorModal {
 impl EventHandler for ErrorModal {}
 
 impl Draw for ErrorModal {
-    fn draw(&self, frame: &mut Frame, _: (), area: Rect) {
+    fn draw(&self, frame: &mut Frame, _: (), metadata: DrawMetadata) {
         frame.render_widget(
             Paragraph::new(self.0.generate()).wrap(Wrap::default()),
-            area,
+            metadata.area(),
         );
     }
 }
@@ -125,8 +125,8 @@ impl EventHandler for PromptModal {
 }
 
 impl Draw for PromptModal {
-    fn draw(&self, frame: &mut Frame, _: (), area: Rect) {
-        self.text_box.draw(frame, (), area);
+    fn draw(&self, frame: &mut Frame, _: (), metadata: DrawMetadata) {
+        self.text_box.draw(frame, (), metadata.area(), true);
     }
 }
 
@@ -208,8 +208,8 @@ impl EventHandler for ConfirmModal {
 }
 
 impl Draw for ConfirmModal {
-    fn draw(&self, frame: &mut Frame, _: (), area: Rect) {
-        self.buttons.draw(frame, (), area);
+    fn draw(&self, frame: &mut Frame, _: (), metadata: DrawMetadata) {
+        self.buttons.draw(frame, (), metadata.area(), true);
     }
 }
 
@@ -234,7 +234,10 @@ impl NotificationText {
 }
 
 impl Draw for NotificationText {
-    fn draw(&self, frame: &mut Frame, _: (), area: Rect) {
-        frame.render_widget(Paragraph::new(self.notification.generate()), area);
+    fn draw(&self, frame: &mut Frame, _: (), metadata: DrawMetadata) {
+        frame.render_widget(
+            Paragraph::new(self.notification.generate()),
+            metadata.area(),
+        );
     }
 }

--- a/src/tui/view/state/fixed_select.rs
+++ b/src/tui/view/state/fixed_select.rs
@@ -1,7 +1,7 @@
 use crate::tui::{
     message::MessageSender,
     view::{
-        draw::Draw,
+        draw::{Draw, DrawMetadata},
         event::{Event, EventHandler, Update},
         state::{
             persistence::{Persistable, PersistentContainer},
@@ -11,7 +11,6 @@ use crate::tui::{
 };
 use itertools::Itertools;
 use ratatui::{
-    layout::Rect,
     widgets::{ListState, StatefulWidget},
     Frame,
 };
@@ -172,8 +171,8 @@ where
     State: SelectStateData,
     W: StatefulWidget<State = State>,
 {
-    fn draw(&self, frame: &mut Frame, props: W, area: Rect) {
-        self.select.draw(frame, props, area);
+    fn draw(&self, frame: &mut Frame, props: W, metadata: DrawMetadata) {
+        self.select.draw(frame, props, metadata);
     }
 }
 

--- a/src/tui/view/state/select.rs
+++ b/src/tui/view/state/select.rs
@@ -2,13 +2,12 @@ use crate::tui::{
     input::Action,
     message::MessageSender,
     view::{
-        draw::Draw,
+        draw::{Draw, DrawMetadata},
         event::{Event, EventHandler, Update},
         state::persistence::{Persistable, PersistentContainer},
     },
 };
 use ratatui::{
-    layout::Rect,
     widgets::{ListState, StatefulWidget, TableState},
     Frame,
 };
@@ -269,8 +268,12 @@ where
     State: SelectStateData,
     W: StatefulWidget<State = State>,
 {
-    fn draw(&self, frame: &mut Frame, props: W, area: Rect) {
-        frame.render_stateful_widget(props, area, &mut self.state.borrow_mut());
+    fn draw(&self, frame: &mut Frame, props: W, metadata: DrawMetadata) {
+        frame.render_stateful_widget(
+            props,
+            metadata.area(),
+            &mut self.state.borrow_mut(),
+        );
     }
 }
 

--- a/src/tui/view/theme.rs
+++ b/src/tui/view/theme.rs
@@ -148,8 +148,8 @@ pub struct PaneStyles {
 
 impl PaneStyles {
     /// Get the type and style of the border for a pane
-    pub fn border(&self, is_focused: bool) -> (BorderType, Style) {
-        if is_focused {
+    pub fn border(&self, has_focus: bool) -> (BorderType, Style) {
+        if has_focus {
             (self.border_type_selected, self.border_selected)
         } else {
             (self.border_type, self.border)


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Automatically track which components are drawn, so we can automatically filter out events from hidden components. This means individual components don't have to duplicate logic that decides whether a component should receive events. If it's visible, it receives events. If not, it doesn't.

Also, mouse events are now sent to unfocused components. This means you can scroll on things out of focus if your mouse is over it. It'll also make it easier to implement list item selection in the future.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

This changes underlying logic in the view, so there's totally the potential to change event/visbility behavior. Some of that is intentional but there may be bugs. Mitigated via manual testing (I'm going to use this for a few days and see if I notice anything wrong).

## QA

_How did you test this?_

Added one unit test, also ongoing manual testing.

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
