### PR TITLE
Add --insecure flag, only use config for TUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Breaking
+
+- `ignore_certificate_hosts` config field no longer applies to the CLI
+  - It has been replaced by the `--insecure` CLI flag on the `request` subcommand
+  - This means the config file no longer impacts the CLI at all
+- Remove `slumber show config` sub-subcommand
+- Remove `Config` line from `slumber show paths` output
+  - Config file location can still be retrieved in the help menu of the TUI
+
 ## [1.6.0] - 2024-07-07
 
 ### Added

--- a/docs/src/api/configuration/index.md
+++ b/docs/src/api/configuration/index.md
@@ -1,23 +1,16 @@
 # Configuration
 
-Configuration provides _application_-level settings, as opposed to collection-level settings.
+Configuration provides _application_-level settings, as opposed to collection-level settings. Configuration **only applies to the TUI**. The CLI is not impacted by the configuration file. Config fields that are relevant to the CLI are also available as CLI flags.
 
 ## Location & Creation
 
 Configuration is stored in the Slumber root directory, under the file `config.yml`. To find the root directory, you can run:
 
 ```sh
-slumber show dir
+slumber show paths
 ```
 
-To quickly create and edit the file:
-
-```sh
-# Replace vim with your favorite text editor
-vim $(slumber show dir)/config.yml
-```
-
-If the root directory doesn't exist yet, you can create it yourself or have Slumber create it by simply starting the TUI.
+You can also find the config path by running the TUI and opening the help menu with `?`. If the root directory doesn't exist yet, you can create it yourself or have Slumber create it by simply starting the TUI.
 
 ## Fields
 

--- a/docs/src/troubleshooting/tls.md
+++ b/docs/src/troubleshooting/tls.md
@@ -12,6 +12,16 @@ If you can't or don't want to fix the certificate, and you need to keep TLS enab
 
 > **WARNING:** This is dangerous. You will be susceptible to MITM attacks on these hosts. Only do this if you control the server you're hitting, and are confident your network is not compromised.
 
+## CLI
+
+The `--insecure` flag disables TLS checks for a particular request:
+
+```
+slumber request --insecure hello_world
+```
+
+## TUI
+
 - Open your [Slumber configuration](../api/configuration/index.md)
 - Add the field `ignore_certificate_hosts: ["<hostname>"]`
   - `<hostname>` is the domain or IP of the server you're requesting from

--- a/src/cli/generate.rs
+++ b/src/cli/generate.rs
@@ -1,5 +1,6 @@
 use crate::{
     cli::{request::BuildRequestCommand, Subcommand},
+    http::InsecureHosts,
     template::TemplateError,
     GlobalArgs,
 };
@@ -30,7 +31,7 @@ impl Subcommand for GenerateCommand {
         let (_, ticket) = self
             .build_request
             // User has to explicitly opt into executing triggered requests
-            .build_request(global, self.execute_triggers)
+            .build_request(global, InsecureHosts::None, self.execute_triggers)
             .await
             .map_err(|error| {
                 // If the build failed because triggered requests are disabled,

--- a/src/cli/request.rs
+++ b/src/cli/request.rs
@@ -1,9 +1,10 @@
 use crate::{
     cli::Subcommand,
     collection::{CollectionFile, ProfileId, RecipeId},
-    config::Config,
     db::{CollectionDatabase, Database},
-    http::{BuildOptions, HttpEngine, RequestSeed, RequestTicket},
+    http::{
+        BuildOptions, HttpEngine, InsecureHosts, RequestSeed, RequestTicket,
+    },
     template::{Prompt, Prompter, TemplateContext, TemplateError},
     util::{HeaderDisplay, ResultExt},
     GlobalArgs,
@@ -31,6 +32,12 @@ const HTTP_ERROR_EXIT_CODE: u8 = 2;
 pub struct RequestCommand {
     #[clap(flatten)]
     build_request: BuildRequestCommand,
+
+    /// **DANGER** Ignore all TLS errors on this request. The request will be
+    /// susceptible to man-in-the-middle and other attacks. Only use this if
+    /// you are sure the target host is secure!
+    #[clap(long)]
+    insecure: bool,
 
     /// Print HTTP response status
     #[clap(long)]
@@ -77,10 +84,15 @@ pub struct BuildRequestCommand {
 
 impl Subcommand for RequestCommand {
     async fn execute(self, global: GlobalArgs) -> anyhow::Result<ExitCode> {
+        let insecure_hosts = if self.insecure {
+            InsecureHosts::All
+        } else {
+            InsecureHosts::None
+        };
         let (database, ticket) = self
             .build_request
             // Don't execute sub-requests in a dry run
-            .build_request(global, !self.dry_run)
+            .build_request(global, insecure_hosts, !self.dry_run)
             .await
             .map_err(|error| {
                 // If the build failed because triggered requests are disabled,
@@ -147,14 +159,14 @@ impl BuildRequestCommand {
     pub async fn build_request(
         self,
         global: GlobalArgs,
+        insecure_hosts: InsecureHosts,
         trigger_dependencies: bool,
     ) -> anyhow::Result<(CollectionDatabase, RequestTicket)> {
         let collection_path = CollectionFile::try_path(None, global.file)?;
         let database = Database::load()?.into_collection(&collection_path)?;
         let collection_file = CollectionFile::load(collection_path).await?;
         let collection = collection_file.collection;
-        let config = Config::load()?;
-        let http_engine = HttpEngine::new(&config);
+        let http_engine = HttpEngine::new(insecure_hosts);
 
         // Validate profile ID, so we can provide a good error if it's invalid
         if let Some(profile_id) = &self.profile {

--- a/src/cli/show.rs
+++ b/src/cli/show.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cli::Subcommand, collection::CollectionFile, config::Config, db::Database,
+    cli::Subcommand, collection::CollectionFile, db::Database,
     util::paths::DataDirectory, GlobalArgs,
 };
 use clap::Parser;
@@ -17,8 +17,6 @@ pub struct ShowCommand {
 enum ShowTarget {
     /// Print the path of all directories/files that Slumber uses
     Paths,
-    /// Print loaded configuration
-    Config,
     /// Print current request collection
     Collection,
 }
@@ -31,7 +29,6 @@ impl Subcommand for ShowCommand {
                     CollectionFile::try_path(None, global.file);
                 println!("Data directory: {}", DataDirectory::root());
                 println!("Log file: {}", DataDirectory::log());
-                println!("Config: {}", Config::path());
                 println!("Database: {}", Database::path());
                 println!(
                     "Collection: {}",
@@ -40,10 +37,6 @@ impl Subcommand for ShowCommand {
                         .map(Path::to_string_lossy)
                         .unwrap_or_else(|error| Cow::Owned(error.to_string()))
                 )
-            }
-            ShowTarget::Config => {
-                let config = Config::load()?;
-                println!("{}", to_yaml(&config));
             }
             ShowTarget::Collection => {
                 let collection_path =

--- a/src/http.rs
+++ b/src/http.rs
@@ -44,7 +44,6 @@ pub use query::*;
 
 use crate::{
     collection::{Authentication, JsonBody, Method, Recipe, RecipeBody},
-    config::Config,
     db::CollectionDatabase,
     template::{Template, TemplateContext},
     util::ResultExt,
@@ -83,12 +82,15 @@ pub struct HttpEngine {
     /// specifically wants to ignore errors for the request!
     danger_client: Client,
     /// Hostnames for which we should ignore TLS
-    danger_hostnames: HashSet<String>,
+    insecure_hosts: InsecureHosts,
 }
 
 impl HttpEngine {
-    /// Build a new HTTP engine, which can be used for the entire program life
-    pub fn new(config: &Config) -> Self {
+    /// Build a new HTTP engine, which can be used for the entire program life.
+    /// `ignore_certificate_hosts` defines the hosts for which we should ignore
+    /// any TLS certificate errors. This is dangerous! Only pass hostnames that
+    /// you know are safe (e.g. `localhost`).
+    pub fn new(insecure_hosts: InsecureHosts) -> Self {
         Self {
             client: Client::builder()
                 .user_agent(USER_AGENT)
@@ -99,11 +101,7 @@ impl HttpEngine {
                 .danger_accept_invalid_certs(true)
                 .build()
                 .expect("Error building reqwest client"),
-            danger_hostnames: config
-                .ignore_certificate_hosts
-                .iter()
-                .cloned()
-                .collect(),
+            insecure_hosts,
         }
     }
 
@@ -260,10 +258,40 @@ impl HttpEngine {
     /// dangerous client.
     fn get_client(&self, url: &Url) -> &Client {
         let host = url.host_str().unwrap_or_default();
-        if self.danger_hostnames.contains(host) {
+        if self.insecure_hosts.is_insecure(host) {
             &self.danger_client
         } else {
             &self.client
+        }
+    }
+}
+
+impl Default for HttpEngine {
+    fn default() -> Self {
+        Self::new(InsecureHosts::default())
+    }
+}
+
+/// Which hosts should be handled insecurely. I.e. for which hosts should we
+/// ignore all TLS errors?
+#[derive(Clone, Debug, Default)]
+pub enum InsecureHosts {
+    /// Handle all hosts securely
+    #[default]
+    None,
+    /// Ignore TLS errors on a specific set of hosts
+    Only(HashSet<String>),
+    /// Ignore TLS errors on all hosts
+    All,
+}
+
+impl InsecureHosts {
+    /// Check if a host should be handled insecurely
+    fn is_insecure(&self, host: &str) -> bool {
+        match self {
+            InsecureHosts::None => false,
+            InsecureHosts::Only(hosts) => hosts.contains(host),
+            InsecureHosts::All => true,
         }
     }
 }
@@ -737,7 +765,7 @@ mod tests {
 
     #[fixture]
     fn http_engine() -> HttpEngine {
-        HttpEngine::new(&Config::default())
+        HttpEngine::default()
     }
 
     #[fixture]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@
 
 mod cli;
 mod collection;
-mod config;
 mod db;
 mod http;
 mod template;

--- a/src/template.rs
+++ b/src/template.rs
@@ -208,7 +208,6 @@ mod tests {
             Chain, ChainOutputTrim, ChainRequestSection, ChainRequestTrigger,
             ChainSource, Profile, Recipe, RecipeId,
         },
-        config::Config,
         http::{ContentType, Exchange, RequestRecord, ResponseRecord},
         test_util::{
             assert_err, by_id, header_map, temp_dir, Factory, TempDir,
@@ -604,14 +603,13 @@ mod tests {
             },
             ..Chain::factory(())
         };
-        let http_engine = HttpEngine::new(&Config::default());
         let context = TemplateContext {
             collection: Collection {
                 recipes: by_id([recipe]).into(),
                 chains: by_id([chain]),
                 ..Collection::factory(())
             },
-            http_engine: Some(http_engine),
+            http_engine: Some(HttpEngine::default()),
             database,
             ..TemplateContext::factory(())
         };

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,3 +1,4 @@
+mod config;
 pub mod context;
 pub mod input;
 pub mod message;
@@ -8,11 +9,11 @@ pub mod view;
 
 use crate::{
     collection::{Collection, CollectionFile, ProfileId, Recipe, RecipeId},
-    config::Config,
     db::{CollectionDatabase, Database},
     http::RequestSeed,
     template::{Prompter, Template, TemplateChunk, TemplateContext},
     tui::{
+        config::Config,
         context::TuiContext,
         input::Action,
         message::{Message, MessageSender, RequestConfig},

--- a/src/tui/config.rs
+++ b/src/tui/config.rs
@@ -15,10 +15,10 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use tracing::info;
 
-/// App-level configuration, which is global across all sessions and
-/// collections. This is *not* meant to modifiable during a session. If changes
-/// are made to the config file while a session is running, they won't be
-/// picked up until the app restarts.
+/// App-level configuration, specific to the TUI. This is global across all
+/// sessions and collections. This is *not* meant to be modifiable during a
+/// session. If changes are made to the config file while a session is running,
+/// they won't be picked up until the app restarts.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct Config {

--- a/src/tui/context.rs
+++ b/src/tui/context.rs
@@ -1,7 +1,6 @@
 use crate::{
-    config::Config,
-    http::HttpEngine,
-    tui::{input::InputEngine, view::Styles},
+    http::{HttpEngine, InsecureHosts},
+    tui::{config::Config, input::InputEngine, view::Styles},
 };
 use std::sync::OnceLock;
 
@@ -47,7 +46,9 @@ impl TuiContext {
     fn new(config: Config) -> Self {
         let styles = Styles::new(&config.theme);
         let input_engine = InputEngine::new(config.input_bindings.clone());
-        let http_engine = HttpEngine::new(&config);
+        let http_engine = HttpEngine::new(InsecureHosts::Only(
+            config.ignore_certificate_hosts.iter().cloned().collect(),
+        ));
         Self {
             config,
             styles,

--- a/src/tui/view/component/help.rs
+++ b/src/tui/view/component/help.rs
@@ -1,14 +1,12 @@
-use crate::{
+use crate::tui::{
     config::Config,
-    tui::{
-        context::TuiContext,
-        input::{Action, InputBinding},
-        view::{
-            common::{modal::Modal, table::Table},
-            context::ViewContext,
-            draw::{Draw, DrawMetadata, Generate},
-            event::EventHandler,
-        },
+    context::TuiContext,
+    input::{Action, InputBinding},
+    view::{
+        common::{modal::Modal, table::Table},
+        context::ViewContext,
+        draw::{Draw, DrawMetadata, Generate},
+        event::EventHandler,
     },
 };
 use itertools::Itertools;


### PR DESCRIPTION

## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Also remove the `config` target of the `slumber show` subcommand, because it's no longer relevant to the CLI. It's a bit odd to have the config file control the CLI. Generally CLIs are only configured through flags. Also this split will make it much easier to break the crate apart into multiple subcrates in the future.

This is a BREAKING change. In reality I think the number of people impacted by this will be very small, but it will push us to 2.0.0.


## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Breaking change bad! Could also be shortsighted. Maybe in the future we'll have other config fields that really should apply to the CLI. I'm skeptical though, I think config being TUI-specific is a good thing.

## QA

_How did you test this?_

Manually ran stuff.

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
