### PR TITLE
Support multiple instances of query param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   - `!json` [#242](https://github.com/LucasPickering/slumber/issues/242)
   - `!form_urlencoded` [#244](https://github.com/LucasPickering/slumber/issues/244)
   - [See docs](https://slumber.lucaspickering.me/book/api/request_collection/recipe_body.html) for usage instructions
+- Support multiple instances of the same query param [#245](https://github.com/LucasPickering/slumber/issues/245) (@maksimowiczm)
+  - Query params can now be defined as a list of `<param>=<value>` entries
+  - [See docs](https://slumber.lucaspickering.me/book/api/request_collection/query_parameters.html)
 - Templates can now render binary values in certain contexts
   - [See docs](https://slumber.lucaspickering.me/book/user_guide/templates.html#binary-templates)
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -28,6 +28,7 @@
 - [Request Collection](./api/request_collection/index.md)
   - [Profile](./api/request_collection/profile.md)
   - [Request Recipe](./api/request_collection/request_recipe.md)
+    - [Query Parameters](./api/request_collection/query_parameters.md)
     - [Authentication](./api/request_collection/authentication.md)
     - [Recipe Body](./api/request_collection/recipe_body.md)
     - [Chain](./api/request_collection/chain.md)

--- a/docs/src/api/request_collection/query_parameters.md
+++ b/docs/src/api/request_collection/query_parameters.md
@@ -1,0 +1,32 @@
+# Query Parameters
+
+Query parameters are a component of a request URL. They provide additional information to the server about a request. In a request recipe, query parameters can be defined in one of two formats:
+
+- Mapping of `key: value`
+- List of strings, in the format `<key>=<value>`
+
+The mapping format is typically more readable, but the list format allows you to define the same query parameter multiple times. In either format, **the key is treated as a plain string but the value is treated as a template**.
+
+> Note: If you need to include a `=` in your parameter _name_, you'll need to use the mapping format. That means there is currently no support for multiple instances of a parameter with `=` in the name. This is very unlikely to be a restriction in the real world, but if you need support for this please [open an issue](https://github.com/LucasPickering/slumber/issues/new/choose).
+
+## Examples
+
+```yaml
+recipes:
+  get_fishes_mapping: !request
+    method: GET
+    url: "{{host}}/get"
+    query:
+      big: true
+      color: red
+      name: "{{name}}"
+
+  get_fishes_list: !request
+    method: GET
+    url: "{{host}}/get"
+    query:
+      - big=true
+      - color=red
+      - color=blue
+      - name={{name}}
+```

--- a/docs/src/api/request_collection/request_recipe.md
+++ b/docs/src/api/request_collection/request_recipe.md
@@ -15,7 +15,7 @@ The tag for a recipe is `!request` (see examples).
 | `name`           | `string`                                     | Descriptive name to use in the UI | Value of key in parent |
 | `method`         | `string`                                     | HTTP request method               | Required               |
 | `url`            | [`Template`](./template.md)                  | HTTP request URL                  | Required               |
-| `query`          | [`mapping[string, Template]`](./template.md) | HTTP request query parameters     | `{}`                   |
+| `query`          | [`QueryParameters`](./query_parameters.md)   | URL query parameters              | `{}`                   |
 | `headers`        | [`mapping[string, Template]`](./template.md) | HTTP request headers              | `{}`                   |
 | `authentication` | [`Authentication`](./authentication.md)      | Authentication scheme             | `null`                 |
 | `body`           | [`RecipeBody`](./recipe_body.md)             | HTTP request body                 | `null`                 |
@@ -40,7 +40,7 @@ recipes:
     headers:
       accept: application/json
     query:
-      root_access: yes_please
+      - root_access=yes_please
     body:
       !json {
         "username": "{{chains.username}}",
@@ -58,5 +58,5 @@ recipes:
         method: GET
         url: "{{host}}/fishes"
         query:
-          big: true
+          - big=true
 ```

--- a/docs/src/cli/generate.md
+++ b/docs/src/cli/generate.md
@@ -17,7 +17,7 @@ requests:
     method: GET
     url: "{{host}}/fishes"
     query:
-      big: true
+      - big=true
 ```
 
 ```sh

--- a/docs/src/cli/request.md
+++ b/docs/src/cli/request.md
@@ -24,7 +24,7 @@ requests:
     method: GET
     url: "{{host}}/fishes"
     query:
-      big: true
+      - big=true
 ```
 
 ```sh

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -49,7 +49,7 @@ requests:
     method: GET
     url: "{{host}}/fishes"
     query:
-      big: true
+      - big=true
 ```
 
 This request collection uses [templates](./user_guide//templates.md) and [profiles](./api/request_collection/profile.md) allow you to dynamically change the target host.

--- a/docs/src/user_guide/filter_query.md
+++ b/docs/src/user_guide/filter_query.md
@@ -54,7 +54,7 @@ requests:
     method: GET
     url: "https://myfishes.fish/anything/current-user"
     query:
-      auth: "{{chains.auth_token}}"
+      - auth={{chains.auth_token}}
 ```
 
 While this example simple extracts inner fields, JSONPath can be used for much more powerful transformations. See the [JSONPath docs](https://www.ietf.org/archive/id/draft-goessner-dispatch-jsonpath-00.html) or [this JSONPath editor](https://jsonpath.com/) for more examples.
@@ -95,7 +95,7 @@ requests:
     method: GET
     url: "https://myfishes.fish/anything/current-user"
     query:
-      auth: "{{chains.auth_token}}"
+      - auth={{chains.auth_token}}
 ```
 
 You can use this capability to manipulate responses via `grep`, `awk`, or any other program you like.

--- a/docs/src/user_guide/inheritance.md
+++ b/docs/src/user_guide/inheritance.md
@@ -21,7 +21,7 @@ requests:
     method: GET
     url: "{{host}}/fishes"
     query:
-      big: true
+      - big=true
     headers:
       Accept: application/json
     authentication: !bearer "{{chains.token}}"
@@ -65,7 +65,7 @@ requests:
     method: GET
     url: "{{host}}/fishes"
     query:
-      big: true
+      - big=true
 
   get_fish: !request
     <<: *request_base
@@ -102,7 +102,7 @@ requests:
     method: GET
     url: "{{host}}/fishes"
     query:
-      big: true
+      - big=true
 
   get_fish: !request
     <<: *request_base

--- a/docs/src/user_guide/templates.md
+++ b/docs/src/user_guide/templates.md
@@ -34,7 +34,7 @@ requests:
     method: GET
     url: "{{host}}/fishes"
     query:
-      big: true
+      - big=true
 ```
 
 Now you can easily select which host to hit. In the TUI, this is done via the Profile list. In the CLI, use the `--profile` option:

--- a/slumber.yml
+++ b/slumber.yml
@@ -41,8 +41,9 @@ requests:
     method: POST
     url: "{{host}}/anything/login"
     query:
-      sudo: yes_please
-      fast: no_thanks
+      - sudo=yes_please
+      - fast=no_thanks
+      - fast=actually_maybe
     headers:
       Accept: application/json
     body: !form_urlencoded
@@ -58,7 +59,7 @@ requests:
         method: GET
         url: "{{host}}/get"
         query:
-          foo: bar
+          - foo=bar
 
       get_user: !request
         <<: *base

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -462,10 +462,10 @@ mod tests {
                             .into(),
                     )),
                     authentication: None,
-                    query: indexmap! {
-                        "sudo".into() => "yes_please".into(),
-                        "fast".into() => "no_thanks".into(),
-                    },
+                    query: vec![
+                        ("sudo".into(), "yes_please".into()),
+                        ("fast".into(), "no_thanks".into()),
+                    ],
                     headers: indexmap! {
                         "Accept".into() => "application/json".into(),
                     },
@@ -479,10 +479,12 @@ mod tests {
                             name: Some("Get User".into()),
                             method: Method::Get,
                             url: "{{host}}/anything/{{user_guid}}".into(),
-
                             body: None,
                             authentication: None,
-                            query: indexmap! {},
+                            query: vec![
+                                ("value".into(), "{{field1}}".into()),
+                                ("value".into(), "{{field2}}".into()),
+                            ],
                             headers: indexmap! {},
                         }),
                         RecipeNode::Recipe(Recipe {
@@ -490,7 +492,6 @@ mod tests {
                             name: Some("Modify User".into()),
                             method: Method::Put,
                             url: "{{host}}/anything/{{user_guid}}".into(),
-
                             body: Some(RecipeBody::Json(
                                 json!({
                                     "username": "new username"
@@ -500,7 +501,7 @@ mod tests {
                             authentication: Some(Authentication::Bearer(
                                 "{{chains.auth_token}}".into(),
                             )),
-                            query: indexmap! {},
+                            query: vec![],
                             headers: indexmap! {
                                 "Accept".into() => "application/json".into(),
                             },
@@ -518,7 +519,7 @@ mod tests {
                                 username: "{{username}}".into(),
                                 password: Some("{{password}}".into()),
                             }),
-                            query: indexmap! {},
+                            query: vec![],
                             headers: indexmap! {
                                 "Accept".into() => "application/json".into(),
                             },
@@ -533,7 +534,7 @@ mod tests {
                                 "username".into() => "new username".into()
                             })),
                             authentication: None,
-                            query: indexmap! {},
+                            query: vec![],
                             headers: indexmap! {
                                 "Accept".into() => "application/json".into(),
                             },

--- a/src/collection/models.rs
+++ b/src/collection/models.rs
@@ -150,7 +150,7 @@ impl crate::test_util::Factory for Recipe {
             url: "http://localhost/url".into(),
             body: None,
             authentication: None,
-            query: IndexMap::new(),
+            query: Vec::new(),
             headers: IndexMap::new(),
         }
     }
@@ -174,8 +174,11 @@ pub struct Recipe {
     pub url: Template,
     pub body: Option<RecipeBody>,
     pub authentication: Option<Authentication>,
-    #[serde(default)]
-    pub query: IndexMap<String, Template>,
+    #[serde(
+        default,
+        deserialize_with = "cereal::deserialize_query_parameters"
+    )]
+    pub query: Vec<(String, Template)>,
     #[serde(default)]
     pub headers: IndexMap<String, Template>,
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -391,7 +391,7 @@ impl Recipe {
             .iter()
             // Filter out disabled params
             .filter(|(param, _)| {
-                !options.disabled_query_parameters.contains(*param)
+                !options.disabled_query_parameters.contains(param)
             })
             .map(|(k, v)| async move {
                 Ok::<_, anyhow::Error>((
@@ -731,10 +731,10 @@ mod tests {
         let recipe = Recipe {
             method: collection::Method::Post,
             url: "{{host}}/users/{{user_id}}".into(),
-            query: indexmap! {
-                "mode".into() => "{{mode}}".into(),
-                "fast".into() => "true".into(),
-            },
+            query: vec![
+                ("mode".into(), "{{mode}}".into()),
+                ("fast".into(), "true".into()),
+            ],
             headers: indexmap! {
                 // Leading/trailing newlines should be stripped
                 "Accept".into() => "application/json".into(),
@@ -779,10 +779,12 @@ mod tests {
     ) {
         let recipe = Recipe {
             url: "{{host}}/users/{{user_id}}".into(),
-            query: indexmap! {
-                "mode".into() => "{{mode}}".into(),
-                "fast".into() => "true".into(),
-            },
+            query: vec![
+                ("mode".into(), "{{mode}}".into()),
+                ("fast".into(), "true".into()),
+                ("fast".into(), "false".into()),
+                ("mode".into(), "user".into()),
+            ],
             ..Recipe::factory(())
         };
 
@@ -794,7 +796,7 @@ mod tests {
 
         assert_eq!(
             url.as_str(),
-            "http://localhost/users/1?mode=sudo&fast=true"
+            "http://localhost/users/1?mode=sudo&fast=true&fast=false&mode=user"
         );
     }
 
@@ -983,12 +985,12 @@ mod tests {
         template_context: TemplateContext,
     ) {
         let recipe = Recipe {
-            query: indexmap! {
+            query: vec![
                 // Included
-                "mode".into() => "sudo".into(),
+                ("mode".into(), "sudo".into()),
                 // Excluded
-                "fast".into() => "true".into(),
-            },
+                ("fast".into(), "true".into()),
+            ],
             headers: indexmap! {
                 // Included
                 "Accept".into() => "application/json".into(),

--- a/src/http/models.rs
+++ b/src/http/models.rs
@@ -20,7 +20,6 @@ use reqwest::{
 };
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashSet,
     fmt::{Debug, Write},
     sync::{Arc, OnceLock},
 };
@@ -77,17 +76,21 @@ impl RequestSeed {
 /// recipes everywhere. Recipes could be very large so cloning may be expensive,
 /// and this options layer makes the available modifications clear and
 /// restricted.
+///
+/// These store *indexes* rather than keys because keys may not be necessarily
+/// unique (e.g. in the case of query params). Technically some could use keys
+/// and some could use indexes, but I chose consistency. I also chose `Vec` over
+/// `HashSet` because I expect these to be very small, so we don't need the
+/// overhead of hashing.
 #[derive(Clone, Debug, Default)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct BuildOptions {
-    /// Which headers should be excluded? A blacklist allows the default to be
-    /// "include all".
-    pub disabled_headers: HashSet<String>,
-    /// Which query parameters should be excluded?  A blacklist allows the
-    /// default to be "include all".
-    pub disabled_query_parameters: HashSet<String>,
+    /// Which headers should be excluded?
+    pub disabled_headers: Vec<usize>,
+    /// Which query parameters should be excluded?
+    pub disabled_query_parameters: Vec<usize>,
     /// For form bodies, which form fields should be excluded?
-    pub disabled_form_fields: HashSet<String>,
+    pub disabled_form_fields: Vec<usize>,
 }
 
 /// A request ready to be launched into through the stratosphere. This is

--- a/src/template.rs
+++ b/src/template.rs
@@ -60,15 +60,19 @@ pub struct TemplateContext {
 
 /// An immutable string that can contain templated content. The string is parsed
 /// during creation to identify template keys, hence the immutability.
-#[derive(Clone, Debug, Default, Display, Serialize)]
-#[cfg_attr(test, derive(PartialEq))]
+///
+/// Invariant: two templates with the same source string will have the same set
+/// of chunks
+#[derive(Clone, Debug, Default, Display, PartialEq, Serialize)]
 #[display("{template}")]
 #[serde(into = "String", try_from = "String")]
 pub struct Template {
     template: String,
     /// Pre-parsed chunks of the template. We can't store slices here because
     /// that would be self-referential, so just store locations. These chunks
-    /// are contiguous and span the whole template.
+    /// are contiguous and span the whole template. We *could* omit this from
+    /// the `PartialEq` check because of the above invariant, but let's keep
+    /// it in to be safe for tests.
     chunks: Vec<TemplateInputChunk<Span>>,
 }
 
@@ -160,8 +164,7 @@ pub enum TemplateChunk {
 ///
 /// The `Display` impl here should return exactly what this was parsed from.
 /// This is important for matching override keys during rendering.
-#[derive(Copy, Clone, Debug, Display)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Copy, Clone, Debug, Display, PartialEq)]
 enum TemplateKey<T> {
     /// A plain field, which can come from the profile or an override
     Field(T),

--- a/src/template/parse.rs
+++ b/src/template/parse.rs
@@ -39,8 +39,7 @@ impl Template {
 
 /// A parsed piece of a template. After parsing, each chunk is either raw text
 /// or a parsed key, ready to be rendered.
-#[derive(Copy, Clone, Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum TemplateInputChunk<T> {
     Raw(T),
     Key(TemplateKey<T>),
@@ -59,8 +58,7 @@ impl<T> TemplateInputChunk<T> {
 
 /// Indexes defining a substring of text within some string. This is a useful
 /// alternative to string slices when avoiding self-referential structs.
-#[derive(Copy, Clone, Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Span {
     start: usize,
     /// Store length instead of end so it can never be invalid

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -11,8 +11,12 @@ use indexmap::IndexMap;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use rstest::fixture;
 use std::{
-    env, fs,
+    env, fs, io,
     path::{Path, PathBuf},
+};
+use tracing_subscriber::{
+    fmt::format::FmtSpan, layer::SubscriberExt, util::SubscriberInitExt,
+    EnvFilter, Layer,
 };
 use uuid::Uuid;
 
@@ -27,6 +31,21 @@ use uuid::Uuid;
 /// multiple param types.
 pub trait Factory<Param = ()> {
     fn factory(param: Param) -> Self;
+}
+
+/// Set up tracing for tests. This needs to be manually pulled into whatever
+/// tests want it.
+#[fixture]
+#[once]
+pub fn tracing() {
+    // Initialize tracing
+    let subscriber = tracing_subscriber::fmt::layer()
+        .with_writer(io::stderr)
+        .with_target(false)
+        .with_span_events(FmtSpan::NEW)
+        .without_time()
+        .with_filter(EnvFilter::from_default_env());
+    tracing_subscriber::registry().with(subscriber).init();
 }
 
 /// Directory containing static test data

--- a/src/tui/view/common/template_preview.rs
+++ b/src/tui/view/common/template_preview.rs
@@ -55,6 +55,13 @@ impl TemplatePreview {
             Self::Disabled { template }
         }
     }
+
+    pub fn template(&self) -> &Template {
+        match self {
+            Self::Disabled { template } => template,
+            Self::Enabled { template, .. } => template,
+        }
+    }
 }
 
 impl Generate for &TemplatePreview {

--- a/src/tui/view/state/persistence.rs
+++ b/src/tui/view/state/persistence.rs
@@ -3,6 +3,7 @@
 use crate::{
     collection::RecipeId,
     http::RequestId,
+    template::Template,
     tui::view::{
         component::Component,
         context::ViewContext,
@@ -99,10 +100,17 @@ pub enum PersistentKey {
     /// Selected tab in the recipe pane
     RecipeTab,
 
-    /// Selected query param, per recipe. Value is the query param name
+    /// Selected query param, per recipe. Value is the query param name. The
+    /// param isn't necessarily unique so sometimes this will be wrong, but
+    /// it's close enough for now.
     RecipeSelectedQuery(RecipeId),
-    /// Toggle state for a single recipe+query param
-    RecipeQuery { recipe: RecipeId, param: String },
+    /// Toggle state for a single recipe+query param. Include the value because
+    /// keys aren't unique.
+    RecipeQuery {
+        recipe_id: RecipeId,
+        param: String,
+        value: Template,
+    },
 
     /// Selected header, per recipe. Value is the header name
     RecipeSelectedHeader(RecipeId),

--- a/src/tui/view/test_util.rs
+++ b/src/tui/view/test_util.rs
@@ -67,6 +67,11 @@ where
         &mut self.harness
     }
 
+    /// Drop this component, returning the contained harness to be re-used
+    pub fn into_harness(self) -> TestHarness {
+        self.harness
+    }
+
     /// Get a reference to the wrapped component's inner data
     pub fn data(&self) -> &T {
         self.component.data()

--- a/test_data/regression.yml
+++ b/test_data/regression.yml
@@ -110,6 +110,9 @@ requests:
         method: GET
         # No headers or authentication
         url: "{{host}}/anything/{{user_guid}}"
+        query:
+          - value={{field1}}
+          - value={{field2}}
 
       json_body: !request
         <<: *base_recipe


### PR DESCRIPTION
## Description

From now `query` can be `list[string]`, `mapping[string, string]` is still supported.

Changes:
- `Recpie.query` is now `QueryParameters` struct.
- `QueryParameters` wraps a `Vec` instead of an `IndexMap`, allowing it to store duplicate keys
- `QueryParameters` impements `Deserialize` with `visit_seq` and `visit_map`.


Closes #245

## Known Risks

It shouldn't break any older config.

## QA

Edited `test_build_url` to use multiple query parameters.

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
