### PR TITLE
Fix double key events on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+- Fix double key events on Windows [#226](https://github.com/LucasPickering/slumber/issues/226)
+
 ## [1.3.0] - 2024-05-17
 
 The biggest feature in this release is the ability to browse request history. Slumber has already had the ability to _track_ history, meaning all your history since you started using it will already be there! In addition, this release contains some UI improvements, as well as some pretty major internal refactors to enable these UI changes. These will also make future UI improvements easier and faster to implement.

--- a/src/tui/util.rs
+++ b/src/tui/util.rs
@@ -197,10 +197,10 @@ mod tests {
         ));
 
         // First we expect a prompt for the file path
-        let prompt = match messages.pop_wait().await {
+        let prompt = assert_matches!(
+            messages.pop_wait().await,
             Message::PromptStart(prompt) => prompt,
-            message => panic!("Wrong message: {message:?}"),
-        };
+        );
         assert_eq!(&prompt.message, "Enter a path for the file");
         assert_eq!(prompt.default.as_deref(), Some("default.txt"));
         prompt
@@ -209,10 +209,10 @@ mod tests {
 
         if exists {
             // Now we expect a confirmation prompt
-            let confirm = match messages.pop_wait().await {
+            let confirm = assert_matches!(
+                messages.pop_wait().await,
                 Message::ConfirmStart(confirm) => confirm,
-                message => panic!("Wrong message: {message:?}"),
-            };
+            );
             assert_eq!(
                 confirm.message,
                 format!(

--- a/src/tui/view/component/recipe_pane.rs
+++ b/src/tui/view/component/recipe_pane.rs
@@ -556,8 +556,7 @@ mod tests {
     fn test_copy_url(component: (MessageQueue, RecipePane)) {
         let (mut messages, mut component) = component;
         let update = component.update(Event::new_other(MenuAction::CopyUrl));
-        // unstable: https://github.com/rust-lang/rust/issues/82775
-        assert!(matches!(update, Update::Consumed));
+        assert_matches!(update, Update::Consumed);
 
         let message = messages.pop_now();
         let Message::CopyRequestUrl(request_config) = &message else {
@@ -578,8 +577,7 @@ mod tests {
     fn test_copy_body(component: (MessageQueue, RecipePane)) {
         let (mut messages, mut component) = component;
         let update = component.update(Event::new_other(MenuAction::CopyBody));
-        // unstable: https://github.com/rust-lang/rust/issues/82775
-        assert!(matches!(update, Update::Consumed));
+        assert_matches!(update, Update::Consumed);
 
         let message = messages.pop_now();
         let Message::CopyRequestBody(request_config) = &message else {
@@ -600,8 +598,7 @@ mod tests {
     fn test_copy_as_curl(component: (MessageQueue, RecipePane)) {
         let (mut messages, mut component) = component;
         let update = component.update(Event::new_other(MenuAction::CopyCurl));
-        // unstable: https://github.com/rust-lang/rust/issues/82775
-        assert!(matches!(update, Update::Consumed));
+        assert_matches!(update, Update::Consumed);
 
         let message = messages.pop_now();
         let Message::CopyRequestCurl(request_config) = &message else {

--- a/src/tui/view/component/response_view.rs
+++ b/src/tui/view/component/response_view.rs
@@ -221,8 +221,7 @@ mod tests {
 
         let update =
             component.update(Event::new_other(BodyMenuAction::CopyBody));
-        // unstable: https://github.com/rust-lang/rust/issues/82775
-        assert!(matches!(update, Update::Consumed));
+        assert_matches!(update, Update::Consumed);
 
         let message = messages.pop_now();
         let Message::CopyText(body) = &message else {
@@ -294,8 +293,7 @@ mod tests {
 
         let update =
             component.update(Event::new_other(BodyMenuAction::SaveBody));
-        // unstable: https://github.com/rust-lang/rust/issues/82775
-        assert!(matches!(update, Update::Consumed));
+        assert_matches!(update, Update::Consumed);
 
         let message = messages.pop_now();
         let Message::SaveFile { data, default_path } = &message else {

--- a/src/tui/view/context.rs
+++ b/src/tui/view/context.rs
@@ -144,8 +144,8 @@ mod tests {
         ViewContext::push_event(Event::CloseModal);
         assert_events!(Event::Other(_), Event::CloseModal);
 
-        assert!(matches!(ViewContext::pop_event(), Some(Event::Other(_))));
-        assert!(matches!(ViewContext::pop_event(), Some(Event::CloseModal)));
+        assert_matches!(ViewContext::pop_event(), Some(Event::Other(_)));
+        assert_matches!(ViewContext::pop_event(), Some(Event::CloseModal));
         assert_events!(); // Empty again
     }
 
@@ -157,7 +157,7 @@ mod tests {
         ViewContext::init(database, messages.tx().clone());
         ViewContext::send_message(Message::CollectionStartReload);
         ViewContext::send_message(Message::CollectionEdit);
-        assert!(matches!(messages.pop_now(), Message::CollectionStartReload));
-        assert!(matches!(messages.pop_now(), Message::CollectionEdit));
+        assert_matches!(messages.pop_now(), Message::CollectionStartReload);
+        assert_matches!(messages.pop_now(), Message::CollectionEdit);
     }
 }

--- a/src/tui/view/state/request_store.rs
+++ b/src/tui/view/state/request_store.rs
@@ -152,16 +152,16 @@ mod tests {
             profile_id: record.request.profile_id.clone(),
             recipe_id: record.request.recipe_id.clone()
         }));
-        assert!(matches!(store.get(id), Some(RequestState::Building { .. })));
+        assert_matches!(store.get(id), Some(RequestState::Building { .. }));
 
         assert!(!store.update(RequestState::Loading {
             request: Arc::clone(&record.request),
             start_time: record.start_time,
         }));
-        assert!(matches!(store.get(id), Some(RequestState::Loading { .. })));
+        assert_matches!(store.get(id), Some(RequestState::Loading { .. }));
 
         assert!(!store.update(RequestState::response(record)));
-        assert!(matches!(store.get(id), Some(RequestState::Response { .. })));
+        assert_matches!(store.get(id), Some(RequestState::Response { .. }));
 
         // Insert a new request, just to make sure it's independent
         let record2 = RequestRecord::factory(());
@@ -172,11 +172,8 @@ mod tests {
             profile_id: record2.request.profile_id.clone(),
             recipe_id: record2.request.recipe_id.clone()
         }));
-        assert!(matches!(store.get(id), Some(RequestState::Response { .. })));
-        assert!(matches!(
-            store.get(id2),
-            Some(RequestState::Building { .. })
-        ));
+        assert_matches!(store.get(id), Some(RequestState::Response { .. }));
+        assert_matches!(store.get(id2), Some(RequestState::Building { .. }));
     }
 
     #[rstest]
@@ -197,23 +194,23 @@ mod tests {
         store
             .requests
             .insert(present_id, RequestState::response(present_record));
-        assert!(matches!(
+        assert_matches!(
             store.get(present_id),
             Some(RequestState::Response { .. })
-        ));
+        );
         store.load(present_id).expect("Expected success");
-        assert!(matches!(
+        assert_matches!(
             store.get(present_id),
             Some(RequestState::Response { .. })
-        ));
+        );
 
         // Not in store, fetch successfully
         assert!(store.get(missing_id).is_none());
         store.load(missing_id).expect("Expected success");
-        assert!(matches!(
+        assert_matches!(
             store.get(missing_id),
             Some(RequestState::Response { .. })
-        ));
+        );
 
         // Not in store and not in DB, return error
         assert_err!(store.load(RequestId::new()), "Unknown request ID");
@@ -239,10 +236,10 @@ mod tests {
         );
 
         // Non-match
-        assert!(matches!(
+        assert_matches!(
             store.load_latest(Some(&profile_id), &("other".into())),
             Ok(None)
-        ));
+        );
     }
 
     #[rstest]
@@ -331,7 +328,7 @@ mod tests {
             .load_summaries(Some(&profile_id), &recipe_id)
             .unwrap()
             .collect_vec();
-        assert!(matches!(
+        assert_matches!(
             loaded.as_slice(),
             &[
                 RequestStateSummary::RequestError { .. },
@@ -344,7 +341,7 @@ mod tests {
                 RequestStateSummary::Response { .. },
                 RequestStateSummary::Response { .. },
             ]
-        ));
+        );
 
         let ids = loaded.iter().map(RequestStateSummary::id).collect_vec();
         // These should be sorted descending by start time, with dupes removed


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Windows sends both a Press and a Release key event, which need to be de-duplicated. I had handled this for bound input, meaning the Release event wouldn't get assigned an action. For things that handled all key input though (e.g. text boxes), the events were still being duplicated.

Also, added a neat new macro assert_matches!, which cleans up a bunch of code.

Closes #226

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

It's possible there's still things subtly wrong in Windows since I can't test there. Mitigated by having the reporter confirm this fix works (see associated issue).

## QA

_How did you test this?_

- Added a unit test
- Had the reporter confirm this works

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
