### PR TITLE
Add support for `multipart/form-data` bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Structured bodies can now be defined with tags on the `body` field of a recipe, making it more convenient to construct bodies of common types. Supported types are:
   - `!json` [#242](https://github.com/LucasPickering/slumber/issues/242)
   - `!form_urlencoded` [#244](https://github.com/LucasPickering/slumber/issues/244)
+  - `!form_multipart` [#243](https://github.com/LucasPickering/slumber/issues/243)
   - [See docs](https://slumber.lucaspickering.me/book/api/request_collection/recipe_body.html) for usage instructions
 - Support multiple instances of the same query param [#245](https://github.com/LucasPickering/slumber/issues/245) (@maksimowiczm)
   - Query params can now be defined as a list of `<param>=<value>` entries

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,6 +1152,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1547,9 +1557,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1615,6 +1625,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -2033,6 +2044,7 @@ dependencies = [
  "open",
  "pretty_assertions",
  "ratatui",
+ "regex",
  "reqwest",
  "rmp-serde",
  "rstest",
@@ -2364,6 +2376,15 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ nom = "7.1.3"
 notify = {version = "^6.1.1", default-features = false, features = ["macos_fsevent"]}
 open = "5.1.1"
 ratatui = {version = "^0.26.0", features = ["serde", "unstable-rendered-line-info"]}
-reqwest = {version = "^0.12.4", default-features = false, features = ["rustls-tls"]}
+reqwest = {version = "^0.12.4", default-features = false, features = ["multipart", "rustls-tls"]}
 rmp-serde = "^1.1.2"
 rusqlite = {version = "^0.31.0", default-features = false, features = ["bundled", "chrono", "uuid"]}
 rusqlite_migration = "^1.2.0"
@@ -52,6 +52,7 @@ uuid = {version = "^1.4.1", default-features = false, features = ["serde", "v4"]
 [dev-dependencies]
 mockito = {version = "1.4.0", default-features = false}
 pretty_assertions = "1.4.0"
+regex = {version = "1.10.5", default-features = false}
 rstest = {version = "0.19.0", default-features = false}
 serde_test = "1.0.176"
 

--- a/docs/src/api/request_collection/recipe_body.md
+++ b/docs/src/api/request_collection/recipe_body.md
@@ -8,10 +8,11 @@ In addition, you can pass any [`Template`](./template.md) to render any text or 
 
 The following content types have first-class support. Slumber will automatically set the `Content-Type` header to the specified value, but you can override this simply by providing your own value for the header.
 
-| Variant            | Type                                         | `Content-Type`                      | Description                                                                                               |
-| ------------------ | -------------------------------------------- | ----------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| `!json`            | Any                                          | `application/json`                  | Structured JSON body; all strings are treated as templates                                                |
-| `!form_urlencoded` | [`mapping[string, Template]`](./template.md) | `application/x-www-form-urlencoded` | URL-encoded form data; [see here for more](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST |
+| Variant            | Type                                         | `Content-Type`                      | Description                                                                                                |
+| ------------------ | -------------------------------------------- | ----------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `!json`            | Any                                          | `application/json`                  | Structured JSON body; all strings are treated as templates                                                 |
+| `!form_urlencoded` | [`mapping[string, Template]`](./template.md) | `application/x-www-form-urlencoded` | URL-encoded form data; [see here for more](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST) |
+| `!form_multipart`  | [`mapping[string, Template]`](./template.md) | `multipart/form-data`               | Binary form data; [see here for more](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST)      |
 
 ## Examples
 
@@ -41,4 +42,19 @@ requests:
     url: "{{host}}/fishes/{{fish_id}}"
     # Content-Type header will be set automatically based on the body type
     body: !json { "name": "Alfonso" }
+
+  urlencoded_body: !request
+    method: POST
+    url: "{{host}}/fishes/{{fish_id}}"
+    # Content-Type header will be set automatically based on the body type
+    body: !form_urlencoded
+      name: Alfonso
+
+  multipart_body: !request
+    method: POST
+    url: "{{host}}/fishes/{{fish_id}}"
+    # Content-Type header will be set automatically based on the body type
+    body: !form_multipart
+      name: Alfonso
+      image: "{{chains.fish_image}}"
 ```

--- a/slumber.yml
+++ b/slumber.yml
@@ -29,6 +29,9 @@ chains:
       recipe: login
       trigger: !expire 12h
     selector: $.data
+  image:
+    source: !file
+      path: ./static/slumber.png
 
 .ignore:
   base: &base
@@ -80,6 +83,14 @@ requests:
     name: Get Image
     method: GET
     url: "{{host}}/image"
+
+  upload_image: !request
+    name: Upload Image
+    method: POST
+    url: "{{host}}/anything/image"
+    body: !form_multipart
+      filename: "logo.png"
+      image: "{{chains.image}}"
 
   delay: !request
     <<: *base

--- a/src/cli/history.rs
+++ b/src/cli/history.rs
@@ -7,6 +7,7 @@ use crate::{
     GlobalArgs,
 };
 use anyhow::anyhow;
+use bytesize::ByteSize;
 use clap::Parser;
 use dialoguer::console::Style;
 use std::process::ExitCode;
@@ -94,8 +95,8 @@ impl HistoryCommand {
             print!(
                 "{} ({})\n{}",
                 subheader_style.apply_to("Body"),
-                body.size(),
-                MaybeStr(body.bytes())
+                ByteSize(body.len() as u64),
+                MaybeStr(body)
             )
         }
         println!();

--- a/src/collection/models.rs
+++ b/src/collection/models.rs
@@ -13,7 +13,6 @@ use derive_more::{Deref, Display, From, FromStr};
 use equivalent::Equivalent;
 use indexmap::IndexMap;
 use itertools::Itertools;
-use mime::Mime;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use strum::{EnumIter, IntoEnumIterator};
@@ -296,22 +295,10 @@ pub enum RecipeBody {
     Raw(Template),
     /// Strutured JSON, which will be stringified and sent as text
     Json(JsonBody),
-    /// `application/x-www-form-urlencoded` fields
+    /// `application/x-www-form-urlencoded` fields. Values must be strings
     FormUrlencoded(IndexMap<String, Template>),
-}
-
-impl RecipeBody {
-    /// Get the MIME type of this body. For raw bodies we have no idea, but for
-    /// structured bodies we can make a very educated guess
-    pub fn mime(&self) -> Option<Mime> {
-        match self {
-            RecipeBody::Raw(_) => None,
-            RecipeBody::Json(_) => Some(mime::APPLICATION_JSON),
-            RecipeBody::FormUrlencoded(_) => {
-                Some(mime::APPLICATION_WWW_FORM_URLENCODED)
-            }
-        }
-    }
+    /// `multipart/form-data` fields. Values can be binary
+    FormMultipart(IndexMap<String, Template>),
 }
 
 #[cfg(test)]

--- a/src/http.rs
+++ b/src/http.rs
@@ -945,7 +945,7 @@ mod tests {
         template_context: TemplateContext,
         #[case] body: RecipeBody,
         #[case] content_type: Option<&str>,
-        #[case] expected_body: &[u8],
+        #[case] expected_body: &'static [u8],
         #[case] expected_content_type: &str,
     ) {
         let headers = if let Some(content_type) = content_type {

--- a/src/http/content_type.rs
+++ b/src/http/content_type.rs
@@ -35,15 +35,6 @@ impl ContentType {
     const EXTENSIONS: Mapping<'static, ContentType> =
         Mapping::new(&[(Self::Json, &["json"])]);
 
-    /// Get MIME corresponding to this content type. Each content type maps to a
-    /// single MIME (although the reverse is not true)
-    pub fn mime(&self) -> Mime {
-        // Don't use a Mapping because this is a one-way relationship
-        match self {
-            ContentType::Json => mime::APPLICATION_JSON,
-        }
-    }
-
     /// Parse the value of the content-type header and map it to a known content
     /// type
     fn from_mime(mime_type: &str) -> anyhow::Result<Self> {

--- a/src/http/models.rs
+++ b/src/http/models.rs
@@ -222,11 +222,10 @@ impl RequestRecord {
             method: request.method().clone(),
             url: request.url().clone(),
             headers: request.headers().clone(),
-            body: request.body().map(|body| {
-                body.as_bytes()
-                    .expect("Streaming bodies not supported")
-                    .to_owned()
-                    .into()
+            body: request.body().and_then(|body| {
+                // Stream bodies are just thrown away for now
+                // https://github.com/LucasPickering/slumber/issues/256
+                Some(body.as_bytes()?.to_owned().into())
             }),
         }
     }

--- a/src/http/models.rs
+++ b/src/http/models.rs
@@ -196,7 +196,7 @@ pub struct RequestRecord {
     #[serde(with = "cereal::serde_header_map")]
     pub headers: HeaderMap,
     /// Body content as bytes. This should be decoded as needed
-    pub body: Option<ResponseBody>,
+    pub body: Option<Bytes>,
 }
 
 impl RequestRecord {
@@ -223,12 +223,10 @@ impl RequestRecord {
             url: request.url().clone(),
             headers: request.headers().clone(),
             body: request.body().map(|body| {
-                ResponseBody::new(
-                    body.as_bytes()
-                        .expect("Streaming bodies not supported")
-                        .to_owned()
-                        .into(),
-                )
+                body.as_bytes()
+                    .expect("Streaming bodies not supported")
+                    .to_owned()
+                    .into()
             }),
         }
     }
@@ -264,8 +262,7 @@ impl RequestRecord {
     pub fn body_str(&self) -> anyhow::Result<Option<&str>> {
         if let Some(body) = &self.body {
             Ok(Some(
-                std::str::from_utf8(&body.data)
-                    .context("Error decoding body")?,
+                std::str::from_utf8(body).context("Error decoding body")?,
             ))
         } else {
             Ok(None)

--- a/src/tui/view/common/template_preview.rs
+++ b/src/tui/view/common/template_preview.rs
@@ -55,13 +55,6 @@ impl TemplatePreview {
             Self::Disabled { template }
         }
     }
-
-    pub fn template(&self) -> &Template {
-        match self {
-            Self::Disabled { template } => template,
-            Self::Enabled { template, .. } => template,
-        }
-    }
 }
 
 impl Generate for &TemplatePreview {

--- a/src/tui/view/component.rs
+++ b/src/tui/view/component.rs
@@ -1,4 +1,3 @@
-mod exchange_body;
 mod exchange_pane;
 mod help;
 mod history;
@@ -6,6 +5,7 @@ mod internal;
 mod misc;
 mod primary;
 mod profile_select;
+mod queryable_body;
 mod recipe_list;
 mod recipe_pane;
 mod request_view;

--- a/src/tui/view/component/recipe_pane.rs
+++ b/src/tui/view/component/recipe_pane.rs
@@ -449,6 +449,7 @@ enum RecipeBodyDisplay {
 }
 
 impl RecipeBodyDisplay {
+    /// Build a component to display the body, based on the body type
     fn new(
         body: &RecipeBody,
         selected_profile_id: Option<ProfileId>,
@@ -485,7 +486,8 @@ impl RecipeBodyDisplay {
                     .into(),
                 )
             }
-            RecipeBody::FormUrlencoded(fields) => {
+            RecipeBody::FormUrlencoded(fields)
+            | RecipeBody::FormMultipart(fields) => {
                 let form_items = fields
                     .iter()
                     .map(|(field, value)| {

--- a/src/tui/view/component/response_view.rs
+++ b/src/tui/view/component/response_view.rs
@@ -8,7 +8,7 @@ use crate::{
         message::Message,
         view::{
             common::{actions::ActionsModal, header_table::HeaderTable},
-            component::exchange_body::{ExchangeBody, ExchangeBodyProps},
+            component::queryable_body::{ExchangeBodyProps, QueryableBody},
             draw::{Draw, DrawMetadata, Generate, ToStringGenerate},
             event::{Event, EventHandler, Update},
             state::{persistence::PersistentKey, StateCell},
@@ -55,7 +55,7 @@ struct State {
     /// The presentable version of the response body, which may or may not
     /// match the response body. We apply transformations such as filter,
     /// prettification, or in the case of binary responses, a hex dump.
-    body: Component<ExchangeBody>,
+    body: Component<QueryableBody>,
 }
 
 impl EventHandler for ResponseBodyView {
@@ -128,9 +128,9 @@ impl<'a> Draw<ResponseBodyViewProps<'a>> for ResponseBodyView {
         let response = &props.response;
         let state = self.state.get_or_update(props.request_id, || State {
             response: Arc::clone(&props.response),
-            body: ExchangeBody::new(Some(PersistentKey::ResponseBodyQuery(
+            body: QueryableBody::new(PersistentKey::ResponseBodyQuery(
                 props.recipe_id.clone(),
-            )))
+            ))
             .into(),
         });
 

--- a/test_data/insomnia.json
+++ b/test_data/insomnia.json
@@ -1,7 +1,7 @@
 {
   "_type": "export",
   "__export_format": 4,
-  "__export_date": "2024-06-04T21:09:14.812Z",
+  "__export_date": "2024-06-09T20:02:13.394Z",
   "__export_source": "insomnia.desktop.app:v9.2.0",
   "resources": [
     {
@@ -37,7 +37,10 @@
           "name": "Content-Type",
           "value": "application/x-www-form-urlencoded"
         },
-        { "name": "User-Agent", "value": "insomnia/8.6.1" }
+        {
+          "name": "User-Agent",
+          "value": "insomnia/8.6.1"
+        }
       ],
       "authentication": {},
       "metaSortKey": -1712668704594,
@@ -70,12 +73,21 @@
       "name": "With Text Body",
       "description": "",
       "method": "POST",
-      "body": { "mimeType": "text/plain", "text": "hello!" },
+      "body": {
+        "mimeType": "text/plain",
+        "text": "hello!"
+      },
       "preRequestScript": "",
       "parameters": [],
       "headers": [
-        { "name": "Content-Type", "value": "text/plain" },
-        { "name": "User-Agent", "value": "insomnia/8.6.1" }
+        {
+          "name": "Content-Type",
+          "value": "text/plain"
+        },
+        {
+          "name": "User-Agent",
+          "value": "insomnia/8.6.1"
+        }
       ],
       "authentication": {},
       "metaSortKey": -1712668712522,
@@ -117,11 +129,69 @@
       "preRequestScript": "",
       "parameters": [],
       "headers": [
-        { "name": "Content-Type", "value": "application/json" },
-        { "name": "User-Agent", "value": "insomnia/8.6.1" }
+        {
+          "name": "Content-Type",
+          "value": "application/json"
+        },
+        {
+          "name": "User-Agent",
+          "value": "insomnia/8.6.1"
+        }
       ],
       "authentication": {},
       "metaSortKey": -1712668712422,
+      "isPrivate": false,
+      "pathParameters": [],
+      "settingStoreCookies": true,
+      "settingSendCookies": true,
+      "settingDisableRenderRequestBody": false,
+      "settingEncodeUrl": true,
+      "settingRebuildPath": true,
+      "settingFollowRedirects": "global",
+      "_type": "request"
+    },
+    {
+      "_id": "req_a01b6de924274654bda0835e2a073bd0",
+      "parentId": "fld_9a7332db608943b093c929a82c81df50",
+      "modified": 1717963268333,
+      "created": 1717550289566,
+      "url": "https://httpbin.org/post",
+      "name": "With Multipart Body",
+      "description": "",
+      "method": "POST",
+      "body": {
+        "mimeType": "multipart/form-data",
+        "params": [
+          {
+            "id": "pair_92d49a8597ea457aa377169046e6670c",
+            "name": "username",
+            "value": "user",
+            "description": ""
+          },
+          {
+            "id": "pair_b9dfab38415a4c98a08d99a1d4a35682",
+            "name": "image",
+            "value": "",
+            "description": "",
+            "type": "file",
+            "fileName": "./public/slumber.png"
+          }
+        ]
+      },
+      "preRequestScript": "",
+      "parameters": [],
+      "headers": [
+        {
+          "name": "Content-Type",
+          "value": "multipart/form-data"
+        },
+        {
+          "name": "User-Agent",
+          "value": "insomnia/8.6.1"
+        }
+      ],
+      "authentication": {},
+      "metaSortKey": -1712668712372,
       "isPrivate": false,
       "pathParameters": [],
       "settingStoreCookies": true,
@@ -144,7 +214,12 @@
       "body": {},
       "preRequestScript": "",
       "parameters": [],
-      "headers": [{ "name": "User-Agent", "value": "insomnia/8.6.1" }],
+      "headers": [
+        {
+          "name": "User-Agent",
+          "value": "insomnia/8.6.1"
+        }
+      ],
       "authentication": {
         "type": "bearer",
         "token": " {% response 'body', 'req_3bc2de939f1a4d1ebc00835cbefd6b5d', 'b64::JC5oZWFkZXJzLkhvc3Q=::46b', 'when-expired', 60 %}"
@@ -184,7 +259,12 @@
       "body": {},
       "preRequestScript": "",
       "parameters": [],
-      "headers": [{ "name": "User-Agent", "value": "insomnia/8.6.1" }],
+      "headers": [
+        {
+          "name": "User-Agent",
+          "value": "insomnia/8.6.1"
+        }
+      ],
       "authentication": {
         "type": "digest",
         "disabled": false,
@@ -214,7 +294,12 @@
       "body": {},
       "preRequestScript": "",
       "parameters": [],
-      "headers": [{ "name": "User-Agent", "value": "insomnia/8.6.1" }],
+      "headers": [
+        {
+          "name": "User-Agent",
+          "value": "insomnia/8.6.1"
+        }
+      ],
       "authentication": {
         "type": "basic",
         "useISO88591": false,
@@ -245,7 +330,12 @@
       "body": {},
       "preRequestScript": "",
       "parameters": [],
-      "headers": [{ "name": "User-Agent", "value": "insomnia/8.6.1" }],
+      "headers": [
+        {
+          "name": "User-Agent",
+          "value": "insomnia/8.6.1"
+        }
+      ],
       "authentication": {},
       "metaSortKey": -1712668873967,
       "isPrivate": false,
@@ -261,11 +351,17 @@
     {
       "_id": "env_99d30891da4bdcebc63947a8fc17f076de878684",
       "parentId": "wrk_scratchpad",
-      "modified": 1717286296579,
+      "modified": 1717963323879,
       "created": 1717286296579,
       "name": "Base Environment",
-      "data": {},
-      "dataPropertyOrder": null,
+      "data": {
+        "base_field": "base"
+      },
+      "dataPropertyOrder": {
+        "&": [
+          "base_field"
+        ]
+      },
       "color": null,
       "isPrivate": false,
       "metaSortKey": 1717286296579,
@@ -283,7 +379,7 @@
     {
       "_id": "env_3b607180e18c41228387930058c9ca43",
       "parentId": "env_99d30891da4bdcebc63947a8fc17f076de878684",
-      "modified": 1710624708900,
+      "modified": 1717963225790,
       "created": 1710624684621,
       "name": "Local",
       "data": {
@@ -291,9 +387,11 @@
         "greeting": "hello!"
       },
       "dataPropertyOrder": {
-        "&": ["host", "greeting"]
+        "&": [
+          "host",
+          "greeting"
+        ]
       },
-      "dataPropertyOrder": { "&": ["host"] },
       "color": null,
       "isPrivate": false,
       "metaSortKey": 1710624684621,
@@ -305,8 +403,16 @@
       "modified": 1713480842495,
       "created": 1710624689589,
       "name": "Remote",
-      "data": { "host": "https://httpbin.org", "greeting": "howdy" },
-      "dataPropertyOrder": { "&": ["host", "greeting"] },
+      "data": {
+        "host": "https://httpbin.org",
+        "greeting": "howdy"
+      },
+      "dataPropertyOrder": {
+        "&": [
+          "host",
+          "greeting"
+        ]
+      },
       "color": null,
       "isPrivate": false,
       "metaSortKey": 1710624689589,

--- a/test_data/insomnia_imported.yml
+++ b/test_data/insomnia_imported.yml
@@ -3,14 +3,21 @@ profiles:
   env_3b607180e18c41228387930058c9ca43:
     name: Local
     data:
+      base_field: base
       host: http://localhost:3000
       greeting: hello!
   env_4fb19173966e42898a0a77f45af591c9:
     name: Remote
     data:
+      base_field: base
       host: https://httpbin.org
       greeting: howdy
-chains: {}
+
+chains:
+  pair_b9dfab38415a4c98a08d99a1d4a35682:
+    source: !file
+      path: ./public/slumber.png
+
 requests:
   fld_9a7332db608943b093c929a82c81df50: !folder
     name: My Folder
@@ -60,23 +67,37 @@ requests:
         name: With Text Body
         method: POST
         url: https://httpbin.org/post
-        body: "hello!"
         authentication: null
         query: {}
         headers:
           content-type: text/plain
+        body: "hello!"
 
       req_1419670d20eb4964956df954e1eb7c4b: !request
         name: With JSON Body
         method: POST
         url: https://httpbin.org/post
-        body: !json { "message": "hello!" }
         authentication: null
         query: {}
         headers:
           # This is redundant with the body type, but it's more effort than
           # it's worth to remove it
           content-type: application/json
+        body: !json { "message": "hello!" }
+
+      req_a01b6de924274654bda0835e2a073bd0: !request
+        name: With Multipart Body
+        method: POST
+        url: https://httpbin.org/post
+        authentication: null
+        query: {}
+        headers:
+          # This is redundant with the body type, but it's more effort than
+          # it's worth to remove it
+          content-type: multipart/form-data
+        body: !form_multipart
+          username: user
+          image: "{{chains.pair_b9dfab38415a4c98a08d99a1d4a35682}}"
 
   req_a345faa530a7453e83ee967d18555712: !request
     name: Login


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

This adds first-class support for `multipart/form-data` bodies, similar to the existing `application/x-www-form-urlencoded` bodies. This one was a bit more complicated, mainly because reqwest forces the body to be a stream rather than binary blob when using the `multipart` builder. So we're forced to turn plain bytes into a stream. This is annoying now but leaves us in an ok spot for #256. An example:

```yaml
chains:
  image:
    source: !file
      path: ./static/slumber.png
requests:
  upload_image: !request
    name: Upload Image
    method: POST
    url: "{{host}}/anything/image"
    body: !form_multipart
      filename: "logo.png"
      image: "{{chains.image}}"
```

Closes #243 

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

I haven't tested this much so there's totally room for an edge case. Also large files are forced to be loaded entirely into memory, which could create issues for some people.

## QA

_How did you test this?_

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
