### PR TITLE
Exit modal instead of app for Action::Quit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- When a modal/dialog is open `q` now exits the dialog instead of the entire app
 - Upgrade to Rust 1.76
 
 ## [1.3.2] - 2024-05-27

--- a/src/tui/view/common/modal.rs
+++ b/src/tui/view/common/modal.rs
@@ -99,8 +99,10 @@ impl EventHandler for ModalQueue {
             // Close the active modal. If there's no modal open, we'll propagate
             // the event down
             Event::Input {
-                // Enter to close is a convenience thing, modals may override
-                action: Some(Action::Cancel | Action::Submit),
+                // Enter to close is a convenience thing, modals may override.
+                // We eat the Quit action here because it's (hopefully)
+                // intuitive and consistent with other TUIs
+                action: Some(Action::Cancel | Action::Quit | Action::Submit),
                 event: _,
             }
             | Event::CloseModal => {


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

This feels more intuitive.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Could be unintuitive for some users. You can still ctrl-c to exit the app from anywhere though.

## QA

_How did you test this?_

Manually in TUI

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
