### PR TITLE
Remove some dead functions

### DIFF
--- a/src/collection/recipe_tree.rs
+++ b/src/collection/recipe_tree.rs
@@ -208,14 +208,6 @@ impl RecipeNode {
         }
     }
 
-    /// Get a presentable name for this folder/recipe
-    pub fn name(&self) -> &str {
-        match self {
-            RecipeNode::Folder(folder) => folder.name(),
-            RecipeNode::Recipe(recipe) => recipe.name(),
-        }
-    }
-
     /// If this node is a recipe, return it. Otherwise return `None`
     pub fn recipe(&self) -> Option<&Recipe> {
         match self {

--- a/src/db.rs
+++ b/src/db.rs
@@ -270,10 +270,6 @@ pub struct CollectionDatabase {
 }
 
 impl CollectionDatabase {
-    pub fn collection_id(&self) -> CollectionId {
-        self.collection_id
-    }
-
     /// Get the full path for the collection file associated with this DB handle
     pub fn collection_path(&self) -> anyhow::Result<PathBuf> {
         self.database
@@ -489,6 +485,11 @@ impl CollectionDatabase {
             .context("Error saving UI state to database")
             .traced()?;
         Ok(())
+    }
+
+    #[cfg(test)]
+    pub fn collection_id(&self) -> CollectionId {
+        self.collection_id
     }
 }
 

--- a/src/http/content_type.rs
+++ b/src/http/content_type.rs
@@ -35,13 +35,6 @@ impl ContentType {
     const EXTENSIONS: Mapping<'static, ContentType> =
         Mapping::new(&[(Self::Json, &["json"])]);
 
-    /// Get the file extension associated with this content type. For content
-    /// types that have multiple common extensions (e.g. `image/jpeg` has `jpeg`
-    /// and `jpg`), return whichever is defined first in the mapping.
-    pub fn extension(&self) -> &'static str {
-        Self::EXTENSIONS.get_label(*self)
-    }
-
     /// Get MIME corresponding to this content type. Each content type maps to a
     /// single MIME (although the reverse is not true)
     pub fn mime(&self) -> Mime {

--- a/src/http/models.rs
+++ b/src/http/models.rs
@@ -395,12 +395,6 @@ impl ResponseRecord {
                 Some(format!("data.{}", mime.subtype()))
             })
     }
-
-    /// Get the content type of this response, based on the `Content-Type`
-    /// header. Return `None` if the header is missing or an unknown type.
-    pub fn content_type(&self) -> Option<ContentType> {
-        ContentType::from_response(self).ok()
-    }
 }
 
 /// HTTP response body. Content is stored as bytes because it may not

--- a/src/template.rs
+++ b/src/template.rs
@@ -93,7 +93,7 @@ impl Template {
     /// impossible (either type state or a runtime check), but it's not worth
     /// the extra code for something that is very unlikely to happen. It says
     /// "dangerous", don't be stupid.
-    pub(crate) fn dangerous(template: String) -> Self {
+    pub fn dangerous(template: String) -> Self {
         // Create one raw chunk for everything
         let chunk = TemplateInputChunk::Raw(Span::new(0, template.len()));
         Self {

--- a/src/tui/view/state.rs
+++ b/src/tui/view/state.rs
@@ -214,11 +214,6 @@ impl RequestState {
         }
     }
 
-    /// Is the initial stage in a request life cycle?
-    pub fn is_initial(&self) -> bool {
-        matches!(self, Self::Building { .. })
-    }
-
     /// Create a loading state with the current timestamp. This will generally
     /// be slightly off from when the request was actually launched, but it
     /// shouldn't matter. See [crate::http::RequestTicket::send] for why it


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Not needed anymore! Turns out rustc won't warn you about unused functions if they're `pub` and in struct impls, even if the struct isn't exported outside the crate

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

## QA

_How did you test this?_

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
