### PR TITLE
Use terminal editor for Edit Collection action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- "Edit Collection" action now uses the editor set in `$VISUAL`/`$EDITOR` instead of whatever editor you have set as default for `.yaml`/`.yml` files
+  - In most cases this means you'll now get `vim` instead of VSCode or another GUI editor
+  - Closing the editor will return you to Slumber, meaning you can stay in the terminal the entire time
+
 ## [1.4.0] - 2024-06-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,25 +980,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
-name = "is-docker"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "is-wsl"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
-dependencies = [
- "is-docker",
- "once_cell",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1320,17 +1301,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
-name = "open"
-version = "5.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb49fbd5616580e9974662cb96a3463da4476e649a7e4b258df0de065db0657"
-dependencies = [
- "is-wsl",
- "libc",
- "pathdiff",
-]
-
-[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1380,12 +1350,6 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pathdiff"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "percent-encoding"
@@ -2041,7 +2005,6 @@ dependencies = [
  "mockito",
  "nom",
  "notify",
- "open",
  "pretty_assertions",
  "ratatui",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ itertools = "^0.12.0"
 mime = "^0.3.17"
 nom = "7.1.3"
 notify = {version = "^6.1.1", default-features = false, features = ["macos_fsevent"]}
-open = "5.1.1"
 ratatui = {version = "^0.26.0", features = ["serde", "unstable-rendered-line-info"]}
 reqwest = {version = "^0.12.4", default-features = false, features = ["multipart", "rustls-tls"]}
 rmp-serde = "^1.1.2"

--- a/src/tui/test_util.rs
+++ b/src/tui/test_util.rs
@@ -11,6 +11,10 @@ use crate::{
 };
 use ratatui::{backend::TestBackend, Terminal};
 use rstest::fixture;
+use std::{
+    env,
+    sync::{Mutex, MutexGuard},
+};
 use tokio::sync::mpsc::{self, UnboundedReceiver};
 
 /// Get a test harness, with a clean terminal etc. See [TestHarness].
@@ -60,16 +64,6 @@ impl TestHarness {
         &self.messages_tx
     }
 
-    /// Assert the message queue is empty. Requires `&mut self` because it will
-    /// actually pop a message off the queue
-    pub fn assert_messages_empty(&mut self) {
-        let message = self.messages_rx.try_recv().ok();
-        assert!(
-            message.is_none(),
-            "Expected empty queue, but had message {message:?}"
-        );
-    }
-
     /// Pop the next message off the queue. Panic if the queue is empty
     pub fn pop_message_now(&mut self) -> Message {
         self.messages_rx.try_recv().expect("Message queue empty")
@@ -83,6 +77,69 @@ impl TestHarness {
     /// Clear all messages in the queue
     pub fn clear_messages(&mut self) {
         while self.messages_rx.try_recv().is_ok() {}
+    }
+}
+
+/// A guard used to indicate that the current process environment is locked.
+/// This should be used in all tests that access environment variables, to
+/// prevent interference from external variable settings or tests conflicting
+/// with each other.
+pub struct EnvGuard {
+    previous_values: Vec<(String, Option<String>)>,
+    #[allow(unused)]
+    guard: MutexGuard<'static, ()>,
+}
+
+impl EnvGuard {
+    /// Lock the environment and set each given variable to its corresponding
+    /// value. The returned guard will keep the environment locked so the
+    /// calling test has exclusive access to it. Upon being dropped, the old
+    /// environment values will be restored and then the environment will be
+    /// unlocked.
+    pub fn lock(
+        variables: impl IntoIterator<
+            Item = (impl Into<String>, Option<impl Into<String>>),
+        >,
+    ) -> Self {
+        /// Global mutex for accessing environment variables. Technically we
+        /// could break this out into a map with one mutex per variable, but
+        /// that adds a ton of complexity for very little value.
+        static MUTEX: Mutex<()> = Mutex::new(());
+
+        let guard = MUTEX.lock().expect("Environment lock is poisoned");
+        let previous_values = variables
+            .into_iter()
+            .map(|(variable, new_value)| {
+                let variable: String = variable.into();
+                let previous_value = env::var(&variable).ok();
+
+                if let Some(value) = new_value {
+                    env::set_var(&variable, value.into());
+                } else {
+                    env::remove_var(&variable);
+                }
+
+                (variable, previous_value)
+            })
+            .collect();
+
+        Self {
+            previous_values,
+            guard,
+        }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        // Restore each env var
+        for (variable, value) in &self.previous_values {
+            if let Some(value) = value {
+                env::set_var(variable, value);
+            } else {
+                env::remove_var(variable);
+            }
+        }
     }
 }
 

--- a/src/tui/util.rs
+++ b/src/tui/util.rs
@@ -9,9 +9,9 @@ use crate::{
     },
     util::ResultExt,
 };
-use anyhow::Context;
+use anyhow::{anyhow, Context};
 use futures::{future, FutureExt};
-use std::io;
+use std::{env, io, path::Path, process::Command};
 use tokio::{fs::OpenOptions, io::AsyncWriteExt, sync::oneshot};
 use tracing::{debug, info, warn};
 
@@ -135,6 +135,22 @@ pub async fn save_file(
     Ok(())
 }
 
+/// Get a command to open the given file in the user's configured editor. Return
+/// an error if the user has no editor configured
+pub fn get_editor_command(file: &Path) -> anyhow::Result<Command> {
+    let command = env::var("VISUAL").or(env::var("EDITOR")).map_err(|_| {
+        anyhow!(
+            "No editor configured. Please set the `VISUAL` or `EDITOR` \
+            environment variable"
+        )
+    })?;
+    let mut splits = command.split(' ');
+    let editor = splits.next().expect("`split` returns at least one value");
+    let mut command = Command::new(editor);
+    command.args(splits).arg(file);
+    Ok(command)
+}
+
 /// Ask the user for some text input and wait for a response. Return `None` if
 /// the prompt is closed with no input.
 async fn prompt(
@@ -169,11 +185,66 @@ async fn confirm(messages_tx: &MessageSender, message: impl ToString) -> bool {
 mod tests {
     use super::*;
     use crate::{
-        test_util::{assert_matches, temp_dir, TempDir},
-        tui::test_util::{harness, TestHarness},
+        test_util::{assert_err, assert_matches, temp_dir, TempDir},
+        tui::test_util::{harness, EnvGuard, TestHarness},
     };
+    use itertools::Itertools;
     use rstest::rstest;
+    use std::ffi::OsStr;
     use tokio::fs;
+
+    /// Test reading editor command from VISUAL/EDITOR env vars
+    #[rstest]
+    #[case::visual(Some("ted"), Some("fred"), "ted", &[])]
+    #[case::editor(None, Some("fred"), "fred", &[])]
+    #[case::with_args(None, Some("ned --wait 60s"), "ned", &["--wait", "60s"])]
+    // This case is actually a bug, but I don't think it's worth the effort of
+    // engineering around. I added this test case for completeness
+    #[case::with_args_quoted(
+        None, Some("ned '--wait 60s'"), "ned", &["'--wait", "60s'"],
+    )]
+    fn test_get_editor(
+        #[case] env_visual: Option<&str>,
+        #[case] env_editor: Option<&str>,
+        #[case] expected_program: &str,
+        #[case] expected_args: &[&str],
+    ) {
+        let file_name = "file.yml";
+        // Make sure we're not competing with the other tests that want to set
+        // these env vars
+        let command = {
+            let _guard = EnvGuard::lock([
+                ("VISUAL", env_visual),
+                ("EDITOR", env_editor),
+            ]);
+            get_editor_command(Path::new(file_name))
+        }
+        .unwrap();
+        let mut expected_args = expected_args.to_owned();
+        expected_args.push(file_name);
+        assert_eq!(command.get_program(), expected_program);
+        assert_eq!(
+            command
+                .get_args()
+                .filter_map(OsStr::to_str)
+                .collect_vec()
+                .as_slice(),
+            expected_args
+        );
+    }
+
+    /// Test when VISUAL/EDITOR env vars are empty
+    #[test]
+    fn test_get_editor_error() {
+        // Make sure we're not competing with the other tests that want to set
+        // these env vars
+        let result = {
+            let _guard =
+                EnvGuard::lock([("VISUAL", None::<String>), ("EDITOR", None)]);
+            get_editor_command(Path::new("file.yml"))
+        };
+        assert_err!(result, "No editor configured");
+    }
 
     /// Test various cases of save_file
     #[rstest]


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Instead of using the default system editor for `.yml` files when launching the Edit Collection action, we now defer to the `$VISUAL`/`$EDITOR` env vars. This means we will probably open a text-based editor like vim, where previously it was likely a GUI editor like VSCode. This could potentially be annoying but I think in most cases will be more convenient for users. If we get complaints we can make it configurable.

This also includes a new utility `EnvGuard`, which should be used in tests that access environment variables. Since the process environment is global mutable state, tests that access and modify it can fight with each other. This mutex ensures the tests each take their turn. It also makes it easy for them to clean up after themselves.

Closes #262

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

This is a change in functionality that could potentially break someone's workflow. In general I think it will be an improvement but it could be annoying for some users.

## QA

_How did you test this?_

Manual testing in TUI, added some unit tests

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
