### PR TITLE
Show folder content in recipe pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Checkbox row state and folder expand/collapse state are now toggled via the spacebar instead of enter
   - This can be rebound ([see docs](https://slumber.lucaspickering.me/book/api/configuration/input_bindings.html))
+- Show folder tree in recipe pane when a folder is selected
 
 ## [1.6.0] - 2024-07-07
 

--- a/src/collection/recipe_tree.rs
+++ b/src/collection/recipe_tree.rs
@@ -208,19 +208,26 @@ impl From<IndexMap<RecipeId, RecipeNode>> for RecipeTree {
 }
 
 impl RecipeNode {
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Folder(folder) => folder.name(),
+            Self::Recipe(recipe) => recipe.name(),
+        }
+    }
+
     /// If this node is a recipe, return it. Otherwise return `None`
     pub fn recipe(&self) -> Option<&Recipe> {
         match self {
-            RecipeNode::Recipe(recipe) => Some(recipe),
-            RecipeNode::Folder(_) => None,
+            Self::Recipe(recipe) => Some(recipe),
+            Self::Folder(_) => None,
         }
     }
 
     /// If this node is a folder, return it. Otherwise return `None`
     pub fn folder(&self) -> Option<&Folder> {
         match self {
-            RecipeNode::Recipe(_) => None,
-            RecipeNode::Folder(folder) => Some(folder),
+            Self::Recipe(_) => None,
+            Self::Folder(folder) => Some(folder),
         }
     }
 }

--- a/src/tui/view/component/exchange_pane.rs
+++ b/src/tui/view/component/exchange_pane.rs
@@ -21,13 +21,12 @@ use crate::{
             RequestState, ViewContext,
         },
     },
-    util::doc_link,
 };
 use derive_more::Display;
 use persisted::SingletonKey;
 use ratatui::{
     layout::{Alignment, Constraint, Layout},
-    text::{Line, Text},
+    text::Line,
     widgets::block::Title,
     Frame,
 };
@@ -121,24 +120,16 @@ impl<'a> Draw<ExchangePaneProps<'a>> for ExchangePane {
         // Empty states
         match props.selected_recipe_node {
             None => {
-                frame.render_widget(
-                    Text::from(vec![
-                        "No recipes defined; add one to your collection".into(),
-                        doc_link("api/request_collection/request_recipe")
-                            .into(),
-                    ]),
-                    area,
-                );
                 return;
             }
-            Some(RecipeNode::Folder { .. }) => {
+            Some(RecipeNode::Folder(_)) => {
                 frame.render_widget(
                     "Select a recipe to see its request history",
                     area,
                 );
                 return;
             }
-            Some(RecipeNode::Recipe { .. }) => {}
+            Some(RecipeNode::Recipe(_)) => {}
         }
 
         // Split out the areas we *may* need

--- a/src/tui/view/component/recipe_list.rs
+++ b/src/tui/view/component/recipe_list.rs
@@ -1,7 +1,5 @@
 use crate::{
-    collection::{
-        HasId, Recipe, RecipeId, RecipeLookupKey, RecipeNode, RecipeTree,
-    },
+    collection::{HasId, RecipeId, RecipeLookupKey, RecipeNode, RecipeTree},
     tui::{
         context::TuiContext,
         input::Action,
@@ -85,12 +83,6 @@ impl RecipeListPane {
     /// empty
     pub fn selected_node(&self) -> Option<&RecipeNode> {
         self.select.data().selected()
-    }
-
-    /// Which recipe in the recipe list is selected? `None` iff the list is
-    /// empty OR a folder is selected.
-    pub fn selected_recipe(&self) -> Option<&Recipe> {
-        self.selected_node().and_then(RecipeNode::recipe)
     }
 
     /// Set the currently selected folder as expanded/collapsed (or toggle it).


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Instead of having an empty recipe pane when a folder is selected, show the folder contents. This isn't _particularly_ useful because you can see the same content in the sidebar, but it's at least _something_ so a user won't ever be confused why the pane is blank.

![image](https://github.com/user-attachments/assets/c8f00d28-5baa-4424-a428-6a132432afc4)

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Code complexity?

## QA

_How did you test this?_

Manual testing

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
