### PR TITLE
Apply body query continuously while typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Checkbox row state and folder expand/collapse state are now toggled via the spacebar instead of enter
   - This can be rebound ([see docs](https://slumber.lucaspickering.me/book/api/configuration/input_bindings.html))
 - Show folder tree in recipe pane when a folder is selected
+- Apply body JSONPath filter continuously while typing [#270](https://github.com/LucasPickering/slumber/issues/270)
 
 ## [1.6.0] - 2024-07-07
 

--- a/src/tui/view/component/misc.rs
+++ b/src/tui/view/component/misc.rs
@@ -77,11 +77,11 @@ impl PromptModal {
         let submit = Rc::new(Cell::new(false));
         let submit_cell = Rc::clone(&submit);
         let text_box = TextBox::default()
-            .with_sensitive(prompt.sensitive)
-            .with_default(prompt.default.unwrap_or_default())
+            .sensitive(prompt.sensitive)
+            .default_value(prompt.default.unwrap_or_default())
             // Make sure cancel gets propagated to close the modal
-            .with_on_cancel(|_| ViewContext::push_event(Event::CloseModal))
-            .with_on_submit(move |_| {
+            .on_cancel(|| ViewContext::push_event(Event::CloseModal))
+            .on_submit(move || {
                 // We have to defer submission to on_close, because we need the
                 // owned value of `self.prompt`. We could have just put that in
                 // a refcell, but this felt a bit cleaner because we know this

--- a/src/tui/view/component/queryable_body.rs
+++ b/src/tui/view/component/queryable_body.rs
@@ -57,19 +57,17 @@ impl QueryableBody {
     /// box, or want to persist the value.
     pub fn new() -> Self {
         let text_box = TextBox::default()
-            .with_placeholder("'/' to filter body with JSONPath")
-            .with_validator(|text| JsonPath::parse(text).is_ok())
+            .placeholder("'/' to filter body with JSONPath")
+            .validator(|text| JsonPath::parse(text).is_ok())
             // Callback trigger an events, so we can modify our own state
-            .with_on_click(|_| {
+            .on_click(|| {
                 ViewContext::push_event(Event::new_local(QueryCallback::Focus))
             })
-            .with_on_cancel(|_| {
+            .on_cancel(|| {
                 ViewContext::push_event(Event::new_local(QueryCallback::Cancel))
             })
-            .with_on_submit(|text_box| {
-                ViewContext::push_event(Event::new_local(
-                    QueryCallback::Submit(text_box.text().to_owned()),
-                ))
+            .on_submit(|| {
+                ViewContext::push_event(Event::new_local(QueryCallback::Submit))
             });
         Self {
             text_window: Default::default(),
@@ -113,7 +111,8 @@ impl EventHandler for QueryableBody {
                     );
                     self.query_focused = false;
                 }
-                QueryCallback::Submit(text) => {
+                QueryCallback::Submit => {
+                    let text = self.query_text_box.data().text();
                     self.query = text
                         .parse()
                         // Log the error, then throw it away
@@ -197,7 +196,7 @@ impl PersistedContainer for QueryableBody {
 enum QueryCallback {
     Focus,
     Cancel,
-    Submit(String),
+    Submit,
 }
 
 fn init_text_window(


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

This adds a new `on_change` callback to `TextBox`, which is called whenever the text is changed (and valid). In `QueryableBody` we now use this to apply the query.

I played around with some major refactors to replace callbacks with events, but I think it adds a ton of complexity for little gain. The main issue is you need a way to link callback events to their individual senders (for when there's multiple instances of the same component type emitting), which adds a whole other layer of complexity. It's still possible in the future but still not worth it I think.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Without a debounce this could potentially be annoying and slow to apply continuously. I wanted to implement a debounce but it's difficult because the debounced callback has to be called on the main thread (because `ViewContext` and the event queue is a thread local), but the main thread doesn't have a `LocalSet` so we can't do that. I think it would require a pretty major refactor to make this work.

## QA

_How did you test this?_

Manual testing in the UI. Added unit tests.

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
