### PR TITLE
Use spacebar to toggle state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Remove `Config` line from `slumber show paths` output
   - Config file location can still be retrieved in the help menu of the TUI
 
+### Changes
+
+- Checkbox row state and folder expand/collapse state are now toggled via the spacebar instead of enter
+  - This can be rebound ([see docs](https://slumber.lucaspickering.me/book/api/configuration/input_bindings.html))
+
 ## [1.6.0] - 2024-07-07
 
 ### Added

--- a/docs/src/api/configuration/input_bindings.md
+++ b/docs/src/api/configuration/input_bindings.md
@@ -52,6 +52,7 @@ input_bindings:
 | `home`                | `home`                      |
 | `end`                 | `end`                       |
 | `submit`              | `enter`                     |
+| `toggle`              | `space`                     |
 | `cancel`              | `esc`                       |
 | `history`             | `h`                         |
 | `search`              | `/`                         |

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -234,6 +234,7 @@ impl Default for InputEngine {
                 Action::Home => KeyCode::Home.into(),
                 Action::End => KeyCode::End.into(),
                 Action::Submit => KeyCode::Enter.into(),
+                Action::Toggle => KeyCode::Char(' ').into(),
                 Action::Cancel => KeyCode::Esc.into(),
                 Action::SelectProfileList => KeyCode::Char('p').into(),
                 Action::SelectRecipeList => KeyCode::Char('l').into(),
@@ -296,9 +297,11 @@ pub enum Action {
     Home,
     End,
 
-    /// Do a thing, e.g. submit a modal. Alternatively, send a request
+    /// Do a thing, e.g. submit in a text prompt. Alternatively, send a request
     #[display("Send Request/Submit")]
     Submit,
+    /// Toggle checkbox and similar components on/off
+    Toggle,
     /// Close the current modal/dialog/etc.
     Cancel,
     /// Browse request history

--- a/src/tui/view/component/recipe_list.rs
+++ b/src/tui/view/component/recipe_list.rs
@@ -149,10 +149,9 @@ impl EventHandler for RecipeListPane {
             Action::Right => {
                 self.set_selected_collapsed(CollapseState::Expand);
             }
-            // If this state update does nothing, then we have a recipe
-            // selected. Fall through to propagate the event
-            Action::Submit
-                if self.set_selected_collapsed(CollapseState::Toggle) => {}
+            Action::Toggle => {
+                self.set_selected_collapsed(CollapseState::Toggle);
+            }
             Action::OpenActions => ViewContext::open_modal_default::<
                 ActionsModal<RecipeMenuAction>,
             >(),

--- a/src/tui/view/component/recipe_pane.rs
+++ b/src/tui/view/component/recipe_pane.rs
@@ -154,8 +154,7 @@ impl<K: PersistedKey<Value = bool>> RowState<K> {
         }
     }
 
-    /// Toggle row state on submit
-    fn on_submit(row: &mut Self) {
+    fn toggle(row: &mut Self) {
         *row.enabled ^= true;
     }
 }
@@ -424,14 +423,14 @@ impl RecipeState {
             query: PersistedLazy::new(
                 QueryRowKey(recipe.id.clone()),
                 SelectState::builder(query_items)
-                    .on_submit(RowState::on_submit)
+                    .on_toggle(RowState::toggle)
                     .build(),
             )
             .into(),
             headers: PersistedLazy::new(
                 HeaderRowKey(recipe.id.clone()),
                 SelectState::builder(header_items)
-                    .on_submit(RowState::on_submit)
+                    .on_toggle(RowState::toggle)
                     .build(),
             )
             .into(),
@@ -592,7 +591,7 @@ impl RecipeBodyDisplay {
                     })
                     .collect();
                 let select = SelectState::builder(form_items)
-                    .on_submit(RowState::on_submit)
+                    .on_toggle(RowState::toggle)
                     .build();
                 Self::Form(
                     PersistedLazy::new(FormRowKey(recipe_id.clone()), select)


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Table rows and folders used to be toggled via Submit (Enter). This adds an additional action Toggle (bound to Space by default) that applies to folder expand state and checkbox row state. This may be a bit of a confusing change because what previously toggled rows will now send a request instead, but I think it's worth it for the long term improvement.

This also means you can send a request from any tab in the recipe pane now, which has been a goal for a while.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Changes behavior in a way that might be startling to users. I think the behavior will be overall more intuitive though so hopefully people get used to it quickly.

## QA

_How did you test this?_

Locally

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
