### PR TITLE
Fix deserializing unit value for query params

### DIFF
--- a/src/collection/cereal.rs
+++ b/src/collection/cereal.rs
@@ -126,6 +126,13 @@ where
             formatter.write_str("sequence of \"<param>=<value>\" or map")
         }
 
+        fn visit_unit<E>(self) -> Result<Self::Value, E>
+        where
+            E: Error,
+        {
+            Ok(Vec::new())
+        }
+
         fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
         where
             A: SeqAccess<'de>,
@@ -573,6 +580,7 @@ mod tests {
         ],
         vec![("param", "{{value}}")]
     )]
+    #[case::unit(&[Token::Unit], vec![])]
     fn test_deserialize_query_parameters(
         #[case] tokens: &[Token],
         #[case] expected: Vec<(&str, &str)>,

--- a/test_data/regression.yml
+++ b/test_data/regression.yml
@@ -113,6 +113,7 @@ requests:
         query:
           - value={{field1}}
           - value={{field2}}
+        headers: # Should parse as an empty map
 
       json_body: !request
         <<: *base_recipe
@@ -121,6 +122,7 @@ requests:
         url: "{{host}}/anything/{{user_guid}}"
         authentication: !bearer "{{chains.auth_token}}"
         body: !json { "username": "new username" }
+        query: # Should parse as an empty map
 
       json_body_but_not: !request
         <<: *base_recipe


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Previously specifying no value for the `query` field of a recipe would deserialize as an empty map. That broke with the recent change to support duplicate query params.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

none this is literally risk free nothing could possibly go wrong

## QA

_How did you test this?_

New unit tests, added to integration test

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
