### PR TITLE
FIx flaky file tests

### DIFF
--- a/src/collection.rs
+++ b/src/collection.rs
@@ -179,7 +179,7 @@ mod tests {
     #[case::parent_and_child(None, true, true, "child/slumber.yml")]
     #[case::overriden(Some("override.yml"), true, true, "child/override.yml")]
     fn test_try_path(
-        temp_dir: PathBuf,
+        temp_dir: TempDir,
         #[case] override_file: Option<&str>,
         #[case] has_parent: bool,
         #[case] has_child: bool,
@@ -209,10 +209,11 @@ mod tests {
     /// Test that try_path fails when no collection file is found and no
     /// override is given
     #[rstest]
-    fn test_try_path_error(temp_dir: PathBuf) {
+    fn test_try_path_error(temp_dir: TempDir) {
         assert_err!(
-            CollectionFile::try_path(Some(temp_dir), None),
+            CollectionFile::try_path(Some(temp_dir.to_path_buf()), None),
             "No collection file found in current or ancestor directories"
         );
+        drop(temp_dir); // Dropping deletes the directory
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -422,12 +422,10 @@ impl CollectionDatabase {
     }
 }
 
-/// Test-only helpers
+/// Create an in-memory DB, only for testing
 #[cfg(test)]
-impl Database {
-    /// Create an in-memory DB, only for testing
-    pub fn testing() -> Self {
-        // TODO turn into factory impl
+impl crate::test_util::Factory for Database {
+    fn factory() -> Self {
         let mut connection = Connection::open_in_memory().unwrap();
         Self::migrate(&mut connection).unwrap();
         Self {
@@ -436,13 +434,11 @@ impl Database {
     }
 }
 
-/// Test-only helpers
+/// Create an in-memory DB, only for testing
 #[cfg(test)]
-impl CollectionDatabase {
-    /// Create an in-memory DB, only for testing
-    pub fn testing() -> Self {
-        // TODO turn into factory impl
-        Database::testing()
+impl crate::test_util::Factory for CollectionDatabase {
+    fn factory() -> Self {
+        Database::factory()
             .into_collection(Path::new("./slumber.yml"))
             .expect("Error initializing DB collection")
     }
@@ -577,7 +573,7 @@ mod tests {
 
     #[test]
     fn test_merge() {
-        let database = Database::testing();
+        let database = Database::factory();
         let path1 = Path::new("slumber.yml");
         let path2 = Path::new("README.md"); // Has to be a real file
         let collection1 = database.clone().into_collection(path1).unwrap();
@@ -646,7 +642,7 @@ mod tests {
     /// Test request storage and retrieval
     #[test]
     fn test_request() {
-        let database = Database::testing();
+        let database = Database::factory();
         let collection1 = database
             .clone()
             .into_collection(Path::new("slumber.yml"))
@@ -729,7 +725,7 @@ mod tests {
     /// Test UI state storage and retrieval
     #[test]
     fn test_ui_state() {
-        let database = Database::testing();
+        let database = Database::factory();
         let collection1 = database
             .clone()
             .into_collection(Path::new("slumber.yml"))

--- a/src/template.rs
+++ b/src/template.rs
@@ -731,10 +731,10 @@ mod tests {
     }
 
     /// Test success with chained file
+    #[rstest]
     #[tokio::test]
-    async fn test_chain_file() {
+    async fn test_chain_file(temp_dir: TempDir) {
         // Create a temp file that we'll read from
-        let temp_dir = env::temp_dir();
         let path = temp_dir.join("stuff.txt");
         fs::write(&path, "hello!").await.unwrap();
         // Sanity check to debug race condition
@@ -742,7 +742,7 @@ mod tests {
         let path: Template = path.to_str().unwrap().into();
 
         let chain = Chain {
-            source: ChainSource::File { path },
+            source: ChainSource::File { path: path.clone() },
             ..Chain::factory()
         };
         let context = TemplateContext {
@@ -753,7 +753,11 @@ mod tests {
             ..TemplateContext::factory()
         };
 
-        assert_eq!(render!("{{chains.chain1}}", context).unwrap(), "hello!");
+        assert_eq!(
+            render!("{{chains.chain1}}", context).unwrap(),
+            "hello!",
+            "{path:?}"
+        );
     }
 
     /// Test failure with chained file
@@ -866,10 +870,10 @@ mod tests {
     /// Test linking two chains together. This example is contribed because the
     /// command could just read the file itself, but don't worry about it it's
     /// just a test.
+    #[rstest]
     #[tokio::test]
-    async fn test_chain_nested() {
+    async fn test_chain_nested(temp_dir: TempDir) {
         // Chain 1 - file
-        let temp_dir = env::temp_dir();
         let path = temp_dir.join("stuff.txt");
         fs::write(&path, "hello!").await.unwrap();
         let path: Template = path.to_str().unwrap().into();

--- a/src/template.rs
+++ b/src/template.rs
@@ -336,7 +336,7 @@ mod tests {
         #[case] expected_value: &str,
     ) {
         let recipe_id: RecipeId = "recipe1".into();
-        let database = CollectionDatabase::testing();
+        let database = CollectionDatabase::factory();
         let response_body = json!({
             "string": "Hello World!",
             "number": 6,
@@ -527,7 +527,7 @@ mod tests {
         #[case] record: Option<RequestRecord>,
         #[case] expected_error: &str,
     ) {
-        let database = CollectionDatabase::testing();
+        let database = CollectionDatabase::factory();
 
         let mut recipes = IndexMap::new();
         if let Some(recipe_id) = recipe_id {
@@ -584,7 +584,7 @@ mod tests {
         // Optional request data to store in the database
         #[case] record: Option<RequestRecord>,
     ) {
-        let database = CollectionDatabase::testing();
+        let database = CollectionDatabase::factory();
 
         // Set up DB
         if let Some(record) = record {

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -136,7 +136,7 @@ impl Factory for TemplateContext {
             collection: Collection::default(),
             selected_profile: None,
             http_engine: None,
-            database: CollectionDatabase::testing(),
+            database: CollectionDatabase::factory(),
             overrides: IndexMap::new(),
             prompter: Box::<TestPrompter>::default(),
             recursion_count: 0.into(),
@@ -170,7 +170,7 @@ pub fn terminal() -> Terminal<TestBackend> {
 #[rstest::fixture]
 #[once]
 pub fn tui_context() {
-    TuiContext::init(Config::default(), CollectionDatabase::testing());
+    TuiContext::init(Config::default(), CollectionDatabase::factory());
 }
 
 #[rstest::fixture]


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

- `test_chain_file` was flaky because it wasn't using the generated temp dir, so it was fighting over the file I _think_
- `test_save_file` was failing because we weren't flushing the written bytes of the file, so sometimes it got to the assertion before the write was done

I ran the full test suite ~4k times without failure so I think this is good. Previously it would fail every 50-200 runs.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Tests could still be flaky.

## QA

_How did you test this?_

Ran test suite 4483 times.

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
