### PR TITLE
Persist response query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- Persist response body query text box contents
+  - Previously it would reset whenever you made a new request or changed recipes
+
 ## [1.3.1] - 2024-05-21
 
 ### Fixed

--- a/src/http/record.rs
+++ b/src/http/record.rs
@@ -234,9 +234,8 @@ pub struct Body {
     /// Raw body
     data: Bytes,
     /// For responses of a known content type, we can parse the body into a
-    /// real data structure. This is populated *lazily*, i.e. on first request.
-    /// Useful for filtering and prettification. We store `None` here if we
-    /// tried and failed to parse, so that we know not to try again.
+    /// real data structure. This is populated *eagerly*. Call
+    /// [Response::parse_body] to set the parsed body.
     #[serde(skip)]
     parsed: OnceLock<Option<Box<dyn ResponseContent>>>,
 }

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -201,27 +201,42 @@ impl Factory for TemplateContext {
 }
 
 /// Directory containing static test data
-#[rstest::fixture]
+#[fixture]
 pub fn test_data_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("test_data")
 }
 
 /// Create a terminal instance for testing
-#[rstest::fixture]
-pub fn terminal() -> Terminal<TestBackend> {
-    let backend = TestBackend::new(10, 10);
+#[fixture]
+pub fn terminal(
+    terminal_width: u16,
+    terminal_height: u16,
+) -> Terminal<TestBackend> {
+    let backend = TestBackend::new(terminal_width, terminal_height);
     Terminal::new(backend).unwrap()
 }
 
+/// For injection to [terminal] fixture
+#[fixture]
+fn terminal_width() -> u16 {
+    10
+}
+
+/// For injection to [terminal] fixture
+#[fixture]
+fn terminal_height() -> u16 {
+    10
+}
+
 /// Create an in-memory database for a collection
-#[rstest::fixture]
+#[fixture]
 pub fn database() -> CollectionDatabase {
     CollectionDatabase::factory(())
 }
 
 /// Test fixture for using TUI context. The context is a global read-only var,
 /// so this will initialize it once for *all tests*.
-#[rstest::fixture]
+#[fixture]
 #[once]
 pub fn tui_context() -> &'static TuiContext {
     TuiContext::init(Config::default());
@@ -230,7 +245,7 @@ pub fn tui_context() -> &'static TuiContext {
 
 /// Create a new temporary folder. This will include a random subfolder to
 /// guarantee uniqueness for this test.
-#[rstest::fixture]
+#[fixture]
 pub fn temp_dir() -> TempDir {
     TempDir::new()
 }
@@ -259,7 +274,7 @@ impl Drop for TempDir {
     }
 }
 
-#[rstest::fixture]
+#[fixture]
 pub fn messages() -> MessageQueue {
     let (tx, rx) = mpsc::unbounded_channel();
     MessageQueue { tx: tx.into(), rx }
@@ -417,3 +432,4 @@ macro_rules! assert_events {
     }
 }
 pub(crate) use assert_events;
+use rstest::fixture;

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -219,7 +219,7 @@ pub fn terminal(
 /// For injection to [terminal] fixture
 #[fixture]
 fn terminal_width() -> u16 {
-    10
+    20
 }
 
 /// For injection to [terminal] fixture

--- a/src/tui/view/common/actions.rs
+++ b/src/tui/view/common/actions.rs
@@ -4,7 +4,9 @@ use crate::{
         component::Component,
         draw::{Draw, DrawMetadata, Generate, ToStringGenerate},
         event::{Event, EventHandler},
-        state::fixed_select::{FixedSelectState, FixedSelectWithoutDefault},
+        state::fixed_select::{
+            FixedSelect, FixedSelectState, FixedSelectWithoutDefault,
+        },
         ViewContext,
     },
     util::EnumChain,
@@ -95,7 +97,7 @@ pub enum GlobalAction {
     #[display("Edit Collection")]
     EditCollection,
 }
-
+impl FixedSelect for GlobalAction {}
 impl ToStringGenerate for GlobalAction {}
 
 /// Empty action list. Used when only the default global actions should be shown

--- a/src/tui/view/common/text_window.rs
+++ b/src/tui/view/common/text_window.rs
@@ -156,7 +156,7 @@ where
                     .collect::<Vec<Line>>(),
             )
             .alignment(Alignment::Right)
-            .style(styles.text_window.line_number),
+            .style(styles.text_window.gutter),
             gutter_area,
         );
 

--- a/src/tui/view/component/internal.rs
+++ b/src/tui/view/component/internal.rs
@@ -76,6 +76,8 @@ impl<T> Component<T> {
     where
         T: EventHandler,
     {
+        // TODO short-circuit should_handle? add test for that too
+
         // If we have a child, send them the event. If not, eat it ourselves
         for mut child in self.data_mut().children() {
             // Don't propgate to children that aren't visible or not in focus
@@ -223,6 +225,13 @@ impl<T> Component<T> {
         T: EventHandler,
     {
         use crate::tui::view::ViewContext;
+
+        // Safety check, prevent annoying bugs
+        assert!(
+            self.is_visible(),
+            "Component {} is not visible, it can't handle events",
+            self.name
+        );
 
         while let Some(event) = ViewContext::pop_event() {
             match self.update_all(event) {

--- a/src/tui/view/component/misc.rs
+++ b/src/tui/view/component/misc.rs
@@ -12,7 +12,7 @@ use crate::{
         component::Component,
         draw::{Draw, DrawMetadata, Generate},
         event::{Event, EventHandler, Update},
-        state::Notification,
+        state::{fixed_select::FixedSelect, Notification},
         Confirm, ViewContext,
     },
 };
@@ -157,6 +157,7 @@ enum ConfirmButton {
     #[default]
     Yes,
 }
+impl FixedSelect for ConfirmButton {}
 
 impl ConfirmModal {
     pub fn new(confirm: Confirm) -> Self {

--- a/src/tui/view/component/primary.rs
+++ b/src/tui/view/component/primary.rs
@@ -17,8 +17,10 @@ use crate::{
             draw::{Draw, DrawMetadata},
             event::{Event, EventHandler, Update},
             state::{
-                fixed_select::FixedSelectState,
-                persistence::{Persistent, PersistentKey},
+                fixed_select::{FixedSelect, FixedSelectState},
+                persistence::{
+                    impl_persistable, Persistable, Persistent, PersistentKey,
+                },
                 RequestState,
             },
             Component, ViewContext,
@@ -72,6 +74,7 @@ pub enum PrimaryPane {
     Recipe,
     Record,
 }
+impl FixedSelect for PrimaryPane {}
 
 /// The various things that can be requested (haha get it, requested) to be
 /// shown in fullscreen. If one of these is requested while not available, we
@@ -83,6 +86,7 @@ enum FullscreenMode {
     /// Fullscreen the active request/response
     Record,
 }
+impl_persistable!(Option<FullscreenMode>);
 
 /// Sentinel type for propagating an even that closes fullscreen mode
 struct ExitFullscreen;

--- a/src/tui/view/component/recipe_list.rs
+++ b/src/tui/view/component/recipe_list.rs
@@ -9,7 +9,9 @@ use crate::{
             draw::{Draw, DrawMetadata, Generate},
             event::{Event, EventHandler, Update},
             state::{
-                persistence::{Persistable, Persistent, PersistentKey},
+                persistence::{
+                    impl_persistable, Persistable, Persistent, PersistentKey,
+                },
                 select::SelectState,
             },
             Component, ViewContext,
@@ -249,17 +251,11 @@ impl PartialEq<RecipeNode> for RecipeId {
     }
 }
 
-/// Persistence for collapsed set of folders. Technically this can accrue
-/// removed folders over time (if they were collapsed at the time of deletion).
-/// That isn't really an issue though, it just means it'll be pre-collapsed if
-/// the user ever adds the folder back. Not worth working around.
-impl Persistable for Collapsed {
-    type Persisted = Self;
-
-    fn get_persistent(&self) -> &Self::Persisted {
-        self
-    }
-}
+// Persistence for collapsed set of folders. Technically this can accrue
+// removed folders over time (if they were collapsed at the time of deletion).
+// That isn't really an issue though, it just means it'll be pre-collapsed if
+// the user ever adds the folder back. Not worth working around.
+impl_persistable!(Collapsed);
 
 /// Construct select list based on which nodes are currently visible
 fn build_select_state(

--- a/src/tui/view/component/recipe_pane.rs
+++ b/src/tui/view/component/recipe_pane.rs
@@ -18,6 +18,7 @@ use crate::{
             draw::{Draw, DrawMetadata, Generate, ToStringGenerate},
             event::{Event, EventHandler, Update},
             state::{
+                fixed_select::FixedSelect,
                 persistence::{Persistable, Persistent, PersistentKey},
                 select::SelectState,
                 StateCell,
@@ -96,6 +97,7 @@ enum Tab {
     Headers,
     Authentication,
 }
+impl FixedSelect for Tab {}
 
 /// One row in the query/header table
 #[derive(Debug)]
@@ -522,11 +524,11 @@ mod tests {
     use super::*;
     use crate::{db::CollectionDatabase, test_util::*};
     use ratatui::{backend::TestBackend, Terminal};
-    use rstest::rstest;
+    use rstest::{fixture, rstest};
 
     /// Create component to be tested. Return the associated message queue too,
     /// so it can be tested
-    #[rstest::fixture]
+    #[fixture]
     fn component(
         _tui_context: &TuiContext,
         database: CollectionDatabase,

--- a/src/tui/view/component/recipe_pane.rs
+++ b/src/tui/view/component/recipe_pane.rs
@@ -534,19 +534,18 @@ mod tests {
         database: CollectionDatabase,
         mut messages: MessageQueue,
         mut terminal: Terminal<TestBackend>,
-    ) -> (MessageQueue, RecipePane) {
+    ) -> (MessageQueue, Component<RecipePane>) {
         ViewContext::init(database, messages.tx().clone());
         let recipe = Recipe::factory(());
-        let component = RecipePane::default();
+        let component: Component<RecipePane> = Component::default();
 
         // Draw once to initialize state
-        component.draw(
-            &mut terminal.get_frame(),
+        component.draw_term(
+            &mut terminal,
             RecipePaneProps {
                 selected_recipe: Some(&recipe),
                 selected_profile_id: None,
             },
-            DrawMetadata::default(),
         );
         // Clear template preview messages so we can test what we want
         messages.clear();
@@ -555,10 +554,12 @@ mod tests {
 
     /// Test "Copy URL" action
     #[rstest]
-    fn test_copy_url(component: (MessageQueue, RecipePane)) {
+    fn test_copy_url(component: (MessageQueue, Component<RecipePane>)) {
         let (mut messages, mut component) = component;
-        let update = component.update(Event::new_other(MenuAction::CopyUrl));
-        assert_matches!(update, Update::Consumed);
+        assert_matches!(
+            component.update_all(Event::new_other(MenuAction::CopyUrl)),
+            Update::Consumed
+        );
 
         let message = messages.pop_now();
         let Message::CopyRequestUrl(request_config) = &message else {
@@ -576,10 +577,12 @@ mod tests {
 
     /// Test "Copy Body" action
     #[rstest]
-    fn test_copy_body(component: (MessageQueue, RecipePane)) {
+    fn test_copy_body(component: (MessageQueue, Component<RecipePane>)) {
         let (mut messages, mut component) = component;
-        let update = component.update(Event::new_other(MenuAction::CopyBody));
-        assert_matches!(update, Update::Consumed);
+        assert_matches!(
+            component.update_all(Event::new_other(MenuAction::CopyBody)),
+            Update::Consumed
+        );
 
         let message = messages.pop_now();
         let Message::CopyRequestBody(request_config) = &message else {
@@ -597,10 +600,12 @@ mod tests {
 
     /// Test "Copy as cURL" action
     #[rstest]
-    fn test_copy_as_curl(component: (MessageQueue, RecipePane)) {
+    fn test_copy_as_curl(component: (MessageQueue, Component<RecipePane>)) {
         let (mut messages, mut component) = component;
-        let update = component.update(Event::new_other(MenuAction::CopyCurl));
-        assert_matches!(update, Update::Consumed);
+        assert_matches!(
+            component.update_all(Event::new_other(MenuAction::CopyCurl)),
+            Update::Consumed
+        );
 
         let message = messages.pop_now();
         let Message::CopyRequestCurl(request_config) = &message else {

--- a/src/tui/view/component/record_body.rs
+++ b/src/tui/view/component/record_body.rs
@@ -11,7 +11,10 @@ use crate::{
             },
             draw::{Draw, DrawMetadata},
             event::{Event, EventHandler, Update},
-            state::StateCell,
+            state::{
+                persistence::{Persistent, PersistentKey},
+                StateCell,
+            },
             Component, ViewContext,
         },
     },
@@ -38,7 +41,7 @@ pub struct RecordBody {
     /// Expression used to filter the content of the body down
     query: Option<Query>,
     /// Where the user enters their body query
-    query_text_box: Component<TextBox>,
+    query_text_box: Component<Persistent<TextBox>>,
 }
 
 pub struct RecordBodyProps<'a> {
@@ -49,32 +52,37 @@ pub struct RecordBodyProps<'a> {
 struct QuerySubmit(String);
 
 impl RecordBody {
+    /// Create a new body, optionally loading the query text from the
+    /// persistence DB. This is optional because not all callers use the query
+    /// box, or want to persist the value.
+    pub fn new(query_persistent_key: Option<PersistentKey>) -> Self {
+        let text_box = TextBox::default()
+            .with_focus(false)
+            .with_placeholder("'/' to filter body with JSONPath")
+            .with_validator(|text| JsonPath::parse(text).is_ok())
+            // Callback triggers an event, so we can modify our own state
+            .with_on_submit(|text_box| {
+                ViewContext::push_event(Event::new_other(QuerySubmit(
+                    text_box.text().to_owned(),
+                )))
+            });
+        Self {
+            text_window: Default::default(),
+            query_available: Cell::new(false),
+            query: Default::default(),
+            query_text_box: Persistent::optional(
+                query_persistent_key,
+                text_box,
+            )
+            .into(),
+        }
+    }
+
     /// Get visible body text
     pub fn text(&self) -> Option<String> {
         self.text_window
             .get()
             .map(|text_window| text_window.data().text().to_owned())
-    }
-}
-
-impl Default for RecordBody {
-    fn default() -> Self {
-        Self {
-            text_window: Default::default(),
-            query_available: Cell::new(false),
-            query: Default::default(),
-            query_text_box: TextBox::default()
-                .with_focus(false)
-                .with_placeholder("'/' to filter body with JSONPath")
-                .with_validator(|text| JsonPath::parse(text).is_ok())
-                // Callback triggers an event, so we can modify our own state
-                .with_on_submit(|text_box| {
-                    ViewContext::push_event(Event::new_other(QuerySubmit(
-                        text_box.text().to_owned(),
-                    )))
-                })
-                .into(),
-        }
     }
 }
 
@@ -180,4 +188,210 @@ fn init_text_window(
         .unwrap_or_else(|| format!("{:#}", MaybeStr(body.bytes())));
 
     TextWindow::new(body).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        collection::RecipeId, db::CollectionDatabase, http::Response,
+        test_util::*, tui::context::TuiContext,
+    };
+    use crossterm::event::{
+        KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers,
+    };
+    use ratatui::{backend::TestBackend, buffer::Buffer, text::Span, Terminal};
+    use reqwest::StatusCode;
+    use rstest::{fixture, rstest};
+
+    const TEXT: &[u8] = b"{\"greeting\":\"hello\"}";
+
+    /// Draw a component onto the terminal. Prefer this over calling
+    /// [Component::draw] directly, because that won't update Ratatui's internal
+    /// buffers correctly.
+    /// TODO move somewhere else
+    fn draw<Props, T: Draw<Props>>(
+        terminal: &mut Terminal<TestBackend>,
+        component: &Component<T>,
+        props: Props,
+    ) {
+        terminal
+            .draw(|frame| component.draw(frame, props, frame.size(), true))
+            .unwrap();
+    }
+
+    /// Generate an event for a keypress, and push it onto the event queue
+    /// TODO move
+    fn send_key(
+        code: KeyCode,
+        modifiers: KeyModifiers,
+        action: Option<Action>,
+    ) {
+        let crossterm_event = crossterm::event::Event::Key(KeyEvent {
+            code,
+            modifiers,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::empty(),
+        });
+        let event = Event::Input {
+            event: crossterm_event,
+            action,
+        };
+        ViewContext::push_event(event);
+    }
+
+    /// Send some text as a series of key events
+    /// TODO move
+    fn send_text(text: &str) {
+        for c in text.chars() {
+            send_key(KeyCode::Char(c), KeyModifiers::NONE, None);
+        }
+    }
+
+    /// Style text to match the text window gutter
+    fn gutter(text: &str) -> Span {
+        let styles = &TuiContext::get().styles;
+        Span::styled(text, styles.text_window.gutter)
+    }
+
+    #[fixture]
+    fn json_response() -> Response {
+        let response = Response {
+            status: StatusCode::OK,
+            headers: header_map([("Content-Type", "application/json")]),
+            body: Body::new(TEXT.into()),
+        };
+        response.parse_body();
+        response
+    }
+
+    /// Render an unparsed body with no query box
+    #[rstest]
+    fn test_unparsed(
+        _tui_context: &TuiContext,
+        database: CollectionDatabase,
+        messages: MessageQueue,
+        #[with(30, 2)] mut terminal: Terminal<TestBackend>,
+    ) {
+        ViewContext::init(database.clone(), messages.tx().clone());
+        let component = RecordBody::new(None).into();
+        let body = Body::new(TEXT.into());
+        draw(&mut terminal, &component, RecordBodyProps { body: &body });
+
+        // Assert state
+        let data = component.data();
+        assert_eq!(
+            data.text().as_deref(),
+            Some(std::str::from_utf8(TEXT).unwrap())
+        );
+        assert!(!data.query_available.get());
+        assert_eq!(data.query, None);
+
+        // Assert view
+        // TODO use assert_buffer_lines
+        terminal.backend().assert_buffer(&Buffer::with_lines([
+            vec![gutter("1"), " {\"greeting\":\"hello\"}    ".into()],
+            vec![gutter(" "), "                             ".into()],
+        ]));
+    }
+
+    /// Render a parsed body with query text box
+    #[rstest]
+    fn test_parsed(
+        tui_context: &TuiContext,
+        database: CollectionDatabase,
+        messages: MessageQueue,
+        json_response: Response,
+        #[with(32, 5)] mut terminal: Terminal<TestBackend>,
+    ) {
+        ViewContext::init(database.clone(), messages.tx().clone());
+        let mut component = RecordBody::new(None).into();
+        let props = || RecordBodyProps {
+            body: &json_response.body,
+        };
+        draw(&mut terminal, &component, props());
+
+        // Assert state
+        let data = component.data();
+        assert!(data.query_available.get());
+        assert_eq!(data.query, None);
+        assert_eq!(
+            data.text().as_deref(),
+            Some("{\n  \"greeting\": \"hello\"\n}")
+        );
+
+        // Assert view
+        let styles = &tui_context.styles.text_box;
+        terminal.backend().assert_buffer(&Buffer::with_lines([
+            vec![gutter("1"), " {                        ".into()],
+            vec![gutter("2"), "   \"greeting\": \"hello\"".into()],
+            vec![gutter("3"), " }                        ".into()],
+            vec![gutter(" "), "                          ".into()],
+            vec![Span::styled(
+                "'/' to filter body with JSONPath",
+                styles.text.patch(styles.placeholder),
+            )],
+        ]));
+
+        // Type something into the query box
+        send_key(KeyCode::Char('/'), KeyModifiers::NONE, Some(Action::Search));
+        component.drain_events();
+        // Re-draw to update focus for text box
+        draw(&mut terminal, &component, props());
+        send_text("$.greeting");
+        send_key(KeyCode::Enter, KeyModifiers::NONE, Some(Action::Submit));
+        component.drain_events();
+        // Re-draw again to apply query to body
+        draw(&mut terminal, &component, props());
+
+        // Make sure state updated correctly
+        let data = component.data();
+        assert_eq!(data.query, Some("$.greeting".parse().unwrap()));
+        assert_eq!(data.text().as_deref(), Some("[\n  \"hello\"\n]"));
+
+        // Check the view again too
+        terminal.backend().assert_buffer(&Buffer::with_lines([
+            vec![gutter("1"), " [                        ".into()],
+            vec![gutter("2"), "   \"hello\"              ".into()],
+            vec![gutter("3"), " ]                        ".into()],
+            vec![gutter(" "), "                          ".into()],
+            vec![Span::styled(
+                "$.greeting                      ",
+                styles.text,
+            )],
+        ]));
+    }
+
+    /// Render a parsed body with query text box, and initial query from the DB
+    #[rstest]
+    fn test_initial_query(
+        _tui_context: &TuiContext,
+        database: CollectionDatabase,
+        messages: MessageQueue,
+        json_response: Response,
+        #[with(30, 4)] mut terminal: Terminal<TestBackend>,
+    ) {
+        ViewContext::init(database.clone(), messages.tx().clone());
+        let recipe_id = RecipeId::factory(());
+
+        // Add initial query to the DB
+        let persistent_key =
+            PersistentKey::ResponseBodyQuery(recipe_id.clone());
+        database.set_ui(&persistent_key, "$.greeting").unwrap();
+
+        // We already have another test to check that querying works via typing
+        // in the box, so we just need to make sure state is initialized
+        // correctly here
+        let mut component: Component<_> =
+            RecordBody::new(Some(persistent_key)).into();
+        draw(
+            &mut terminal,
+            &component,
+            RecordBodyProps {
+                body: &json_response.body,
+            },
+        );
+        component.drain_events(); // Events are triggered during init
+        assert_eq!(component.data().query, Some("$.greeting".parse().unwrap()));
+    }
 }

--- a/src/tui/view/component/record_pane.rs
+++ b/src/tui/view/component/record_pane.rs
@@ -17,7 +17,7 @@ use crate::{
             },
             draw::{Draw, DrawMetadata, Generate},
             event::{Event, EventHandler, Update},
-            state::persistence::PersistentKey,
+            state::{fixed_select::FixedSelect, persistence::PersistentKey},
             RequestState, ViewContext,
         },
     },
@@ -81,6 +81,7 @@ enum Tab {
     Body,
     Headers,
 }
+impl FixedSelect for Tab {}
 
 impl EventHandler for RecordPane {
     fn update(&mut self, event: Event) -> Update {
@@ -230,6 +231,7 @@ impl<'a> Draw<RecordPaneProps<'a>> for RecordPane {
                                 frame,
                                 ResponseBodyViewProps {
                                     request_id: record.id,
+                                    recipe_id: &record.request.recipe_id,
                                     response: Arc::clone(&record.response),
                                 },
                                 content_area,

--- a/src/tui/view/component/request_view.rs
+++ b/src/tui/view/component/request_view.rs
@@ -105,7 +105,7 @@ impl Draw<RequestViewProps> for RequestView {
     ) {
         let state = self.state.get_or_update(props.request.id, || State {
             request: Arc::clone(&props.request),
-            body: Default::default(),
+            body: RecordBody::new(None).into(),
         });
 
         let [url_area, headers_area, body_area] = Layout::vertical([

--- a/src/tui/view/component/response_view.rs
+++ b/src/tui/view/component/response_view.rs
@@ -209,25 +209,25 @@ mod tests {
     ) {
         ViewContext::init(database.clone(), messages.tx().clone());
         // Draw once to initialize state
-        let mut component = ResponseBodyView::default();
+        let mut component: Component<ResponseBodyView> = Component::default();
         response.parse_body(); // Normally the view does this
         let record = RequestRecord {
             response: response.into(),
             ..RequestRecord::factory(())
         };
-        component.draw(
-            &mut terminal.get_frame(),
+        component.draw_term(
+            &mut terminal,
             ResponseBodyViewProps {
                 request_id: record.id,
                 recipe_id: &record.request.recipe_id,
                 response: record.response,
             },
-            DrawMetadata::default(),
         );
 
-        let update =
-            component.update(Event::new_other(BodyMenuAction::CopyBody));
-        assert_matches!(update, Update::Consumed);
+        assert_matches!(
+            component.update_all(Event::new_other(BodyMenuAction::CopyBody)),
+            Update::Consumed
+        );
 
         let message = messages.pop_now();
         let Message::CopyText(body) = &message else {
@@ -280,7 +280,7 @@ mod tests {
         #[case] expected_path: &str,
     ) {
         ViewContext::init(database.clone(), messages.tx().clone());
-        let mut component = ResponseBodyView::default();
+        let mut component: Component<ResponseBodyView> = Component::default();
         response.parse_body(); // Normally the view does this
         let record = RequestRecord {
             response: response.into(),
@@ -288,19 +288,19 @@ mod tests {
         };
 
         // Draw once to initialize state
-        component.draw(
-            &mut terminal.get_frame(),
+        component.draw_term(
+            &mut terminal,
             ResponseBodyViewProps {
                 request_id: record.id,
                 recipe_id: &record.request.recipe_id,
                 response: record.response,
             },
-            DrawMetadata::default(),
         );
 
-        let update =
-            component.update(Event::new_other(BodyMenuAction::SaveBody));
-        assert_matches!(update, Update::Consumed);
+        assert_matches!(
+            component.update_all(Event::new_other(BodyMenuAction::SaveBody)),
+            Update::Consumed
+        );
 
         let message = messages.pop_now();
         let Message::SaveFile { data, default_path } = &message else {

--- a/src/tui/view/component/root.rs
+++ b/src/tui/view/component/root.rs
@@ -214,7 +214,7 @@ impl Draw for Root {
 
 /// A wrapper for the selected request ID. This is needed to customize
 /// persistence loading. We have to load the persisted value via an event so it
-/// can be loaded into the DB.
+/// can be loaded from the DB.
 #[derive(Debug, Default, Deref, DerefMut)]
 struct SelectedRequestId(Option<RequestId>);
 

--- a/src/tui/view/draw.rs
+++ b/src/tui/view/draw.rs
@@ -39,7 +39,6 @@ where
 
 /// Metadata associated with each draw action, which may instruct how the draw
 /// should occur.
-/// TODO remove default impl
 #[derive(Copy, Clone, Debug, Default)]
 pub struct DrawMetadata {
     /// Which area on the screen should we draw to?

--- a/src/tui/view/draw.rs
+++ b/src/tui/view/draw.rs
@@ -39,6 +39,7 @@ where
 
 /// Metadata associated with each draw action, which may instruct how the draw
 /// should occur.
+/// TODO remove default impl
 #[derive(Copy, Clone, Debug, Default)]
 pub struct DrawMetadata {
     /// Which area on the screen should we draw to?

--- a/src/tui/view/state/fixed_select.rs
+++ b/src/tui/view/state/fixed_select.rs
@@ -1,10 +1,13 @@
-use crate::tui::view::{
-    draw::{Draw, DrawMetadata},
-    event::{Event, EventHandler, Update},
-    state::{
-        persistence::{Persistable, PersistentContainer},
-        select::{SelectState, SelectStateBuilder, SelectStateData},
+use crate::{
+    tui::view::{
+        draw::{Draw, DrawMetadata},
+        event::{Event, EventHandler, Update},
+        state::{
+            persistence::{Persistable, PersistentContainer},
+            select::{SelectState, SelectStateBuilder, SelectStateData},
+        },
     },
+    util::EnumChain,
 };
 use itertools::Itertools;
 use ratatui::{
@@ -175,7 +178,8 @@ where
 
 impl<Item, State> PersistentContainer for FixedSelectState<Item, State>
 where
-    Item: FixedSelect + Persistable<Persisted = Item>,
+    Item: FixedSelect + Persistable,
+    Item::Persisted: PartialEq<Item>,
     State: SelectStateData,
 {
     type Value = Item;
@@ -222,5 +226,12 @@ impl<T> FixedSelectWithoutDefault for T where
 /// Trait alias for a static list of items to be cycled through
 pub trait FixedSelect: FixedSelectWithoutDefault + Default {}
 
-/// Auto-impl for anything we can
-impl<T> FixedSelect for T where T: FixedSelectWithoutDefault + Default {}
+// / Auto-impl for anything we can
+// impl<T> FixedSelect for T where T: FixedSelectWithoutDefault + Default {}
+
+impl<T, U> FixedSelect for EnumChain<T, U>
+where
+    T: FixedSelect,
+    U: FixedSelectWithoutDefault,
+{
+}

--- a/src/tui/view/theme.rs
+++ b/src/tui/view/theme.rs
@@ -145,7 +145,7 @@ pub struct TextBoxStyle {
 #[derive(Debug)]
 pub struct TextWindowStyle {
     /// Line numbers on large text areas
-    pub line_number: Style,
+    pub gutter: Style,
 }
 
 impl Styles {
@@ -213,7 +213,7 @@ impl Styles {
                 invalid: Style::default().bg(Color::LightRed),
             },
             text_window: TextWindowStyle {
-                line_number: Style::default().fg(Color::DarkGray),
+                gutter: Style::default().fg(Color::DarkGray),
             },
         }
     }


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Response query text box now persists the query. Each recipe gets its own persistent slot, so changing recipes and changing back will keep the previous query.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

There could still be mistakes in the behavior, I need to play with it more. Also it's possible that someone enters a query and forgets, and is confused about the shown response body. This could be mitigated by adding more of a visual indicator when a query is applied.

## QA

_How did you test this?_

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
