### PR TITLE
Add scrollbars to lists and text windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 
 - Request history is now browsable! [#55](https://github.com/LucasPickering/slumber/issues/55)
+- Add scrollbars to lists and text windows [#220](https://github.com/LucasPickering/slumber/issues/220)
 
 ### Changed
 

--- a/src/tui/view/common.rs
+++ b/src/tui/view/common.rs
@@ -6,6 +6,7 @@ pub mod button;
 pub mod header_table;
 pub mod list;
 pub mod modal;
+pub mod scrollbar;
 pub mod table;
 pub mod tabs;
 pub mod template_preview;
@@ -74,7 +75,7 @@ impl Generate for Checkbox {
 
 impl Generate for String {
     /// Use `Text` because a string can be multiple lines
-    type Output<'this> = Text<'static>;
+    type Output<'this> = Text<'this>;
 
     fn generate<'this>(self) -> Self::Output<'this>
     where

--- a/src/tui/view/common/actions.rs
+++ b/src/tui/view/common/actions.rs
@@ -79,11 +79,7 @@ where
     fn draw(&self, frame: &mut Frame, _: (), metadata: DrawMetadata) {
         self.actions.draw(
             frame,
-            List {
-                pane: None,
-                list: self.actions.data().items(),
-            }
-            .generate(),
+            List::new(self.actions.data().items()),
             metadata.area(),
             true,
         );

--- a/src/tui/view/common/scrollbar.rs
+++ b/src/tui/view/common/scrollbar.rs
@@ -1,0 +1,152 @@
+use ratatui::{
+    buffer::Buffer,
+    layout::{Offset, Rect},
+    widgets::{ScrollbarOrientation, ScrollbarState, StatefulWidget, Widget},
+};
+
+/// A wrapper around Ratatui's scrollbar to make it more ergonomic. This has two
+/// main purposes:
+/// - Standardize styling
+/// - Handle annoying state calculation
+#[derive(Clone, Debug)]
+pub struct Scrollbar {
+    /// Number of rows in your content, e.g. items in a list or lines in a
+    /// text file. For horizontal scrolling, this is the number of columns.
+    pub content_length: usize,
+    /// Visual offset into the content, i.e. the index of the first visible
+    /// item
+    pub offset: usize,
+    /// How far should the scrollbar be offset from its content? Positive to
+    /// offset out, negative to offset in. Defaults to 1, because most content
+    /// has a border that can contain the scrollbar.
+    pub margin: i32,
+    /// Which way should the scrollbar face?
+    pub orientation: ScrollbarOrientation,
+}
+
+impl Default for Scrollbar {
+    fn default() -> Self {
+        Self {
+            content_length: 0,
+            offset: 0,
+            margin: 1,
+            orientation: ScrollbarOrientation::VerticalRight,
+        }
+    }
+}
+
+impl Scrollbar {
+    fn state(&self, area: Rect) -> ScrollbarState {
+        let size = match &self.orientation {
+            ScrollbarOrientation::VerticalRight
+            | ScrollbarOrientation::VerticalLeft => area.height,
+            ScrollbarOrientation::HorizontalBottom
+            | ScrollbarOrientation::HorizontalTop => area.width,
+        } as usize;
+
+        // To Ratatui, content_length is how many possible scroll positions
+        // there are, which is the number of items beyond the viewport, plus one
+        // to capture all items in the viewport. If the entire content fits in
+        // the viewport though, we just use 0 to hide the scroll
+        let content_length = if self.content_length <= size {
+            0
+        } else {
+            self.content_length.saturating_sub(size) + 1
+        };
+        ScrollbarState::new(content_length)
+            // position is the index of the first *visible* element
+            .position(self.offset)
+    }
+}
+
+impl Widget for Scrollbar {
+    fn render(self, area: Rect, buf: &mut Buffer)
+    where
+        Self: Sized,
+    {
+        let (begin_symbol, thumb_symbol, end_symbol) = match &self.orientation {
+            ScrollbarOrientation::VerticalRight
+            | ScrollbarOrientation::VerticalLeft => ("▲", "█", "▼"),
+            ScrollbarOrientation::HorizontalBottom
+            | ScrollbarOrientation::HorizontalTop => ("◀", "■", "▶"),
+        };
+
+        // Apply an offset to put this outside the content
+        let offset = match &self.orientation {
+            ScrollbarOrientation::VerticalRight => Offset {
+                x: self.margin,
+                y: 0,
+            },
+            ScrollbarOrientation::VerticalLeft => Offset {
+                x: -self.margin,
+                y: 0,
+            },
+            ScrollbarOrientation::HorizontalBottom => Offset {
+                x: 0,
+                y: self.margin,
+            },
+            ScrollbarOrientation::HorizontalTop => Offset {
+                x: 0,
+                y: -self.margin,
+            },
+        };
+
+        let scrollbar =
+            ratatui::widgets::Scrollbar::new(self.orientation.clone())
+                .begin_symbol(Some(begin_symbol))
+                .thumb_symbol(thumb_symbol)
+                .end_symbol(Some(end_symbol));
+
+        StatefulWidget::render(
+            scrollbar,
+            area.offset(offset),
+            buf,
+            &mut self.state(area),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::{
+        buffer::Buffer,
+        widgets::{List, ListState, ScrollbarState},
+    };
+    use rstest::rstest;
+
+    #[rstest]
+    // If len <= height, we should have *no* scrollbar
+    #[case::empty(0, 0, ScrollbarState::new(0).position(0))]
+    #[case::extra_space(9, 0, ScrollbarState::new(0).position(0))]
+    #[case::perfect_fit_first(10, 0, ScrollbarState::new(0).position(0))]
+    #[case::perfect_fit_last(10, 0, ScrollbarState::new(0).position(0))]
+    // Overflow without offset
+    #[case::overflow(11, 0, ScrollbarState::new(2).position(0))]
+    // We scrolled down, but not far enough to move the scrollbar
+    #[case::overflow_offset(11, 3, ScrollbarState::new(2).position(0))]
+    // We scrolled down far enough to move the scrollbar
+    #[case::overflow_scrolled(12, 10, ScrollbarState::new(3).position(1))]
+    #[case::overflow_scrolled_bottom(20, 19, ScrollbarState::new(11).position(10))]
+    fn test_state(
+        #[case] content_length: usize,
+        #[case] selected: usize,
+        #[case] expected: ScrollbarState,
+    ) {
+        let area = Rect::new(0, 0, 5, 10);
+
+        // Render a list once to get a realistic offset calculation
+        let mut buffer = Buffer::empty(area);
+        let list = List::new((0..content_length).map(|i| i.to_string()));
+        let mut state = ListState::default().with_selected(Some(selected));
+        StatefulWidget::render(list, area, &mut buffer, &mut state);
+
+        let scrollbar = Scrollbar {
+            content_length,
+            offset: state.offset(),
+            margin: 0,
+            orientation: ScrollbarOrientation::VerticalRight,
+        };
+        assert_eq!(scrollbar.state(area), expected);
+    }
+}

--- a/src/tui/view/component/history.rs
+++ b/src/tui/view/component/history.rs
@@ -79,12 +79,12 @@ impl EventHandler for History {
 
 impl Draw for History {
     fn draw(&self, frame: &mut Frame, _: (), metadata: DrawMetadata) {
-        let list = List {
-            pane: None,
-            list: self.select.data().items(),
-        };
-        self.select
-            .draw(frame, list.generate(), metadata.area(), true);
+        self.select.draw(
+            frame,
+            List::new(self.select.data().items()),
+            metadata.area(),
+            true,
+        );
     }
 }
 

--- a/src/tui/view/component/profile_select.rs
+++ b/src/tui/view/component/profile_select.rs
@@ -183,8 +183,8 @@ impl EventHandler for ProfileListModal {
 impl Draw for ProfileListModal {
     fn draw(&self, frame: &mut Frame, _: (), metadata: DrawMetadata) {
         // Empty state
-        let items = self.select.data().items();
-        if items.is_empty() {
+        let select = self.select.data();
+        if select.items().is_empty() {
             frame.render_widget(
                 Text::from(vec![
                     "No profiles defined; add one to your collection.".into(),
@@ -196,23 +196,15 @@ impl Draw for ProfileListModal {
         }
 
         let [list_area, _, detail_area] = Layout::vertical([
-            Constraint::Length(items.len().min(5) as u16),
+            Constraint::Length(select.items().len().min(5) as u16),
             Constraint::Length(1), // Padding
             Constraint::Min(0),
         ])
         .areas(metadata.area());
 
-        self.select.draw(
-            frame,
-            List {
-                pane: None,
-                list: items,
-            }
-            .generate(),
-            list_area,
-            true,
-        );
-        if let Some(profile) = self.select.data().selected() {
+        self.select
+            .draw(frame, List::new(select.items()), list_area, true);
+        if let Some(profile) = select.selected() {
             self.detail.draw(
                 frame,
                 ProfileDetailProps { profile },

--- a/src/tui/view/component/recipe_list.rs
+++ b/src/tui/view/component/recipe_list.rs
@@ -4,7 +4,7 @@ use crate::{
         context::TuiContext,
         input::Action,
         view::{
-            common::Pane,
+            common::{list::List, Pane},
             component::primary::PrimaryPane,
             draw::{Draw, DrawMetadata, Generate},
             event::{Event, EventHandler, Update},
@@ -168,10 +168,13 @@ impl Draw for RecipeListPane {
         let title = context
             .input_engine
             .add_hint("Recipes", Action::SelectRecipeList);
-        let pane = Pane {
+        let block = Pane {
             title: &title,
             has_focus: metadata.has_focus(),
-        };
+        }
+        .generate();
+        let area = block.inner(metadata.area());
+        frame.render_widget(block, metadata.area());
 
         // We have to build this manually instead of using our own List type,
         // because we need outside context during the render
@@ -208,10 +211,8 @@ impl Draw for RecipeListPane {
                 )
             })
             .collect_vec();
-        let list = ratatui::widgets::List::new(items)
-            .block(pane.generate())
-            .highlight_style(context.styles.list.highlight);
-        self.select.draw(frame, list, metadata.area(), true);
+
+        self.select.draw(frame, List::new(items), area, true);
     }
 }
 

--- a/src/tui/view/component/recipe_pane.rs
+++ b/src/tui/view/component/recipe_pane.rs
@@ -11,7 +11,7 @@ use crate::{
                 table::{Table, ToggleRow},
                 tabs::Tabs,
                 template_preview::TemplatePreview,
-                text_window::TextWindow,
+                text_window::{TextWindow, TextWindowProps},
                 Pane,
             },
             component::primary::PrimaryPane,
@@ -268,7 +268,14 @@ impl<'a> Draw<RecipePaneProps<'a>> for RecipePane {
             match self.tabs.data().selected() {
                 Tab::Body => {
                     if let Some(body) = &recipe_state.body {
-                        body.draw(frame, (), content_area, true);
+                        body.draw(
+                            frame,
+                            TextWindowProps {
+                                has_search_box: false,
+                            },
+                            content_area,
+                            true,
+                        );
                     }
                 }
                 Tab::Query => recipe_state.query.draw(

--- a/src/tui/view/component/record_body.rs
+++ b/src/tui/view/component/record_body.rs
@@ -5,7 +5,10 @@ use crate::{
     tui::{
         input::Action,
         view::{
-            common::{text_box::TextBox, text_window::TextWindow},
+            common::{
+                text_box::TextBox,
+                text_window::{TextWindow, TextWindowProps},
+            },
             draw::{Draw, DrawMetadata},
             event::{Event, EventHandler, Update},
             state::StateCell,
@@ -136,7 +139,14 @@ impl<'a> Draw<RecordBodyProps<'a>> for RecordBody {
         let text = self.text_window.get_or_update(self.query.clone(), || {
             init_text_window(props.body, self.query.as_ref())
         });
-        text.draw(frame, (), body_area, true);
+        text.draw(
+            frame,
+            TextWindowProps {
+                has_search_box: query_available,
+            },
+            body_area,
+            true,
+        );
 
         if query_available {
             self.query_text_box.draw(

--- a/src/tui/view/state/select.rs
+++ b/src/tui/view/state/select.rs
@@ -100,7 +100,7 @@ impl<Item, State> SelectStateBuilder<Item, State> {
         State: SelectStateData,
     {
         let mut select = SelectState {
-            state: RefCell::new(State::default()),
+            state: RefCell::default(),
             items: self.items,
             on_select: self.on_select,
             on_submit: self.on_submit,
@@ -299,9 +299,14 @@ where
 /// multiple state "backends" from Ratatui, to enable usage with different
 /// stateful widgets.
 pub trait SelectStateData: Default {
+    /// Index of the selected element
     fn selected(&self) -> Option<usize>;
 
-    fn select(&mut self, option: usize);
+    /// Select an element by index
+    fn select(&mut self, index: usize);
+
+    /// Visual offset into the list, for scrolling
+    fn offset(&self) -> usize;
 }
 
 impl SelectStateData for ListState {
@@ -309,8 +314,12 @@ impl SelectStateData for ListState {
         self.selected()
     }
 
-    fn select(&mut self, option: usize) {
-        self.select(Some(option))
+    fn select(&mut self, index: usize) {
+        self.select(Some(index))
+    }
+
+    fn offset(&self) -> usize {
+        self.offset()
     }
 }
 
@@ -319,8 +328,12 @@ impl SelectStateData for TableState {
         self.selected()
     }
 
-    fn select(&mut self, option: usize) {
-        self.select(Some(option))
+    fn select(&mut self, index: usize) {
+        self.select(Some(index))
+    }
+
+    fn offset(&self) -> usize {
+        self.offset()
     }
 }
 
@@ -329,8 +342,12 @@ impl SelectStateData for usize {
         Some(*self)
     }
 
-    fn select(&mut self, option: usize) {
-        *self = option;
+    fn select(&mut self, index: usize) {
+        *self = index;
+    }
+
+    fn offset(&self) -> usize {
+        0 // Assume all elements are always visible
     }
 }
 

--- a/src/tui/view/util.rs
+++ b/src/tui/view/util.rs
@@ -36,7 +36,7 @@ pub fn centered_rect(
                 Constraint::Percentage((100 - percent) / 2)
             }
             Constraint::Length(length) => {
-                Constraint::Length((full_size - length) / 2)
+                Constraint::Length((full_size.saturating_sub(length)) / 2)
             }
             // Implement these as needed
             _ => unimplemented!("Other center constraints unsupported"),


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Add vertical scrollbars to lists:

- Profile list
- Recipe list
- History modal

![image](https://github.com/LucasPickering/slumber/assets/2382935/441c8fc4-524f-439f-be32-4837ee6e28a0)

Add vertical and horizontal scrollbars to text windows:

![image](https://github.com/LucasPickering/slumber/assets/2382935/4b35936f-08c5-4479-8858-c6cc0effc8cc)

Also refactor list into a widget, which makes it a bit more usable.

Closes #220

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

There are some oddities around scrollbar placement/size, but it's still a major net positive for usability.

## QA

_How did you test this?_

- Manual testing in TUI
- Added a unit test for scrollbar state

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
