### PR TITLE
Add request history modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Request history is now browsable! [#55](https://github.com/LucasPickering/slumber/issues/55)
+
 ### Changed
 
 - Merge request & response panes

--- a/docs/src/api/configuration/input_bindings.md
+++ b/docs/src/api/configuration/input_bindings.md
@@ -53,6 +53,7 @@ input_bindings:
 | `end`                 | `end`                       |
 | `submit`              | `enter`                     |
 | `cancel`              | `esc`                       |
+| `history`             | `h`                         |
 | `search`              | `/`                         |
 | `reload_collection`   | `f5`                        |
 | `fullscreen`          | `f`                         |

--- a/slumber.yml
+++ b/slumber.yml
@@ -91,4 +91,4 @@ requests:
     <<: *base
     name: Delay
     method: GET
-    url: "{{host}}/delay/1"
+    url: "{{host}}/delay/5"

--- a/src/cli/generate.rs
+++ b/src/cli/generate.rs
@@ -29,7 +29,7 @@ pub enum GenerateFormat {
 #[async_trait]
 impl Subcommand for GenerateCommand {
     async fn execute(self, global: GlobalArgs) -> anyhow::Result<ExitCode> {
-        let (_, request) = self
+        let (_, _, request) = self
             .build_request
             // User has to explicitly opt into executing triggered requests
             .build_request(global, self.execute_triggers)

--- a/src/collection/models.rs
+++ b/src/collection/models.rs
@@ -308,11 +308,6 @@ pub enum ChainOutputTrim {
 }
 
 impl Profile {
-    /// For combinators
-    pub fn id(&self) -> &ProfileId {
-        &self.id
-    }
-
     /// Get a presentable name for this profile
     pub fn name(&self) -> &str {
         self.name.as_deref().unwrap_or(&self.id)

--- a/src/collection/recipe_tree.rs
+++ b/src/collection/recipe_tree.rs
@@ -1,7 +1,7 @@
 //! Recipe/folder tree structure
 
 use crate::collection::{cereal::deserialize_id_map, Folder, Recipe, RecipeId};
-use derive_more::{Debug, From};
+use derive_more::From;
 use indexmap::{map::Values, IndexMap};
 use serde::{de::Error, Deserialize, Deserializer, Serialize};
 
@@ -11,7 +11,7 @@ use serde::{de::Error, Deserialize, Deserializer, Serialize};
 /// recipes. This is a mild restriction on the user that makes implementing a
 /// lot simpler. In reality it's unlikely they would want to give two things
 /// the same ID anyway.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, derive_more::Debug, Default)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct RecipeTree {
     /// Tree structure storing all the folder/recipe data
@@ -274,7 +274,7 @@ mod tests {
     #[fixture]
     fn tree() -> IndexMap<RecipeId, RecipeNode> {
         indexmap! {
-            id("r1") => Recipe { id: id("r1"), ..Recipe::factory() }.into(),
+            id("r1") => Recipe { id: id("r1"), ..Recipe::factory(()) }.into(),
             id("f1") => Folder {
                 id: id("f1"),
                 children: indexmap! {
@@ -283,17 +283,17 @@ mod tests {
                         children: indexmap! {
                             id("r2") => Recipe {
                                 id: id("r2"),
-                                ..Recipe::factory()
+                                ..Recipe::factory(())
                             }.into(),
                         },
-                        ..Folder::factory()
+                        ..Folder::factory(())
                     }.into(),
-                    id("r3") => Recipe { id: id("r3"), ..Recipe::factory() }.into(),
+                    id("r3") => Recipe { id: id("r3"), ..Recipe::factory(()) }.into(),
                 },
-                ..Folder::factory()
+                ..Folder::factory(())
             }
             .into(),
-            id("r4") => Recipe { id: id("r4"), ..Recipe::factory() }.into(),
+            id("r4") => Recipe { id: id("r4"), ..Recipe::factory(()) }.into(),
         }
     }
 

--- a/src/http/content_type.rs
+++ b/src/http/content_type.rs
@@ -243,7 +243,7 @@ mod tests {
         let response = Response {
             headers: headers(content_type),
             body: body.into(),
-            ..Response::factory()
+            ..Response::factory(())
         };
         assert_eq!(
             ContentType::parse_response(&response)
@@ -285,7 +285,7 @@ mod tests {
         let response = Response {
             headers,
             body: body.into(),
-            ..Response::factory()
+            ..Response::factory(())
         };
         assert_err!(ContentType::parse_response(&response), expected_error);
     }

--- a/src/template.rs
+++ b/src/template.rs
@@ -210,22 +210,22 @@ mod tests {
         };
         let profile = Profile {
             data: profile_data,
-            ..Profile::factory()
+            ..Profile::factory(())
         };
         let profile_id = profile.id.clone();
         let chain = Chain {
             source,
-            ..Chain::factory()
+            ..Chain::factory(())
         };
         let context = TemplateContext {
             collection: Collection {
                 profiles: indexmap! {profile_id.clone() => profile},
                 chains: indexmap! {chain.id.clone() => chain},
-                ..Collection::factory()
+                ..Collection::factory(())
             },
             selected_profile: Some(profile_id),
             overrides,
-            ..TemplateContext::factory()
+            ..TemplateContext::factory(())
         };
 
         assert_eq!(
@@ -258,16 +258,16 @@ mod tests {
         };
         let profile = Profile {
             data: profile_data,
-            ..Profile::factory()
+            ..Profile::factory(())
         };
         let profile_id = profile.id.clone();
         let context = TemplateContext {
             collection: Collection {
                 profiles: indexmap! {profile_id.clone() => profile},
-                ..Collection::factory()
+                ..Collection::factory(())
             },
             selected_profile: Some(profile_id),
-            ..TemplateContext::factory()
+            ..TemplateContext::factory(())
         };
 
         assert_eq!(&render!("", context).unwrap(), "");
@@ -302,16 +302,16 @@ mod tests {
         };
         let profile = Profile {
             data: profile_data,
-            ..Profile::factory()
+            ..Profile::factory(())
         };
         let profile_id = profile.id.clone();
         let context = TemplateContext {
             collection: Collection {
                 profiles: indexmap! {profile_id.clone() => profile},
-                ..Collection::factory()
+                ..Collection::factory(())
             },
             selected_profile: Some(profile_id),
-            ..TemplateContext::factory()
+            ..TemplateContext::factory(())
         };
         assert_err!(render!(template, context), expected);
     }
@@ -336,7 +336,7 @@ mod tests {
         #[case] expected_value: &str,
     ) {
         let recipe_id: RecipeId = "recipe1".into();
-        let database = CollectionDatabase::factory();
+        let database = CollectionDatabase::factory(());
         let response_body = json!({
             "string": "Hello World!",
             "number": 6,
@@ -348,24 +348,24 @@ mod tests {
             header_map(indexmap! {"Token" => "Secret Value"});
         let request = Request {
             recipe_id: recipe_id.clone(),
-            ..Request::factory()
+            ..Request::factory(())
         };
         let response = Response {
             body: response_body.to_string().into(),
             headers: response_headers,
-            ..Response::factory()
+            ..Response::factory(())
         };
         database
             .insert_request(&RequestRecord {
                 request: request.into(),
                 response: response.into(),
-                ..RequestRecord::factory()
+                ..RequestRecord::factory(())
             })
             .unwrap();
         let selector = selector.map(|s| s.parse().unwrap());
         let recipe = Recipe {
             id: recipe_id.clone(),
-            ..Recipe::factory()
+            ..Recipe::factory(())
         };
         let chain = Chain {
             source: ChainSource::Request {
@@ -375,16 +375,16 @@ mod tests {
             },
             selector,
             content_type: Some(ContentType::Json),
-            ..Chain::factory()
+            ..Chain::factory(())
         };
         let context = TemplateContext {
             collection: Collection {
                 recipes: indexmap! {recipe.id.clone() => recipe}.into(),
                 chains: indexmap! {chain.id.clone() => chain},
-                ..Collection::factory()
+                ..Collection::factory(())
             },
             database,
-            ..TemplateContext::factory()
+            ..TemplateContext::factory(())
         };
 
         assert_eq!(
@@ -399,7 +399,7 @@ mod tests {
     // Referenced a chain that doesn't exist
     #[case::unknown_chain(
         "unknown",
-        Chain::factory(),
+        Chain::factory(()),
         None,
         None,
         "Unknown chain"
@@ -413,7 +413,7 @@ mod tests {
                 trigger: Default::default(),
                 section: Default::default(),
             },
-            ..Chain::factory()
+            ..Chain::factory(())
         },
         None,
         None,
@@ -428,7 +428,7 @@ mod tests {
                 trigger: Default::default(),
                 section: Default::default(),
             },
-            ..Chain::factory()
+            ..Chain::factory(())
         },
         Some("recipe1"),
         None,
@@ -443,7 +443,7 @@ mod tests {
                 trigger: ChainRequestTrigger::Always,
                 section: Default::default(),
             },
-            ..Chain::factory()
+            ..Chain::factory(())
         },
         Some("recipe1"),
         None,
@@ -459,15 +459,15 @@ mod tests {
                 section: Default::default(),
             },
             selector: Some("$.message".parse().unwrap()),
-            ..Chain::factory()
+            ..Chain::factory(())
         },
         Some("recipe1"),
         Some(RequestRecord {
             response: Response {
                 body: "not json!".into(),
-                ..Response::factory()
+                ..Response::factory(())
             }.into(),
-            ..RequestRecord::factory()
+            ..RequestRecord::factory(())
         }),
         "content type not provided",
     )]
@@ -482,15 +482,15 @@ mod tests {
             },
             selector: Some("$.message".parse().unwrap()),
             content_type: Some(ContentType::Json),
-            ..Chain::factory()
+            ..Chain::factory(())
         },
         Some("recipe1"),
         Some(RequestRecord {
             response: Response {
                 body: "not json!".into(),
-                ..Response::factory()
+                ..Response::factory(())
             }.into(),
-            ..RequestRecord::factory()
+            ..RequestRecord::factory(())
         }),
         "Parsing response: expected ident at line 1 column 2",
     )]
@@ -505,15 +505,15 @@ mod tests {
             },
             selector: Some("$.*".parse().unwrap()),
             content_type: Some(ContentType::Json),
-            ..Chain::factory()
+            ..Chain::factory(())
         },
         Some("recipe1"),
         Some(RequestRecord {
             response: Response {
                 body: "[1, 2]".into(),
-                ..Response::factory()
+                ..Response::factory(())
             }.into(),
-            ..RequestRecord::factory()
+            ..RequestRecord::factory(())
         }),
         "Expected exactly one result",
     )]
@@ -527,7 +527,7 @@ mod tests {
         #[case] record: Option<RequestRecord>,
         #[case] expected_error: &str,
     ) {
-        let database = CollectionDatabase::factory();
+        let database = CollectionDatabase::factory(());
 
         let mut recipes = IndexMap::new();
         if let Some(recipe_id) = recipe_id {
@@ -536,7 +536,7 @@ mod tests {
                 recipe_id.clone(),
                 Recipe {
                     id: recipe_id,
-                    ..Recipe::factory()
+                    ..Recipe::factory(())
                 },
             );
         }
@@ -551,10 +551,10 @@ mod tests {
             collection: Collection {
                 recipes: recipes.into(),
                 chains,
-                ..Collection::factory()
+                ..Collection::factory(())
             },
             database,
-            ..TemplateContext::factory()
+            ..TemplateContext::factory(())
         };
 
         assert_err!(render!("{{chains.chain1}}", context), expected_error);
@@ -571,12 +571,12 @@ mod tests {
         ChainRequestTrigger::Expire(Duration::from_secs(60)),
         Some(RequestRecord {
             end_time: Utc::now() - Duration::from_secs(100),
-            ..RequestRecord::factory()})
+            ..RequestRecord::factory(())})
     )]
     #[case::always_no_history(ChainRequestTrigger::Always, None)]
     #[case::always_with_history(
         ChainRequestTrigger::Always,
-        Some(RequestRecord::factory())
+        Some(RequestRecord::factory(()))
     )]
     #[tokio::test]
     async fn test_triggered_request(
@@ -584,7 +584,7 @@ mod tests {
         // Optional request data to store in the database
         #[case] record: Option<RequestRecord>,
     ) {
-        let database = CollectionDatabase::factory();
+        let database = CollectionDatabase::factory(());
 
         // Set up DB
         if let Some(record) = record {
@@ -603,7 +603,7 @@ mod tests {
 
         let recipe = Recipe {
             url: format!("{url}/get").as_str().into(),
-            ..Recipe::factory()
+            ..Recipe::factory(())
         };
         let chain = Chain {
             source: ChainSource::Request {
@@ -611,18 +611,18 @@ mod tests {
                 trigger,
                 section: Default::default(),
             },
-            ..Chain::factory()
+            ..Chain::factory(())
         };
-        let http_engine = HttpEngine::new(&Config::default(), database.clone());
+        let http_engine = HttpEngine::new(&Config::default());
         let context = TemplateContext {
             collection: Collection {
                 recipes: indexmap! {recipe.id.clone() => recipe}.into(),
                 chains: indexmap! {chain.id.clone() => chain},
-                ..Collection::factory()
+                ..Collection::factory(())
             },
             http_engine: Some(http_engine),
             database,
-            ..TemplateContext::factory()
+            ..TemplateContext::factory(())
         };
 
         assert_eq!(render!("{{chains.chain1}}", context).unwrap(), "hello!");
@@ -646,14 +646,14 @@ mod tests {
         };
         let chain = Chain {
             source,
-            ..Chain::factory()
+            ..Chain::factory(())
         };
         let context = TemplateContext {
             collection: Collection {
                 chains: indexmap! {chain.id.clone() => chain},
-                ..Collection::factory()
+                ..Collection::factory(())
             },
-            ..TemplateContext::factory()
+            ..TemplateContext::factory(())
         };
 
         assert_eq!(render!("{{chains.chain1}}", context).unwrap(), expected);
@@ -677,14 +677,14 @@ mod tests {
                 stdin: None,
             },
             trim,
-            ..Chain::factory()
+            ..Chain::factory(())
         };
         let context = TemplateContext {
             collection: Collection {
                 chains: indexmap! {chain.id.clone() => chain},
-                ..Collection::factory()
+                ..Collection::factory(())
             },
-            ..TemplateContext::factory()
+            ..TemplateContext::factory(())
         };
 
         assert_eq!(render!("{{chains.chain1}}", context).unwrap(), expected);
@@ -717,14 +717,14 @@ mod tests {
         };
         let chain = Chain {
             source,
-            ..Chain::factory()
+            ..Chain::factory(())
         };
         let context = TemplateContext {
             collection: Collection {
                 chains: indexmap! {chain.id.clone() => chain},
-                ..Collection::factory()
+                ..Collection::factory(())
             },
-            ..TemplateContext::factory()
+            ..TemplateContext::factory(())
         };
 
         assert_err!(render!("{{chains.chain1}}", context), expected_error);
@@ -743,14 +743,14 @@ mod tests {
 
         let chain = Chain {
             source: ChainSource::File { path: path.clone() },
-            ..Chain::factory()
+            ..Chain::factory(())
         };
         let context = TemplateContext {
             collection: Collection {
                 chains: indexmap! {chain.id.clone() => chain},
-                ..Collection::factory()
+                ..Collection::factory(())
             },
-            ..TemplateContext::factory()
+            ..TemplateContext::factory(())
         };
 
         assert_eq!(
@@ -767,14 +767,14 @@ mod tests {
             source: ChainSource::File {
                 path: "not-real".into(),
             },
-            ..Chain::factory()
+            ..Chain::factory(())
         };
         let context = TemplateContext {
             collection: Collection {
                 chains: indexmap! {chain.id.clone() => chain},
-                ..Collection::factory()
+                ..Collection::factory(())
             },
-            ..TemplateContext::factory()
+            ..TemplateContext::factory(())
         };
 
         assert_err!(
@@ -790,18 +790,18 @@ mod tests {
                 message: Some("password".into()),
                 default: Some("default".into()),
             },
-            ..Chain::factory()
+            ..Chain::factory(())
         };
 
         // Test value from prompter
         let mut context = TemplateContext {
             collection: Collection {
                 chains: indexmap! {chain.id.clone() => chain},
-                ..Collection::factory()
+                ..Collection::factory(())
             },
 
             prompter: Box::new(TestPrompter::new(Some("hello!"))),
-            ..TemplateContext::factory()
+            ..TemplateContext::factory(())
         };
         assert_eq!(render!("{{chains.chain1}}", context).unwrap(), "hello!");
 
@@ -818,16 +818,16 @@ mod tests {
                 message: Some("password".into()),
                 default: None,
             },
-            ..Chain::factory()
+            ..Chain::factory(())
         };
         let context = TemplateContext {
             collection: Collection {
                 chains: indexmap! {chain.id.clone() => chain},
-                ..Collection::factory()
+                ..Collection::factory(())
             },
             // Prompter gives no response
             prompter: Box::new(TestPrompter::new::<String>(None)),
-            ..TemplateContext::factory()
+            ..TemplateContext::factory(())
         };
 
         assert_err!(
@@ -845,16 +845,16 @@ mod tests {
                 default: None,
             },
             sensitive: true,
-            ..Chain::factory()
+            ..Chain::factory(())
         };
         let context = TemplateContext {
             collection: Collection {
                 chains: indexmap! {chain.id.clone() => chain},
-                ..Collection::factory()
+                ..Collection::factory(())
             },
             // Prompter gives no response
             prompter: Box::new(TestPrompter::new(Some("hello!"))),
-            ..TemplateContext::factory()
+            ..TemplateContext::factory(())
         };
         assert_eq!(
             Template::from("{{chains.chain1}}")
@@ -880,7 +880,7 @@ mod tests {
         let file_chain = Chain {
             id: "file".into(),
             source: ChainSource::File { path },
-            ..Chain::factory()
+            ..Chain::factory(())
         };
 
         // Chain 2 - command
@@ -892,7 +892,7 @@ mod tests {
                 command,
                 stdin: None,
             },
-            ..Chain::factory()
+            ..Chain::factory(())
         };
 
         let context = TemplateContext {
@@ -901,9 +901,9 @@ mod tests {
                     file_chain.id.clone() => file_chain,
                     command_chain.id.clone() => command_chain,
                 },
-                ..Collection::factory()
+                ..Collection::factory(())
             },
-            ..TemplateContext::factory()
+            ..TemplateContext::factory(())
         };
         assert_eq!(
             render!("{{chains.command}}", context).unwrap(),
@@ -921,7 +921,7 @@ mod tests {
                 path: "bogus.txt".into(),
             },
 
-            ..Chain::factory()
+            ..Chain::factory(())
         };
 
         // Chain 2 - command
@@ -933,7 +933,7 @@ mod tests {
                 command,
                 stdin: None,
             },
-            ..Chain::factory()
+            ..Chain::factory(())
         };
 
         let context = TemplateContext {
@@ -942,9 +942,9 @@ mod tests {
                     file_chain.id.clone() => file_chain,
                     command_chain.id.clone() => command_chain,
                 },
-                ..Collection::factory()
+                ..Collection::factory(())
             },
-            ..TemplateContext::factory()
+            ..TemplateContext::factory(())
         };
         assert_err!(
             render!("{{chains.command}}", context),
@@ -956,14 +956,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_environment_success() {
-        let context = TemplateContext::factory();
+        let context = TemplateContext::factory(());
         env::set_var("TEST", "test!");
         assert_eq!(render!("{{env.TEST}}", context).unwrap(), "test!");
     }
 
     #[tokio::test]
     async fn test_environment_error() {
-        let context = TemplateContext::factory();
+        let context = TemplateContext::factory(());
         assert_err!(
             render!("{{env.UNKNOWN}}", context),
             "Accessing environment variable `UNKNOWN`"
@@ -976,16 +976,16 @@ mod tests {
         let profile_data = indexmap! { "user_id".into() => "🧡💛".into() };
         let profile = Profile {
             data: profile_data,
-            ..Profile::factory()
+            ..Profile::factory(())
         };
         let profile_id = profile.id.clone();
         let context = TemplateContext {
             collection: Collection {
                 profiles: indexmap! {profile_id.clone() => profile},
-                ..Collection::factory()
+                ..Collection::factory(())
             },
             selected_profile: Some(profile_id),
-            ..TemplateContext::factory()
+            ..TemplateContext::factory(())
         };
 
         let chunks =

--- a/src/template/render.rs
+++ b/src/template/render.rs
@@ -367,7 +367,7 @@ impl<'a> ChainTemplateSource<'a> {
             || -> Result<Option<RequestRecord>, ChainError> {
                 context
                     .database
-                    .get_last_request(
+                    .get_latest_request(
                         context.selected_profile.as_ref(),
                         recipe_id,
                     )
@@ -399,7 +399,7 @@ impl<'a> ChainTemplateSource<'a> {
                     .http_engine
                     .clone()
                     .ok_or(TriggeredRequestError::NotAllowed)?
-                    .send(Arc::new(request))
+                    .send(&context.database, Arc::new(request))
                     .await
                     .map_err(TriggeredRequestError::Send)
             };

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -211,6 +211,7 @@ impl Default for InputEngine {
                 Action::OpenHelp => KeyCode::Char('?').into(),
                 Action::Fullscreen => KeyCode::Char('f').into(),
                 Action::ReloadCollection => KeyCode::F(5).into(),
+                Action::History => KeyCode::Char('h').into(),
                 Action::Search => KeyCode::Char('/').into(),
                 Action::PreviousPane => KeyCode::BackTab.into(),
                 Action::NextPane => KeyCode::Tab.into(),
@@ -290,6 +291,8 @@ pub enum Action {
     Submit,
     /// Close the current modal/dialog/etc.
     Cancel,
+    /// Browse request history
+    History,
     /// Start a search/filter operation
     #[display("Search/Filter")]
     Search,

--- a/src/tui/message.rs
+++ b/src/tui/message.rs
@@ -17,8 +17,8 @@ use tokio::sync::mpsc::UnboundedSender;
 use tracing::trace;
 
 /// Wrapper around a sender for async messages. Cheap to clone and pass around
-#[derive(Clone, derive_more::Debug, From)]
-pub struct MessageSender(#[debug(skip)] UnboundedSender<Message>);
+#[derive(Clone, Debug, From)]
+pub struct MessageSender(UnboundedSender<Message>);
 
 impl MessageSender {
     pub fn new(sender: UnboundedSender<Message>) -> Self {
@@ -78,17 +78,9 @@ pub enum Message {
     /// Launch an HTTP request from the given recipe/profile.
     HttpBeginRequest(RequestConfig),
     /// Request failed to build
-    HttpBuildError {
-        profile_id: Option<ProfileId>,
-        recipe_id: RecipeId,
-        error: RequestBuildError,
-    },
+    HttpBuildError { error: RequestBuildError },
     /// We launched the HTTP request
-    HttpLoading {
-        profile_id: Option<ProfileId>,
-        recipe_id: RecipeId,
-        request: Arc<Request>,
-    },
+    HttpLoading { request: Arc<Request> },
     /// The HTTP request either succeeded or failed. We don't need to store the
     /// recipe ID here because it's in the inner container already. Combining
     /// these two cases saves a bit of boilerplate.

--- a/src/tui/view/common/actions.rs
+++ b/src/tui/view/common/actions.rs
@@ -3,13 +3,19 @@ use crate::{
         common::{list::List, modal::Modal},
         component::Component,
         draw::{Draw, DrawMetadata, Generate, ToStringGenerate},
-        event::{Event, EventHandler, EventQueue},
+        event::{Event, EventHandler},
         state::fixed_select::{FixedSelectState, FixedSelectWithoutDefault},
+        ViewContext,
     },
     util::EnumChain,
 };
 use derive_more::Display;
-use ratatui::{layout::Constraint, text::Span, widgets::ListState, Frame};
+use ratatui::{
+    layout::Constraint,
+    text::{Line, Span},
+    widgets::ListState,
+    Frame,
+};
 use strum::{EnumCount, EnumIter};
 
 /// Modal to list and trigger arbitrary actions. The list of available actions
@@ -25,12 +31,12 @@ impl<T: FixedSelectWithoutDefault> Default for ActionsModal<T> {
         let on_submit = move |action: &mut EnumChain<GlobalAction, T>| {
             // Close the modal *first*, so the parent can handle the
             // callback event. Jank but it works
-            EventQueue::push(Event::CloseModal);
+            ViewContext::push_event(Event::CloseModal);
             let event = match action {
                 EnumChain::T(action) => Event::new_other(*action),
                 EnumChain::U(action) => Event::new_other(*action),
             };
-            EventQueue::push(event);
+            ViewContext::push_event(event);
         };
 
         Self {
@@ -47,8 +53,8 @@ where
     T: FixedSelectWithoutDefault,
     ActionsModal<T>: Draw,
 {
-    fn title(&self) -> &str {
-        "Actions"
+    fn title(&self) -> Line<'_> {
+        "Actions".into()
     }
 
     fn dimensions(&self) -> (Constraint, Constraint) {

--- a/src/tui/view/common/button.rs
+++ b/src/tui/view/common/button.rs
@@ -3,11 +3,11 @@
 use crate::tui::{
     context::TuiContext,
     input::Action,
-    message::MessageSender,
     view::{
         draw::{Draw, DrawMetadata, Generate},
-        event::{Event, EventHandler, EventQueue, Update},
+        event::{Event, EventHandler, Update},
         state::fixed_select::{FixedSelect, FixedSelectState},
+        ViewContext,
     },
 };
 use ratatui::{
@@ -48,13 +48,13 @@ impl<'a> Generate for Button<'a> {
 /// A collection of buttons. User can cycle between buttons and hit enter to
 /// activate one. When a button is activated, it will emit a dynamic event with
 /// type `T`.
-#[derive(derive_more::Debug, Default)]
+#[derive(Debug, Default)]
 pub struct ButtonGroup<T: FixedSelect> {
     select: FixedSelectState<T>,
 }
 
 impl<T: FixedSelect> EventHandler for ButtonGroup<T> {
-    fn update(&mut self, _: &MessageSender, event: Event) -> Update {
+    fn update(&mut self, event: Event) -> Update {
         let Some(action) = event.action() else {
             return Update::Propagate(event);
         };
@@ -63,7 +63,9 @@ impl<T: FixedSelect> EventHandler for ButtonGroup<T> {
             Action::Right => self.select.next(),
             Action::Submit => {
                 // Propagate the selected item as a dynamic event
-                EventQueue::push(Event::new_other(*self.select.selected()));
+                ViewContext::push_event(Event::new_other(
+                    *self.select.selected(),
+                ));
             }
             _ => return Update::Propagate(event),
         }

--- a/src/tui/view/common/list.rs
+++ b/src/tui/view/common/list.rs
@@ -2,7 +2,7 @@ use crate::tui::{
     context::TuiContext,
     view::{common::Pane, draw::Generate},
 };
-use ratatui::{text::Span, widgets::ListItem};
+use ratatui::{text::Text, widgets::ListItem};
 
 /// A list with optional border and title. Each item has to be convertible to
 /// text
@@ -11,9 +11,10 @@ pub struct List<'a, Item, Iter: 'a + IntoIterator<Item = Item>> {
     pub list: Iter,
 }
 
-impl<'a, Item, Iter> Generate for List<'a, Item, Iter>
+impl<'a, T, Item, Iter> Generate for List<'a, Item, Iter>
 where
-    Item: 'a + Generate<Output<'a> = Span<'a>>,
+    T: Into<Text<'a>>,
+    Item: 'a + Generate<Output<'a> = T>,
     Iter: 'a + IntoIterator<Item = Item>,
 {
     type Output<'this> = ratatui::widgets::List<'this> where Self: 'this;

--- a/src/tui/view/common/modal.rs
+++ b/src/tui/view/common/modal.rs
@@ -1,7 +1,6 @@
 use crate::tui::{
     context::TuiContext,
     input::Action,
-    message::MessageSender,
     view::{
         draw::{Draw, DrawMetadata},
         event::{Event, EventHandler, Update},
@@ -11,6 +10,7 @@ use crate::tui::{
 };
 use ratatui::{
     prelude::Constraint,
+    text::Line,
     widgets::{Block, Borders, Clear},
     Frame,
 };
@@ -27,7 +27,7 @@ use tracing::trace;
 /// (none).
 pub trait Modal: Draw<()> + EventHandler {
     /// Text at the top of the modal
-    fn title(&self) -> &str;
+    fn title(&self) -> Line<'_>;
 
     /// Dimensions of the modal, relative to the whole screen
     fn dimensions(&self) -> (Constraint, Constraint);
@@ -94,7 +94,7 @@ impl ModalQueue {
 }
 
 impl EventHandler for ModalQueue {
-    fn update(&mut self, _: &MessageSender, event: Event) -> Update {
+    fn update(&mut self, event: Event) -> Update {
         match event {
             // Close the active modal. If there's no modal open, we'll propagate
             // the event down
@@ -168,8 +168,8 @@ impl Draw for ModalQueue {
 }
 
 impl EventHandler for Box<dyn Modal> {
-    fn update(&mut self, messages_tx: &MessageSender, event: Event) -> Update {
-        self.deref_mut().update(messages_tx, event)
+    fn update(&mut self, event: Event) -> Update {
+        self.deref_mut().update(event)
     }
 
     fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {

--- a/src/tui/view/common/tabs.rs
+++ b/src/tui/view/common/tabs.rs
@@ -1,7 +1,6 @@
 use crate::tui::{
     context::TuiContext,
     input::Action,
-    message::MessageSender,
     view::{
         draw::{Draw, DrawMetadata},
         event::{Event, EventHandler, Update},
@@ -42,7 +41,7 @@ impl<T> EventHandler for Tabs<T>
 where
     T: FixedSelect + Persistable<Persisted = T>,
 {
-    fn update(&mut self, _: &MessageSender, event: Event) -> Update {
+    fn update(&mut self, event: Event) -> Update {
         let Some(action) = event.action() else {
             return Update::Propagate(event);
         };

--- a/src/tui/view/common/template_preview.rs
+++ b/src/tui/view/common/template_preview.rs
@@ -3,8 +3,8 @@ use crate::{
     template::{Template, TemplateChunk},
     tui::{
         context::TuiContext,
-        message::{Message, MessageSender},
-        view::draw::Generate,
+        message::Message,
+        view::{draw::Generate, ViewContext},
     },
 };
 use ratatui::{
@@ -40,14 +40,10 @@ impl TemplatePreview {
     /// Create a new template preview. This will spawn a background task to
     /// render the template, *if* template preview is enabled. Profile ID
     /// defines which profile to use for the render.
-    pub fn new(
-        messages_tx: &MessageSender,
-        template: Template,
-        profile_id: Option<ProfileId>,
-    ) -> Self {
+    pub fn new(template: Template, profile_id: Option<ProfileId>) -> Self {
         if TuiContext::get().config.preview_templates {
             let chunks = Arc::new(OnceLock::new());
-            messages_tx.send(Message::TemplatePreview {
+            ViewContext::send_message(Message::TemplatePreview {
                 // If this is a bottleneck we can Arc it
                 template: template.clone(),
                 profile_id: profile_id.clone(),
@@ -223,17 +219,17 @@ mod tests {
         let profile_data = indexmap! { "user_id".into() => "🧡\n💛".into() };
         let profile = Profile {
             data: profile_data,
-            ..Profile::factory()
+            ..Profile::factory(())
         };
         let profile_id = profile.id.clone();
         let collection = Collection {
             profiles: indexmap! {profile_id.clone() => profile},
-            ..Collection::factory()
+            ..Collection::factory(())
         };
         let context = TemplateContext {
             collection,
             selected_profile: Some(profile_id),
-            ..TemplateContext::factory()
+            ..TemplateContext::factory(())
         };
         let chunks = template.render_chunks(&context).await;
         let styles = &tui_context.styles;

--- a/src/tui/view/common/text_box.rs
+++ b/src/tui/view/common/text_box.rs
@@ -3,7 +3,6 @@
 use crate::tui::{
     context::TuiContext,
     input::Action,
-    message::MessageSender,
     view::{
         draw::{Draw, DrawMetadata},
         event::{Event, EventHandler, Update},
@@ -189,7 +188,7 @@ impl TextBox {
 }
 
 impl EventHandler for TextBox {
-    fn update(&mut self, _: &MessageSender, event: Event) -> Update {
+    fn update(&mut self, event: Event) -> Update {
         match event {
             Event::Input {
                 action: Some(Action::Submit),

--- a/src/tui/view/common/text_window.rs
+++ b/src/tui/view/common/text_window.rs
@@ -1,7 +1,6 @@
 use crate::tui::{
     context::TuiContext,
     input::Action,
-    message::MessageSender,
     view::{
         draw::{Draw, DrawMetadata, Generate},
         event::{Event, EventHandler, Update},
@@ -22,9 +21,8 @@ use std::{cell::Cell, cmp, fmt::Debug};
 ///
 /// The generic parameter allows for any type that can be converted to ratatui's
 /// `Text`, e.g. `String` or `TemplatePreview`.
-#[derive(derive_more::Debug, Default)]
+#[derive(Debug, Default)]
 pub struct TextWindow<T> {
-    #[debug(skip)]
     text: T,
     offset_x: u16,
     offset_y: u16,
@@ -92,7 +90,7 @@ impl<T> TextWindow<T> {
 }
 
 impl<T: Debug> EventHandler for TextWindow<T> {
-    fn update(&mut self, _: &MessageSender, event: Event) -> Update {
+    fn update(&mut self, event: Event) -> Update {
         let Some(action) = event.action() else {
             return Update::Propagate(event);
         };

--- a/src/tui/view/component.rs
+++ b/src/tui/view/component.rs
@@ -1,4 +1,5 @@
 mod help;
+mod history;
 mod internal;
 mod misc;
 mod primary;

--- a/src/tui/view/component/help.rs
+++ b/src/tui/view/component/help.rs
@@ -5,6 +5,7 @@ use crate::{
         input::{Action, InputBinding},
         view::{
             common::{modal::Modal, table::Table},
+            context::ViewContext,
             draw::{Draw, DrawMetadata, Generate},
             event::EventHandler,
         },
@@ -68,8 +69,8 @@ impl HelpModal {
 }
 
 impl Modal for HelpModal {
-    fn title(&self) -> &str {
-        "Help"
+    fn title(&self) -> Line<'_> {
+        "Help".into()
     }
 
     fn dimensions(&self) -> (Constraint, Constraint) {
@@ -85,8 +86,6 @@ impl EventHandler for HelpModal {}
 
 impl Draw for HelpModal {
     fn draw(&self, frame: &mut Frame, _: (), metadata: DrawMetadata) {
-        let tui_context = TuiContext::get();
-
         // Create layout
         let [collection_area, _, keybindings_area] = Layout::vertical([
             Constraint::Length(Self::GENERAL_LENGTH + 1),
@@ -103,13 +102,12 @@ impl Draw for HelpModal {
                 ("Configuration", Line::from(Config::path().to_string())),
                 (
                     "Collection",
-                    Line::from(
-                        tui_context
-                            .database
+                    Line::from(ViewContext::with_database(|database| {
+                        database
                             .collection_path()
                             .map(|path| path.display().to_string())
-                            .unwrap_or_default(),
-                    ),
+                            .unwrap_or_default()
+                    })),
                 ),
             ]
             .into_iter()

--- a/src/tui/view/component/history.rs
+++ b/src/tui/view/component/history.rs
@@ -1,0 +1,119 @@
+use crate::{
+    collection::Recipe,
+    http::RequestId,
+    tui::{
+        context::TuiContext,
+        view::{
+            common::{list::List, modal::Modal},
+            component::Component,
+            draw::{Draw, DrawMetadata, Generate},
+            event::{Event, EventHandler},
+            state::{select::SelectState, RequestStateSummary},
+            ViewContext,
+        },
+    },
+};
+use ratatui::{
+    layout::Constraint,
+    text::{Line, Span},
+    Frame,
+};
+
+/// Browse request/response history for a recipe
+#[derive(Debug)]
+pub struct History {
+    recipe_name: String,
+    select: Component<SelectState<RequestStateSummary>>,
+}
+
+impl History {
+    /// Construct a new history modal with the given list of requests. Parent
+    /// is responsible for loading the list from the request store.
+    pub fn new(
+        recipe: &Recipe,
+        requests: Vec<RequestStateSummary>,
+        selected_request_id: Option<RequestId>,
+    ) -> Self {
+        let select = SelectState::builder(requests)
+            .preselect_opt(selected_request_id.as_ref())
+            // When an item is selected, load it up
+            .on_select(|record| {
+                ViewContext::push_event(Event::HttpSelectRequest(Some(
+                    record.id(),
+                )))
+            })
+            .build();
+
+        Self {
+            recipe_name: recipe.name().to_owned(),
+            select: select.into(),
+        }
+    }
+}
+
+impl Modal for History {
+    fn title(&self) -> Line<'_> {
+        vec![
+            "History for ".into(),
+            Span::styled(
+                self.recipe_name.as_str(),
+                TuiContext::get().styles.text.primary,
+            ),
+        ]
+        .into()
+    }
+
+    fn dimensions(&self) -> (Constraint, Constraint) {
+        (
+            Constraint::Length(40),
+            Constraint::Length(self.select.data().items().len().min(20) as u16),
+        )
+    }
+}
+
+impl EventHandler for History {
+    fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {
+        vec![self.select.as_child()]
+    }
+}
+
+impl Draw for History {
+    fn draw(&self, frame: &mut Frame, _: (), metadata: DrawMetadata) {
+        let list = List {
+            pane: None,
+            list: self.select.data().items(),
+        };
+        self.select
+            .draw(frame, list.generate(), metadata.area(), true);
+    }
+}
+
+impl Generate for &RequestStateSummary {
+    type Output<'this> = Line<'this> where Self: 'this;
+
+    fn generate<'this>(self) -> Self::Output<'this>
+    where
+        Self: 'this,
+    {
+        let styles = &TuiContext::get().styles;
+        let description: Span = match self {
+            RequestStateSummary::Building { .. } => "Initializing...".into(),
+            RequestStateSummary::BuildError { .. } => {
+                Span::styled("Build error", styles.text.error)
+            }
+            RequestStateSummary::Loading { .. } => "Loading...".into(),
+            RequestStateSummary::Response(record) => record.status.generate(),
+            RequestStateSummary::RequestError { .. } => {
+                Span::styled("Request error", styles.text.error)
+            }
+        };
+        vec![self.time().generate(), " ".into(), description].into()
+    }
+}
+
+/// Allow selection by ID
+impl PartialEq<RequestStateSummary> for RequestId {
+    fn eq(&self, other: &RequestStateSummary) -> bool {
+        self == &other.id()
+    }
+}

--- a/src/tui/view/component/recipe_list.rs
+++ b/src/tui/view/component/recipe_list.rs
@@ -3,17 +3,16 @@ use crate::{
     tui::{
         context::TuiContext,
         input::Action,
-        message::MessageSender,
         view::{
             common::Pane,
             component::primary::PrimaryPane,
             draw::{Draw, DrawMetadata, Generate},
-            event::{Event, EventHandler, EventQueue, Update},
+            event::{Event, EventHandler, Update},
             state::{
                 persistence::{Persistable, Persistent, PersistentKey},
                 select::SelectState,
             },
-            Component,
+            Component, ViewContext,
         },
     },
 };
@@ -130,13 +129,15 @@ impl RecipeListPane {
 }
 
 impl EventHandler for RecipeListPane {
-    fn update(&mut self, _: &MessageSender, event: Event) -> Update {
+    fn update(&mut self, event: Event) -> Update {
         let Some(action) = event.action() else {
             return Update::Propagate(event);
         };
         match action {
             Action::LeftClick => {
-                EventQueue::push(Event::new_other(PrimaryPane::RecipeList));
+                ViewContext::push_event(Event::new_other(
+                    PrimaryPane::RecipeList,
+                ));
             }
             Action::Left => {
                 self.set_selected_collapsed(CollapseState::Collapse);
@@ -267,7 +268,7 @@ fn build_select_state(
     // When highlighting a new recipe, load it from the repo
     fn on_select(_: &mut RecipeNode) {
         // If a recipe isn't selected, this will do nothing
-        EventQueue::push(Event::HttpLoadRequest);
+        ViewContext::push_event(Event::HttpSelectRequest(None));
     }
 
     let items = recipes

--- a/src/tui/view/context.rs
+++ b/src/tui/view/context.rs
@@ -1,0 +1,163 @@
+use crate::{
+    db::CollectionDatabase,
+    tui::{
+        message::{Message, MessageSender},
+        view::{
+            common::modal::Modal,
+            event::{Event, EventQueue},
+            ModalPriority,
+        },
+    },
+};
+use std::cell::RefCell;
+
+/// Thread-local context container, which stores mutable state needed in the
+/// view thread. Until [TuiContext](crate::tui::TuiContext), which stores
+/// read-only state, this state can be mutable because it's not shared between
+/// threads. Some pieces of this state *are* shared between threads, but that's
+/// because they are internally thread-safe.
+///
+/// The main purpose of this is to prevent an absurd amount of plumbing required
+/// to get all these individual pieces to every place they're needed in the
+/// view code. We're leaning heavily on the fact that the view is
+/// single-threaded here.
+pub struct ViewContext {
+    /// Persistence database. The TUI only ever needs to run DB ops related to
+    /// our collection, so we can use a collection-restricted DB handle
+    database: CollectionDatabase,
+    /// Queue of unhandled view events, which will be used to update view state
+    event_queue: EventQueue,
+    /// Sender to the async message queue, which is used to transmit data and
+    /// trigger callbacks that require additional threading/background work.
+    messages_tx: MessageSender,
+}
+
+impl ViewContext {
+    thread_local! {
+        /// This is used to access the view context from anywhere in the view
+        /// code. Since the view is all single-threaded, there should only ever
+        /// be one instance of this thread local (aside from tests). All mutable
+        /// accesses are restricted to the methods on this struct type, so it's
+        /// impossible for an outside caller to hold the ref cell open. This is
+        /// only `None` if the context hasn't yet been initialized for the
+        /// thread.
+        ///
+        /// Technically we could use a global static instead of a thread local
+        /// as far as the app is concerned, since we only initialize it on one
+        /// thread anyway. But that makes testing pretty much impossible, since
+        /// all tests would share the same value.
+        static INSTANCE: RefCell<Option<ViewContext>> = RefCell::default();
+    }
+
+    /// Initialize the view context for this thread
+    pub fn init(database: CollectionDatabase, messages_tx: MessageSender) {
+        Self::INSTANCE.with_borrow_mut(|context| {
+            *context = Some(Self {
+                database,
+                event_queue: EventQueue::default(),
+                messages_tx,
+            })
+        })
+    }
+
+    /// Execute a function with read-only access to the context
+    fn with<T>(f: impl FnOnce(&ViewContext) -> T) -> T {
+        Self::INSTANCE.with_borrow(|context| {
+            let context =
+                context.as_ref().expect("View context not initialized");
+            f(context)
+        })
+    }
+
+    /// Execute a function with mutable access to the context
+    fn with_mut<T>(f: impl FnOnce(&mut ViewContext) -> T) -> T {
+        Self::INSTANCE.with_borrow_mut(|context| {
+            let context =
+                context.as_mut().expect("View context not initialized");
+            f(context)
+        })
+    }
+
+    /// Execute a function with access to the database
+    pub fn with_database<T>(f: impl FnOnce(&CollectionDatabase) -> T) -> T {
+        Self::with(|context| f(&context.database))
+    }
+
+    /// Queue a view event to be handled by the component tree
+    pub fn push_event(event: Event) {
+        Self::with_mut(|context| context.event_queue.push(event))
+    }
+
+    /// Pop an event off the event queue
+    pub fn pop_event() -> Option<Event> {
+        Self::with_mut(|context| context.event_queue.pop())
+    }
+
+    /// Open a modal
+    pub fn open_modal(modal: impl Modal + 'static, priority: ModalPriority) {
+        Self::push_event(Event::OpenModal {
+            modal: Box::new(modal),
+            priority,
+        });
+    }
+
+    /// Open a modal that implements `Default`, with low priority
+    pub fn open_modal_default<T: Modal + Default + 'static>() {
+        Self::open_modal(T::default(), ModalPriority::Low);
+    }
+
+    /// Get a clone of the async message sender. Generally you should use
+    /// [Self::send_message] instead, but in some contexts you need the whole
+    /// sender.
+    pub fn messages_tx() -> MessageSender {
+        Self::with(|context| context.messages_tx.clone())
+    }
+
+    /// Send an async message on the channel
+    pub fn send_message(message: Message) {
+        Self::with(|context| context.messages_tx.send(message));
+    }
+
+    /// Execute a function with read-only access to the event queue
+    #[cfg(test)]
+    pub fn inspect_event_queue(f: impl FnOnce(&[&Event])) {
+        Self::with(|context| {
+            let refs: Vec<_> = context.event_queue.to_vec();
+            f(refs.as_slice());
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_util::*;
+    use rstest::rstest;
+
+    #[rstest]
+    fn test_event_queue(database: CollectionDatabase, messages: MessageQueue) {
+        ViewContext::init(database, messages.tx().clone());
+
+        assert_events!(); // Start empty
+
+        ViewContext::push_event(Event::new_other(3));
+        ViewContext::push_event(Event::CloseModal);
+        assert_events!(Event::Other(_), Event::CloseModal);
+
+        assert!(matches!(ViewContext::pop_event(), Some(Event::Other(_))));
+        assert!(matches!(ViewContext::pop_event(), Some(Event::CloseModal)));
+        assert_events!(); // Empty again
+    }
+
+    #[rstest]
+    fn test_send_message(
+        database: CollectionDatabase,
+        mut messages: MessageQueue,
+    ) {
+        ViewContext::init(database, messages.tx().clone());
+        ViewContext::send_message(Message::CollectionStartReload);
+        ViewContext::send_message(Message::CollectionEdit);
+        assert!(matches!(messages.pop_now(), Message::CollectionStartReload));
+        assert!(matches!(messages.pop_now(), Message::CollectionEdit));
+    }
+}

--- a/src/tui/view/state/fixed_select.rs
+++ b/src/tui/view/state/fixed_select.rs
@@ -1,12 +1,9 @@
-use crate::tui::{
-    message::MessageSender,
-    view::{
-        draw::{Draw, DrawMetadata},
-        event::{Event, EventHandler, Update},
-        state::{
-            persistence::{Persistable, PersistentContainer},
-            select::{SelectState, SelectStateBuilder, SelectStateData},
-        },
+use crate::tui::view::{
+    draw::{Draw, DrawMetadata},
+    event::{Event, EventHandler, Update},
+    state::{
+        persistence::{Persistable, PersistentContainer},
+        select::{SelectState, SelectStateBuilder, SelectStateData},
     },
 };
 use itertools::Itertools;
@@ -159,8 +156,8 @@ where
     Item: FixedSelect,
     State: Debug + SelectStateData,
 {
-    fn update(&mut self, messages_tx: &MessageSender, event: Event) -> Update {
-        self.select.update(messages_tx, event)
+    fn update(&mut self, event: Event) -> Update {
+        self.select.update(event)
     }
 }
 

--- a/src/tui/view/state/request_store.rs
+++ b/src/tui/view/state/request_store.rs
@@ -1,0 +1,385 @@
+use crate::{
+    collection::{ProfileId, RecipeId},
+    http::RequestId,
+    tui::view::{
+        context::ViewContext, state::RequestStateSummary, RequestState,
+    },
+};
+use anyhow::anyhow;
+use itertools::Itertools;
+use std::collections::{hash_map::Entry, HashMap};
+
+/// Simple in-memory "database" for request state. This serves a few purposes:
+///
+/// - Save all incomplete requests (in-progress or failed) from the current app
+///   session. These do *not* get persisted in the database
+/// - Cache historical requests from the database. If we're accessing them
+///   repeatedly, we don't want to keep going back to the DB.
+/// - Provide a simple unified interface over both the in-memory cache and the
+///   persistent DB, so callers can simply ask for requests and we only go to
+///   the DB when necessary.
+///
+/// These operations are generally fallible only when the underlying DB
+/// operation fails.
+#[derive(Debug, Default)]
+pub struct RequestStore {
+    requests: HashMap<RequestId, RequestState>,
+}
+
+impl RequestStore {
+    /// Get request state by ID
+    pub fn get(&self, id: RequestId) -> Option<&RequestState> {
+        self.requests.get(&id)
+    }
+
+    /// Update state of an in-progress HTTP request. Return `true` if the
+    /// request is **new** in the state, i.e. it's the initial insert
+    pub fn update(&mut self, state: RequestState) -> bool {
+        self.requests.insert(state.id(), state).is_none()
+    }
+
+    /// Load a request from the database by ID. If already present in the store,
+    /// do *not* update it. Only go to the DB if it's missing.
+    pub fn load(&mut self, id: RequestId) -> anyhow::Result<()> {
+        if let Entry::Vacant(entry) = self.requests.entry(id) {
+            let record = ViewContext::with_database(|database| {
+                database
+                    .get_request(id)?
+                    .ok_or_else(|| anyhow!("Unknown request ID `{id}`"))
+            })?;
+            entry.insert(RequestState::response(record));
+        }
+        Ok(())
+    }
+
+    /// Get the latest request for a specific profile+recipe combo
+    pub fn load_latest(
+        &mut self,
+        profile_id: Option<&ProfileId>,
+        recipe_id: &RecipeId,
+    ) -> anyhow::Result<Option<&RequestState>> {
+        let record = ViewContext::with_database(|database| {
+            database.get_latest_request(profile_id, recipe_id)
+        })?;
+        let state = record.map(|record| {
+            let state = RequestState::response(record);
+            // Insert into the map, get a reference back
+            // unstable: https://doc.rust-lang.org/std/collections/hash_map/enum.Entry.html#method.insert_entry
+            match self.requests.entry(state.id()) {
+                Entry::Occupied(mut entry) => {
+                    entry.insert(state);
+                    entry.into_mut() as &_ // Drop mutability
+                }
+                Entry::Vacant(entry) => entry.insert(state),
+            }
+        });
+        Ok(state)
+    }
+
+    /// Load all historical requests for a recipe+profile, then return the
+    /// *entire* set of requests, including in-progress ones. Returned requests
+    /// are just summaries, not the full request. This is intended for list
+    /// views, so we don't need to load the entire request/response for each
+    /// one. Results are sorted by request *start* time, descending.
+    pub fn load_summaries<'a>(
+        &'a self,
+        profile_id: Option<&'a ProfileId>,
+        recipe_id: &'a RecipeId,
+    ) -> anyhow::Result<impl 'a + Iterator<Item = RequestStateSummary>> {
+        // Load summaries from the DB. We do *not* want to insert these into the
+        // store, because they don't include request/response data
+        let loaded = ViewContext::with_database(|database| {
+            database.get_all_requests(profile_id, recipe_id)
+        })?;
+
+        // Find what we have in memory already
+        let iter = self
+            .requests
+            .values()
+            .filter(move |state| {
+                state.profile_id() == profile_id
+                    && state.recipe_id() == recipe_id
+            })
+            .map(RequestStateSummary::from)
+            // Add what we loaded from the DB
+            .chain(loaded.into_iter().map(RequestStateSummary::Response))
+            // Sort descending
+            .sorted_by_key(RequestStateSummary::time)
+            .rev()
+            // De-duplicate double-loaded requests
+            .unique_by(RequestStateSummary::id);
+        Ok(iter)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        db::CollectionDatabase,
+        http::{Request, RequestBuildError, RequestError, RequestRecord},
+        test_util::*,
+    };
+    use chrono::Utc;
+    use rstest::rstest;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_get() {
+        let record = RequestRecord::factory(());
+        let id = record.id;
+        let mut store = RequestStore::default();
+        store
+            .requests
+            .insert(record.id, RequestState::response(record));
+
+        // This is a bit jank, but since we can't clone records, the only way
+        // to get the value back for comparison is to access the map directly
+        assert_eq!(store.get(id), Some(store.requests.get(&id).unwrap()));
+        assert_eq!(store.get(RequestId::new()), None);
+    }
+
+    #[test]
+    fn test_update() {
+        let record = RequestRecord::factory(());
+        let id = record.id;
+        let mut store = RequestStore::default();
+
+        // Update for each state in the life cycle
+        assert!(store.update(RequestState::Building {
+            id,
+            start_time: record.start_time,
+            profile_id: record.request.profile_id.clone(),
+            recipe_id: record.request.recipe_id.clone()
+        }));
+        assert!(matches!(store.get(id), Some(RequestState::Building { .. })));
+
+        assert!(!store.update(RequestState::Loading {
+            request: Arc::clone(&record.request),
+            start_time: record.start_time,
+        }));
+        assert!(matches!(store.get(id), Some(RequestState::Loading { .. })));
+
+        assert!(!store.update(RequestState::response(record)));
+        assert!(matches!(store.get(id), Some(RequestState::Response { .. })));
+
+        // Insert a new request, just to make sure it's independent
+        let record2 = RequestRecord::factory(());
+        let id2 = record2.id;
+        assert!(store.update(RequestState::Building {
+            id: id2,
+            start_time: record2.start_time,
+            profile_id: record2.request.profile_id.clone(),
+            recipe_id: record2.request.recipe_id.clone()
+        }));
+        assert!(matches!(store.get(id), Some(RequestState::Response { .. })));
+        assert!(matches!(
+            store.get(id2),
+            Some(RequestState::Building { .. })
+        ));
+    }
+
+    #[rstest]
+    fn test_load(database: CollectionDatabase, messages: MessageQueue) {
+        ViewContext::init(database.clone(), messages.tx().clone());
+        let mut store = RequestStore::default();
+
+        // Generally we would expect this to be in the DB, but in this case omit
+        // it so we can ensure the store *isn't* going to the DB for it
+        let present_record = RequestRecord::factory(());
+        let present_id = present_record.id;
+
+        let missing_record = RequestRecord::factory(());
+        let missing_id = missing_record.id;
+        database.insert_request(&missing_record).unwrap();
+
+        // Already in store, don't fetch
+        store
+            .requests
+            .insert(present_id, RequestState::response(present_record));
+        assert!(matches!(
+            store.get(present_id),
+            Some(RequestState::Response { .. })
+        ));
+        store.load(present_id).expect("Expected success");
+        assert!(matches!(
+            store.get(present_id),
+            Some(RequestState::Response { .. })
+        ));
+
+        // Not in store, fetch successfully
+        assert!(store.get(missing_id).is_none());
+        store.load(missing_id).expect("Expected success");
+        assert!(matches!(
+            store.get(missing_id),
+            Some(RequestState::Response { .. })
+        ));
+
+        // Not in store and not in DB, return error
+        assert_err!(store.load(RequestId::new()), "Unknown request ID");
+    }
+
+    #[rstest]
+    fn test_load_latest(database: CollectionDatabase, messages: MessageQueue) {
+        ViewContext::init(database.clone(), messages.tx().clone());
+        let profile_id = ProfileId::factory(());
+        let recipe_id = RecipeId::factory(());
+
+        // Create some confounding records, that we don't expected to load
+        create_record(&database, Some(&profile_id), Some(&recipe_id));
+        create_record(&database, Some(&profile_id), None);
+        create_record(&database, None, Some(&recipe_id));
+        let expected_record =
+            create_record(&database, Some(&profile_id), Some(&recipe_id));
+
+        let mut store = RequestStore::default();
+        assert_eq!(
+            store.load_latest(Some(&profile_id), &recipe_id).unwrap(),
+            Some(&RequestState::response(expected_record))
+        );
+
+        // Non-match
+        assert!(matches!(
+            store.load_latest(Some(&profile_id), &("other".into())),
+            Ok(None)
+        ));
+    }
+
+    #[rstest]
+    fn test_load_summaries(
+        database: CollectionDatabase,
+        messages: MessageQueue,
+    ) {
+        ViewContext::init(database.clone(), messages.tx().clone());
+        let profile_id = ProfileId::factory(());
+        let recipe_id = RecipeId::factory(());
+
+        let mut records = (0..5)
+            .map(|_| {
+                create_record(&database, Some(&profile_id), Some(&recipe_id))
+            })
+            .collect_vec();
+        // Create some confounders
+        create_record(&database, None, Some(&recipe_id));
+        create_record(&database, Some(&profile_id), None);
+
+        // Add one request of each possible state. We expect to get em all back
+        let mut store = RequestStore::default();
+
+        // Pre-load one from the DB, to make sure it gets de-duped
+        let record = records.pop().unwrap();
+        let response_id = record.id;
+        store.update(RequestState::response(record));
+
+        let building_id = RequestId::new();
+        store.update(RequestState::Building {
+            id: building_id,
+            start_time: Utc::now(),
+            profile_id: Some(profile_id.clone()),
+            recipe_id: recipe_id.clone(),
+        });
+
+        let build_error_id = RequestId::new();
+        store.update(RequestState::BuildError {
+            error: RequestBuildError {
+                profile_id: Some(profile_id.clone()),
+                recipe_id: recipe_id.clone(),
+                id: build_error_id,
+                time: Utc::now(),
+                error: anyhow!("oh no!"),
+            },
+        });
+
+        let request =
+            Request::factory((Some(profile_id.clone()), recipe_id.clone()));
+        let loading_id = request.id;
+        store.update(RequestState::Loading {
+            request: request.into(),
+            start_time: Utc::now(),
+        });
+
+        let request =
+            Request::factory((Some(profile_id.clone()), recipe_id.clone()));
+        let request_error_id = request.id;
+        store.update(RequestState::RequestError {
+            error: RequestError {
+                error: anyhow!("oh no!"),
+                request: request.into(),
+                start_time: Utc::now(),
+                end_time: Utc::now(),
+            },
+        });
+
+        // Neither of these should appear
+        store.update(RequestState::Building {
+            id: RequestId::new(),
+            start_time: Utc::now(),
+            profile_id: Some(ProfileId::factory(())),
+            recipe_id: recipe_id.clone(),
+        });
+        store.update(RequestState::Building {
+            id: RequestId::new(),
+            start_time: Utc::now(),
+            profile_id: Some(profile_id.clone()),
+            recipe_id: RecipeId::factory(()),
+        });
+
+        // It's really annoying to do a full equality comparison because we'd
+        // have to re-create each piece of data (they don't impl Clone), so
+        // instead do a pattern match, then check the IDs
+        let loaded = store
+            .load_summaries(Some(&profile_id), &recipe_id)
+            .unwrap()
+            .collect_vec();
+        assert!(matches!(
+            loaded.as_slice(),
+            &[
+                RequestStateSummary::RequestError { .. },
+                RequestStateSummary::Loading { .. },
+                RequestStateSummary::BuildError { .. },
+                RequestStateSummary::Building { .. },
+                RequestStateSummary::Response { .. },
+                RequestStateSummary::Response { .. },
+                RequestStateSummary::Response { .. },
+                RequestStateSummary::Response { .. },
+                RequestStateSummary::Response { .. },
+            ]
+        ));
+
+        let ids = loaded.iter().map(RequestStateSummary::id).collect_vec();
+        // These should be sorted descending by start time, with dupes removed
+        assert_eq!(
+            ids.as_slice(),
+            &[
+                request_error_id,
+                loading_id,
+                build_error_id,
+                building_id,
+                response_id, // This one got de-duped
+                records[3].id,
+                records[2].id,
+                records[1].id,
+                records[0].id,
+            ]
+        );
+    }
+
+    /// Create a record with the given profile+recipe ID (or random if
+    /// None), and insert it into the DB
+    fn create_record(
+        database: &CollectionDatabase,
+        profile_id: Option<&ProfileId>,
+        recipe_id: Option<&RecipeId>,
+    ) -> RequestRecord {
+        let record = RequestRecord::factory((
+            Some(
+                profile_id
+                    .cloned()
+                    .unwrap_or_else(|| ProfileId::factory(())),
+            ),
+            recipe_id.cloned().unwrap_or_else(|| RecipeId::factory(())),
+        ));
+        database.insert_request(&record).unwrap();
+        record
+    }
+}

--- a/src/tui/view/state/select.rs
+++ b/src/tui/view/state/select.rs
@@ -1,6 +1,5 @@
 use crate::tui::{
     input::Action,
-    message::MessageSender,
     view::{
         draw::{Draw, DrawMetadata},
         event::{Event, EventHandler, Update},
@@ -27,7 +26,6 @@ where
     /// draw phase, by [ratatui::Frame::render_stateful_widget]. This allows
     /// rendering without a mutable reference.
     state: RefCell<State>,
-    #[debug(skip)]
     items: Vec<Item>,
     /// Callback when an item is highlighted
     #[debug(skip)]
@@ -228,7 +226,7 @@ where
     Item: Debug,
     State: Debug + SelectStateData,
 {
-    fn update(&mut self, _: &MessageSender, event: Event) -> Update {
+    fn update(&mut self, event: Event) -> Update {
         let Some(action) = event.action() else {
             return Update::Propagate(event);
         };

--- a/src/tui/view/theme.rs
+++ b/src/tui/view/theme.rs
@@ -50,75 +50,6 @@ pub struct Styles {
     pub text_window: TextWindowStyle,
 }
 
-impl Styles {
-    pub fn new(theme: &Theme) -> Self {
-        Self {
-            list: ListStyles {
-                highlight: Style::default()
-                    .bg(theme.primary_color)
-                    .fg(theme.primary_text_color)
-                    .add_modifier(Modifier::BOLD),
-            },
-            modal: ModalStyles {
-                border: Style::default().fg(theme.primary_color),
-                border_type: BorderType::Double,
-            },
-            pane: PaneStyles {
-                border: Style::default(),
-                border_selected: Style::default()
-                    .fg(theme.primary_color)
-                    .add_modifier(Modifier::BOLD),
-                border_type: BorderType::Plain,
-                border_type_selected: BorderType::Double,
-            },
-            status_code: StatusCodeStyles {
-                success: Style::default()
-                    .fg(Color::Black)
-                    .bg(theme.success_color),
-                error: Style::default().bg(theme.error_color),
-            },
-            tab: TabStyles {
-                highlight: Style::default()
-                    .fg(theme.primary_color)
-                    .add_modifier(Modifier::BOLD)
-                    .add_modifier(Modifier::UNDERLINED),
-            },
-            table: TableStyles {
-                header: Style::default()
-                    .add_modifier(Modifier::BOLD)
-                    .add_modifier(Modifier::UNDERLINED),
-                text: Style::default(),
-                alt: Style::default().bg(Color::DarkGray),
-                disabled: Style::default().add_modifier(Modifier::DIM),
-                highlight: Style::default()
-                    .bg(theme.primary_color)
-                    .fg(theme.primary_text_color)
-                    .add_modifier(Modifier::BOLD)
-                    .add_modifier(Modifier::UNDERLINED),
-                title: Style::default().add_modifier(Modifier::BOLD),
-            },
-            template_preview: TemplatePreviewStyles {
-                text: Style::default().fg(theme.secondary_color),
-                error: Style::default().bg(theme.error_color),
-            },
-            text: TextStyle {
-                highlight: Style::default()
-                    .fg(theme.primary_text_color)
-                    .bg(theme.primary_color),
-            },
-            text_box: TextBoxStyle {
-                text: Style::default().bg(Color::DarkGray),
-                cursor: Style::default().bg(Color::White).fg(Color::Black),
-                placeholder: Style::default().fg(Color::Black),
-                invalid: Style::default().bg(Color::LightRed),
-            },
-            text_window: TextWindowStyle {
-                line_number: Style::default().fg(Color::DarkGray),
-            },
-        }
-    }
-}
-
 /// Styles for List component
 #[derive(Debug)]
 pub struct ListStyles {
@@ -195,6 +126,10 @@ pub struct TemplatePreviewStyles {
 pub struct TextStyle {
     /// Text that needs some visual emphasis/separation
     pub highlight: Style,
+    /// Text in the primary color
+    pub primary: Style,
+    /// Text that means BAD BUSINESS
+    pub error: Style,
 }
 
 /// Styles for TextBox component
@@ -211,4 +146,75 @@ pub struct TextBoxStyle {
 pub struct TextWindowStyle {
     /// Line numbers on large text areas
     pub line_number: Style,
+}
+
+impl Styles {
+    pub fn new(theme: &Theme) -> Self {
+        Self {
+            list: ListStyles {
+                highlight: Style::default()
+                    .bg(theme.primary_color)
+                    .fg(theme.primary_text_color)
+                    .add_modifier(Modifier::BOLD),
+            },
+            modal: ModalStyles {
+                border: Style::default(),
+                border_type: BorderType::Double,
+            },
+            pane: PaneStyles {
+                border: Style::default(),
+                border_selected: Style::default()
+                    .fg(theme.primary_color)
+                    .add_modifier(Modifier::BOLD),
+                border_type: BorderType::Plain,
+                border_type_selected: BorderType::Double,
+            },
+            status_code: StatusCodeStyles {
+                success: Style::default()
+                    .fg(Color::Black)
+                    .bg(theme.success_color),
+                error: Style::default().bg(theme.error_color),
+            },
+            tab: TabStyles {
+                highlight: Style::default()
+                    .fg(theme.primary_color)
+                    .add_modifier(Modifier::BOLD)
+                    .add_modifier(Modifier::UNDERLINED),
+            },
+            table: TableStyles {
+                header: Style::default()
+                    .add_modifier(Modifier::BOLD)
+                    .add_modifier(Modifier::UNDERLINED),
+                text: Style::default(),
+                alt: Style::default().bg(Color::DarkGray),
+                disabled: Style::default().add_modifier(Modifier::DIM),
+                highlight: Style::default()
+                    .bg(theme.primary_color)
+                    .fg(theme.primary_text_color)
+                    .add_modifier(Modifier::BOLD)
+                    .add_modifier(Modifier::UNDERLINED),
+                title: Style::default().add_modifier(Modifier::BOLD),
+            },
+            template_preview: TemplatePreviewStyles {
+                text: Style::default().fg(theme.secondary_color),
+                error: Style::default().bg(theme.error_color),
+            },
+            text: TextStyle {
+                highlight: Style::default()
+                    .fg(theme.primary_text_color)
+                    .bg(theme.primary_color),
+                primary: Style::default().fg(theme.primary_color),
+                error: Style::default().bg(theme.error_color),
+            },
+            text_box: TextBoxStyle {
+                text: Style::default().bg(Color::DarkGray),
+                cursor: Style::default().bg(Color::White).fg(Color::Black),
+                placeholder: Style::default().fg(Color::Black),
+                invalid: Style::default().bg(Color::LightRed),
+            },
+            text_window: TextWindowStyle {
+                line_number: Style::default().fg(Color::DarkGray),
+            },
+        }
+    }
 }


### PR DESCRIPTION

## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Add a modal to browse request history for any recipe+profile. The modal will show in-progress, failed, and completed requests. Since in-progress and failed requests aren't persisted to the DB, those will only show from the current session. This includes a lot of refactoring too, including the ViewContext thread-local.

![image](https://github.com/LucasPickering/slumber/assets/2382935/a288c9fe-b8ae-41b8-80e7-efbb37b6700a)


## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

- Big refactor means large surface area for UI bugs. Mitigated with automated and manual tests
- In-progress and failed requests being session-local may be unintuitive, TBD if anyone complains about that
- The modal does *not* update as request state changes, i.e. if a request is loading when you open the modal, and completes/fails while the modal is open, you have to close the modal and re-open to see that change reflected. This is a bit wonky but the state finaglry required to make it smoother is not worth the squeeze IMO.

## QA

_How did you test this?_

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
