### PR TITLE
Don't exit query text box on submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Checkbox row state and folder expand/collapse state are now toggled via the spacebar instead of enter
   - This can be rebound ([see docs](https://slumber.lucaspickering.me/book/api/configuration/input_bindings.html))
 - Show folder tree in recipe pane when a folder is selected
+- Don't exit body filter text box on Enter [#270](https://github.com/LucasPickering/slumber/issues/270)
 
 ## [1.6.0] - 2024-07-07
 

--- a/src/tui/view/component/queryable_body.rs
+++ b/src/tui/view/component/queryable_body.rs
@@ -121,7 +121,6 @@ impl EventHandler for QueryableBody {
                         })
                         .traced()
                         .ok();
-                    self.query_focused = false;
                 }
             }
         } else {
@@ -329,8 +328,16 @@ mod tests {
         let data = component.data();
         assert_eq!(data.query, Some("$.greeting".parse().unwrap()));
         assert_eq!(data.text().as_deref(), Some("[\n  \"hello\"\n]"));
+        assert!(data.query_focused); // Still focused
 
-        // Check the view again too
+        // Cancelling out of the text box should reset the query value
+        component.send_text("more text").assert_empty();
+        component.send_key(KeyCode::Esc).assert_empty();
+        let data = component.data();
+        assert_eq!(data.query, Some("$.greeting".parse().unwrap()));
+        assert_eq!(data.query_text_box.data().text(), "$.greeting");
+
+        // Check the view again
         component.assert_buffer_lines([
             vec![gutter("1"), " [                        ".into()],
             vec![gutter("2"), "   \"hello\"              ".into()],
@@ -341,14 +348,6 @@ mod tests {
                 styles.text,
             )],
         ]);
-
-        // Cancelling out of the text box should reset the query value
-        component.send_key(KeyCode::Char('/')).assert_empty();
-        component.send_text("more text").assert_empty();
-        component.send_key(KeyCode::Esc).assert_empty();
-        let data = component.data();
-        assert_eq!(data.query, Some("$.greeting".parse().unwrap()));
-        assert_eq!(data.query_text_box.data().text(), "$.greeting");
     }
 
     /// Render a parsed body with query text box, and load initial query from


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Don't exit query text box after pressing enter. User has to press esc to exit now. Enter applies the query while leaving you in the text box, so you can easily filter data down repeatedly. The goal is to make it easier to apply multiple filters in quick succession.

I had tried making the query apply automatically instead (#282), but without a debounce (much harder to implement) I think that pattern is less user-friendly.

Closes #270

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any 
potential risks?_

This adds an additional keystroke when the user just wants to type a filter and exit, which could be confusing/annoying. FWIW this is the pattern Insomnia uses so there's some validity to it.

## QA

_How did you test this?_

- Updated tests
- Manual testing

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
