### PR TITLE
Add !env chain source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Add `!env` chain source, for loading environment variables
+  - This is intended to replace the existing `{{env.VARIABLE}}` syntax, which is now deprecated and will be removed in the future
+
 ### Changed
 
 - "Edit Collection" action now uses the editor set in `$VISUAL`/`$EDITOR` instead of whatever editor you have set as default for `.yaml`/`.yml` files
   - In most cases this means you'll now get `vim` instead of VSCode or another GUI editor
   - Closing the editor will return you to Slumber, meaning you can stay in the terminal the entire time
+
+### Fixed
+
+- Environment variables in `{{env.VARIABLE}}` templates are now loaded as strings according to the OS encoding, as opposed to always being decoded as UTF-8
 
 ## [1.4.0] - 2024-06-11
 

--- a/docs/src/api/request_collection/chain_source.md
+++ b/docs/src/api/request_collection/chain_source.md
@@ -14,6 +14,9 @@ trigger: !expire 12h
 !command
 command: ["echo", "-n", "hello"]
 ---
+!env
+variable: USERNAME
+---
 !file
 path: ./username.txt
 ---
@@ -23,12 +26,13 @@ message: Enter Password
 
 ## Variants
 
-| Variant    | Type                               | Description                                                     |
-| ---------- | ---------------------------------- | --------------------------------------------------------------- |
-| `!request` | [`ChainSource::Request`](#request) | Body of the most recent response for a specific request recipe. |
-| `!command` | [`ChainSource::Command`](#command) | Stdout of the executed command                                  |
-| `!file`    | [`ChainSource::File`](#file)       | Contents of the file                                            |
-| `!prompt`  | [`ChainSource::Prompt`](#prompt)   | Value entered by the user                                       |
+| Variant    | Type                                                | Description                                                     |
+| ---------- | --------------------------------------------------- | --------------------------------------------------------------- |
+| `!request` | [`ChainSource::Request`](#request)                  | Body of the most recent response for a specific request recipe. |
+| `!command` | [`ChainSource::Command`](#command)                  | Stdout of the executed command                                  |
+| `!env`     | [`ChainSource::Environment`](#environment-variable) | Value of an envionrment variable, or empty string if undefined  |
+| `!file`    | [`ChainSource::File`](#file)                        | Contents of the file                                            |
+| `!prompt`  | [`ChainSource::Prompt`](#prompt)                    | Value entered by the user                                       |
 
 ### Request
 
@@ -107,6 +111,14 @@ Execute a command and use its stdout as the rendered value.
 | --------- | ------------ | ----------------------------------------------------------- | -------- |
 | `command` | `Template[]` | Command to execute, in the format `[program, ...arguments]` | Required |
 | `stdin`   | `Template`   | Standard input which will be piped into the command         | None     |
+
+### Environment Variable
+
+Load a value from an environment variable.
+
+| Field      | Type       | Description      | Default  |
+| ---------- | ---------- | ---------------- | -------- |
+| `variable` | `Template` | Variable to load | Required |
 
 ### File
 

--- a/docs/src/api/request_collection/template.md
+++ b/docs/src/api/request_collection/template.md
@@ -10,11 +10,11 @@ For more detail on usage and examples, see the [user guide page on templates](..
 
 There are several ways of sourcing templating values:
 
-| Source                        | Syntax                | Description                                    | Default          |
-| ----------------------------- | --------------------- | ---------------------------------------------- | ---------------- |
-| [Profile](./profile.md) Field | `{{field_name}}`      | Static value from a profile                    | Error if unknown |
-| Environment Variable          | `{{env.VARIABLE}}`    | Environment variable from parent shell/process | `""`             |
-| [Chain](./chain.md)           | `{{chains.chain_id}}` | Complex chained value                          | Error if unknown |
+| Source                        | Syntax                | Description                                                                                                              | Default          |
+| ----------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------- |
+| [Profile](./profile.md) Field | `{{field_name}}`      | Static value from a profile                                                                                              | Error if unknown |
+| Environment Variable          | `{{env.VARIABLE}}`    | Environment variable from parent shell/process. **Deprecated in favor of the [`!env` chain source](./chain_source.md).** | `""`             |
+| [Chain](./chain.md)           | `{{chains.chain_id}}` | Complex chained value                                                                                                    | Error if unknown |
 
 ## Examples
 

--- a/src/collection/models.rs
+++ b/src/collection/models.rs
@@ -486,20 +486,14 @@ impl Equivalent<ChainId> for ChainId<&str> {
 #[cfg_attr(test, derive(PartialEq))]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub enum ChainSource {
-    /// Load data from the most recent response of a particular request recipe
-    Request {
-        recipe: RecipeId,
-        /// When should this request be automatically re-executed?
-        #[serde(default)]
-        trigger: ChainRequestTrigger,
-        #[serde(default)]
-        section: ChainRequestSection,
-    },
     /// Run an external command to get a result
     Command {
         command: Vec<Template>,
         stdin: Option<Template>,
     },
+    /// Load from an environment variable
+    #[serde(rename = "env")]
+    Environment { variable: Template },
     /// Load data from a file
     File { path: Template },
     /// Prompt the user for a value
@@ -508,6 +502,15 @@ pub enum ChainSource {
         message: Option<Template>,
         /// Default value for the shown textbox
         default: Option<Template>,
+    },
+    /// Load data from the most recent response of a particular request recipe
+    Request {
+        recipe: RecipeId,
+        /// When should this request be automatically re-executed?
+        #[serde(default)]
+        trigger: ChainRequestTrigger,
+        #[serde(default)]
+        section: ChainRequestSection,
     },
 }
 


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Add new `!env` chain source:

```yaml
chains:
  username:
    source: !env
      variable: USERNAME
```

This is meant as a replacement for the existing `{{env.USERNAME` syntax. By making this a chain, we allow it to use all the existing chain configuration, e.g. `sensitive`.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

This now provides two ways to do the same thing. Mitigated by deprecating the old syntax, which will be removed in the next major version bump.

## QA

_How did you test this?_

Added a unit test, tested manually

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
