### PR TITLE
Add support for URL-encoded forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- JSON bodies can now be defined with the `!json` tag [#242](https://github.com/LucasPickering/slumber/issues/242)
-  - This should make JSON requests more convenient to write, because you no longer have to specify the `Content-Type` header yourself
-  - [See docs](https://slumber.lucaspickering.me/book/api/request_collection/recipe_body.html)
+- Structured bodies can now be defined with tags on the `body` field of a recipe, making it more convenient to construct bodies of common types. Supported types are:
+  - `!json` [#242](https://github.com/LucasPickering/slumber/issues/242)
+  - `!form_urlencoded` [#244](https://github.com/LucasPickering/slumber/issues/244)
+  - [See docs](https://slumber.lucaspickering.me/book/api/request_collection/recipe_body.html) for usage instructions
 - Templates can now render binary values in certain contexts
   - [See docs](https://slumber.lucaspickering.me/book/user_guide/templates.html#binary-templates)
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ requests:
   get: !request
     method: GET
     url: https://httpbin.org/get
+
+  post: !request
+    method: POST
+    url: https://httpbin.org/post
+    body: !json { "id": 3, "name": "Slumber" }
 ```
 
 Create this file, then run the TUI with `slumber`.

--- a/docs/src/api/request_collection/recipe_body.md
+++ b/docs/src/api/request_collection/recipe_body.md
@@ -8,9 +8,10 @@ In addition, you can pass any [`Template`](./template.md) to render any text or 
 
 The following content types have first-class support. Slumber will automatically set the `Content-Type` header to the specified value, but you can override this simply by providing your own value for the header.
 
-| Variant | Type | `Content-Type` Header | Description                                                      |
-| ------- | ---- | --------------------- | ---------------------------------------------------------------- |
-| `!json` | Any  | `application/json`    | Structured JSON body, where all strings are treated as templates |
+| Variant            | Type                                         | `Content-Type`                      | Description                                                                                               |
+| ------------------ | -------------------------------------------- | ----------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `!json`            | Any                                          | `application/json`                  | Structured JSON body; all strings are treated as templates                                                |
+| `!form_urlencoded` | [`mapping[string, Template]`](./template.md) | `application/x-www-form-urlencoded` | URL-encoded form data; [see here for more](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST |
 
 ## Examples
 

--- a/slumber.yml
+++ b/slumber.yml
@@ -45,8 +45,9 @@ requests:
       fast: no_thanks
     headers:
       Accept: application/json
-    body:
-      !json { "username": "{{username}}", "password": "{{chains.password}}" }
+    body: !form_urlencoded
+      username: "{{username}}"
+      password: "{{chains.password}}"
 
   users: !folder
     name: Users

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -523,6 +523,21 @@ mod tests {
                                 "Accept".into() => "application/json".into(),
                             },
                         }),
+                        RecipeNode::Recipe(Recipe {
+                            id: "form_urlencoded_body".into(),
+                            name: Some("Modify User".into()),
+                            method: Method::Put,
+                            url: "{{host}}/anything/{{user_guid}}".into(),
+
+                            body: Some(RecipeBody::FormUrlencoded(indexmap! {
+                                "username".into() => "new username".into()
+                            })),
+                            authentication: None,
+                            query: indexmap! {},
+                            headers: indexmap! {
+                                "Accept".into() => "application/json".into(),
+                            },
+                        }),
                     ]),
                 }),
             ])

--- a/src/http/models.rs
+++ b/src/http/models.rs
@@ -86,12 +86,15 @@ pub struct BuildOptions {
     /// Which query parameters should be excluded?  A blacklist allows the
     /// default to be "include all".
     pub disabled_query_parameters: HashSet<String>,
+    /// For form bodies, which form fields should be excluded?
+    pub disabled_form_fields: HashSet<String>,
 }
 
 /// A request ready to be launched into through the stratosphere. This is
 /// basically a two-part ticket: the request is the part we'll hand to the HTTP
 /// engine to be launched, and the record is the ticket stub we'll keep for
-/// ourselves (to display to the user).
+/// ourselves (to display to the user
+#[derive(Debug)]
 pub struct RequestTicket {
     /// A record of the request that we can hang onto and persist
     pub(super) record: Arc<RequestRecord>,
@@ -520,23 +523,6 @@ pub struct RequestBuildError {
     pub id: RequestId,
     /// When did the error occur?
     pub time: DateTime<Utc>,
-}
-
-impl RequestBuildError {
-    /// Wrap a given error with context from the build process
-    pub fn new(
-        error: anyhow::Error,
-        seed: &RequestSeed,
-        profile_id: Option<ProfileId>,
-    ) -> Self {
-        Self {
-            profile_id,
-            recipe_id: seed.recipe.id.clone(),
-            id: seed.id,
-            time: Utc::now(),
-            error,
-        }
-    }
 }
 
 #[cfg(test)]

--- a/src/tui/view/state/persistence.rs
+++ b/src/tui/view/state/persistence.rs
@@ -98,14 +98,22 @@ pub enum PersistentKey {
     RecipeCollapsed,
     /// Selected tab in the recipe pane
     RecipeTab,
+
     /// Selected query param, per recipe. Value is the query param name
     RecipeSelectedQuery(RecipeId),
     /// Toggle state for a single recipe+query param
     RecipeQuery { recipe: RecipeId, param: String },
+
     /// Selected header, per recipe. Value is the header name
     RecipeSelectedHeader(RecipeId),
     /// Toggle state for a single recipe+header
     RecipeHeader { recipe: RecipeId, header: String },
+
+    /// Selected form field, per recipe. Value is the field name
+    RecipeSelectedFormField(RecipeId),
+    /// Toggle state for a single recipe+form field
+    RecipeFormField { recipe: RecipeId, field: String },
+
     /// Response body JSONPath query (**not** related to query params)
     ResponseBodyQuery(RecipeId),
 }

--- a/test_data/insomnia.json
+++ b/test_data/insomnia.json
@@ -1,7 +1,7 @@
 {
   "_type": "export",
   "__export_format": 4,
-  "__export_date": "2024-06-02T00:00:08.951Z",
+  "__export_date": "2024-06-04T21:09:14.812Z",
   "__export_source": "insomnia.desktop.app:v9.2.0",
   "resources": [
     {
@@ -37,13 +37,10 @@
           "name": "Content-Type",
           "value": "application/x-www-form-urlencoded"
         },
-        {
-          "name": "User-Agent",
-          "value": "insomnia/8.6.1"
-        }
+        { "name": "User-Agent", "value": "insomnia/8.6.1" }
       ],
       "authentication": {},
-      "metaSortKey": -1712668704494,
+      "metaSortKey": -1712668704594,
       "isPrivate": false,
       "pathParameters": [],
       "settingStoreCookies": true,
@@ -73,21 +70,12 @@
       "name": "With Text Body",
       "description": "",
       "method": "POST",
-      "body": {
-        "mimeType": "text/plain",
-        "text": "hello!"
-      },
+      "body": { "mimeType": "text/plain", "text": "hello!" },
       "preRequestScript": "",
       "parameters": [],
       "headers": [
-        {
-          "name": "Content-Type",
-          "value": "text/plain"
-        },
-        {
-          "name": "User-Agent",
-          "value": "insomnia/8.6.1"
-        }
+        { "name": "Content-Type", "value": "text/plain" },
+        { "name": "User-Agent", "value": "insomnia/8.6.1" }
       ],
       "authentication": {},
       "metaSortKey": -1712668712522,
@@ -110,7 +98,7 @@
       "description": "",
       "environment": {},
       "environmentPropertyOrder": null,
-      "metaSortKey": -1712668700000,
+      "metaSortKey": -1712668704494,
       "_type": "request_group"
     },
     {
@@ -129,14 +117,8 @@
       "preRequestScript": "",
       "parameters": [],
       "headers": [
-        {
-          "name": "Content-Type",
-          "value": "application/json"
-        },
-        {
-          "name": "User-Agent",
-          "value": "insomnia/8.6.1"
-        }
+        { "name": "Content-Type", "value": "application/json" },
+        { "name": "User-Agent", "value": "insomnia/8.6.1" }
       ],
       "authentication": {},
       "metaSortKey": -1712668712422,
@@ -162,12 +144,7 @@
       "body": {},
       "preRequestScript": "",
       "parameters": [],
-      "headers": [
-        {
-          "name": "User-Agent",
-          "value": "insomnia/8.6.1"
-        }
-      ],
+      "headers": [{ "name": "User-Agent", "value": "insomnia/8.6.1" }],
       "authentication": {
         "type": "bearer",
         "token": " {% response 'body', 'req_3bc2de939f1a4d1ebc00835cbefd6b5d', 'b64::JC5oZWFkZXJzLkhvc3Q=::46b', 'when-expired', 60 %}"
@@ -207,12 +184,7 @@
       "body": {},
       "preRequestScript": "",
       "parameters": [],
-      "headers": [
-        {
-          "name": "User-Agent",
-          "value": "insomnia/8.6.1"
-        }
-      ],
+      "headers": [{ "name": "User-Agent", "value": "insomnia/8.6.1" }],
       "authentication": {
         "type": "digest",
         "disabled": false,
@@ -242,12 +214,7 @@
       "body": {},
       "preRequestScript": "",
       "parameters": [],
-      "headers": [
-        {
-          "name": "User-Agent",
-          "value": "insomnia/8.6.1"
-        }
-      ],
+      "headers": [{ "name": "User-Agent", "value": "insomnia/8.6.1" }],
       "authentication": {
         "type": "basic",
         "useISO88591": false,
@@ -278,12 +245,7 @@
       "body": {},
       "preRequestScript": "",
       "parameters": [],
-      "headers": [
-        {
-          "name": "User-Agent",
-          "value": "insomnia/8.6.1"
-        }
-      ],
+      "headers": [{ "name": "User-Agent", "value": "insomnia/8.6.1" }],
       "authentication": {},
       "metaSortKey": -1712668873967,
       "isPrivate": false,
@@ -329,11 +291,9 @@
         "greeting": "hello!"
       },
       "dataPropertyOrder": {
-        "&": [
-          "host",
-          "greeting"
-        ]
+        "&": ["host", "greeting"]
       },
+      "dataPropertyOrder": { "&": ["host"] },
       "color": null,
       "isPrivate": false,
       "metaSortKey": 1710624684621,
@@ -345,16 +305,8 @@
       "modified": 1713480842495,
       "created": 1710624689589,
       "name": "Remote",
-      "data": {
-        "host": "https://httpbin.org",
-        "greeting": "howdy"
-      },
-      "dataPropertyOrder": {
-        "&": [
-          "host",
-          "greeting"
-        ]
-      },
+      "data": { "host": "https://httpbin.org", "greeting": "howdy" },
+      "dataPropertyOrder": { "&": ["host", "greeting"] },
       "color": null,
       "isPrivate": false,
       "metaSortKey": 1710624689589,

--- a/test_data/insomnia_imported.yml
+++ b/test_data/insomnia_imported.yml
@@ -82,7 +82,9 @@ requests:
     name: Login
     method: POST
     url: https://httpbin.org/anything/login
-    body: null
+    body: !form_urlencoded
+      username: user
+      password: pass
     authentication: null
     query: {}
     headers:

--- a/test_data/regression.yml
+++ b/test_data/regression.yml
@@ -129,3 +129,11 @@ requests:
           password: "{{password}}"
         # Nested JSON is *not* parsed
         body: !json '{"warning": "NOT an object"}'
+
+      form_urlencoded_body: !request
+        <<: *base_recipe
+        name: Modify User
+        method: PUT
+        url: "{{host}}/anything/{{user_guid}}"
+        body: !form_urlencoded
+          username: "new username"


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Adds a new type of structured body, `!form_urlencoded`. The associated value is a key-value mapping. Example:

```yaml
login: !request
  method: POST
  url: "{{host}}/anything/login"
  query:
    sudo: yes_please
    fast: no_thanks
  headers:
    Accept: application/json
  body: !form_urlencoded
    username: "{{username}}"
    password: "{{chains.password}}"
```

Closes #244

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

The behavior of auto-header setting could potentially be confusing. This is just following the model set by the previous PR though (#251). 

## QA

_How did you test this?_

- Unit tests
- Manual testing in TUI

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
