### PR TITLE
Offer recipe-related actions in recipe list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- Show "Copy URL", "Copy Body" and "Copy as cURL" actions from the Recipe list [#224](https://github.com/LucasPickering/slumber/issues/224)
+  - Previously this was only available in the Recipe detail pane
+- Fix Edit Collection action in menu
 - Persist response body query text box contents
   - Previously it would reset whenever you made a new request or changed recipes
 

--- a/src/collection/models.rs
+++ b/src/collection/models.rs
@@ -307,6 +307,26 @@ pub enum ChainOutputTrim {
     Both,
 }
 
+/// Test-only helpers
+#[cfg(test)]
+impl Collection {
+    /// Get the ID of the first **recipe** (not recipe node) in the list. Panic
+    /// if empty. This is useful because the default collection factory includes
+    /// one recipe.
+    pub fn first_recipe_id(&self) -> &RecipeId {
+        self.recipes
+            .recipe_ids()
+            .next()
+            .expect("Collection has no recipes")
+    }
+
+    /// Get the ID of the first profile in the list. Panic if empty. This is
+    /// useful because the default collection factory includes one profile.
+    pub fn first_profile_id(&self) -> &ProfileId {
+        self.profiles.first().expect("Collection has no profiles").0
+    }
+}
+
 impl Profile {
     /// Get a presentable name for this profile
     pub fn name(&self) -> &str {

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -219,13 +219,13 @@ pub fn terminal(
 /// For injection to [terminal] fixture
 #[fixture]
 fn terminal_width() -> u16 {
-    20
+    40
 }
 
 /// For injection to [terminal] fixture
 #[fixture]
 fn terminal_height() -> u16 {
-    10
+    20
 }
 
 /// Create an in-memory database for a collection

--- a/src/tui/view/component/recipe_list.rs
+++ b/src/tui/view/component/recipe_list.rs
@@ -4,8 +4,8 @@ use crate::{
         context::TuiContext,
         input::Action,
         view::{
-            common::{list::List, Pane},
-            component::primary::PrimaryPane,
+            common::{actions::ActionsModal, list::List, Pane},
+            component::{primary::PrimaryPane, recipe_pane::RecipeMenuAction},
             draw::{Draw, DrawMetadata, Generate},
             event::{Event, EventHandler, Update},
             state::{
@@ -151,6 +151,9 @@ impl EventHandler for RecipeListPane {
             // selected. Fall through to propagate the event
             Action::Submit
                 if self.set_selected_collapsed(CollapseState::Toggle) => {}
+            Action::OpenActions => ViewContext::open_modal_default::<
+                ActionsModal<RecipeMenuAction>,
+            >(),
             _ => return Update::Propagate(event),
         }
 

--- a/src/tui/view/state.rs
+++ b/src/tui/view/state.rs
@@ -60,16 +60,6 @@ impl<K, V> StateCell<K, V> {
         Ref::map(self.state.borrow(), |state| &state.as_ref().unwrap().1)
     }
 
-    /// Get a reference to the state key. This can panic, if the state key/value
-    /// is already borrowed elsewhere. Returns `None` iff the setate cell is
-    /// uninitialized.
-    pub fn key(&self) -> Option<Ref<'_, K>> {
-        Ref::filter_map(self.state.borrow(), |state| {
-            state.as_ref().map(|(k, _)| k)
-        })
-        .ok()
-    }
-
     /// Get a reference to the state value. This can panic, if the state value
     /// is already borrowed elsewhere. Returns `None` iff the state cell is
     /// uninitialized.


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Also fix Edit Collection action, which was being eaten by `PrimaryView`.

<img width="230" alt="image" src="https://github.com/LucasPickering/slumber/assets/2382935/6057eff9-8a16-4cd1-843e-39c8a621011d">


Closes #224

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Aciton UX is still wonky. Working on a longer term plan to fix that.

## QA

_How did you test this?_

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
