### PR TITLE
Fix latest request not being pre-selected correctly if it's not a successful response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   - This can be rebound ([see docs](https://slumber.lucaspickering.me/book/api/configuration/input_bindings.html))
 - Show folder tree in recipe pane when a folder is selected
 - Don't exit body filter text box on Enter [#270](https://github.com/LucasPickering/slumber/issues/270)
+- Show elapsed time for failed requests (e.g. in case of network error)
+
+### Fixes
+
+- Fix latest request not being pre-selected correctly if it's not a successful response
 
 ## [1.6.0] - 2024-07-07
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -311,9 +311,9 @@ impl CollectionDatabase {
             .traced()
     }
 
-    /// Get the most recent request+response for a profile+recipe, or `None` if
-    /// there has never been one received. If the given profile is `None`, match
-    /// all requests that have no associated profile.
+    /// Get the most recent request+response (by start time) for a profile +
+    /// recipe, or `None` if there has never been one received. If the given
+    /// profile is `None`, match all requests that have no associated profile.
     pub fn get_latest_request(
         &self,
         profile_id: Option<&ProfileId>,

--- a/src/http.rs
+++ b/src/http.rs
@@ -275,11 +275,13 @@ impl RequestSeed {
         future: impl Future<Output = anyhow::Result<T>>,
         template_context: &TemplateContext,
     ) -> Result<T, RequestBuildError> {
+        let start_time = Utc::now();
         future.await.traced().map_err(|error| RequestBuildError {
             profile_id: template_context.selected_profile.clone(),
             recipe_id: self.recipe.id.clone(),
             id: self.id,
-            time: Utc::now(),
+            start_time,
+            end_time: Utc::now(),
             error,
         })
     }

--- a/src/http/models.rs
+++ b/src/http/models.rs
@@ -529,8 +529,10 @@ pub struct RequestBuildError {
     pub recipe_id: RecipeId,
     /// ID of the failed request
     pub id: RequestId,
-    /// When did the error occur?
-    pub time: DateTime<Utc>,
+    /// When did the build start?
+    pub start_time: DateTime<Utc>,
+    /// When did the build end, i.e. when did the error occur?
+    pub end_time: DateTime<Utc>,
 }
 
 #[cfg(test)]
@@ -539,7 +541,8 @@ impl PartialEq for RequestBuildError {
         self.profile_id == other.profile_id
             && self.recipe_id == other.recipe_id
             && self.id == other.id
-            && self.time == other.time
+            && self.start_time == other.start_time
+            && self.end_time == other.end_time
             && self.error.to_string() == other.error.to_string()
     }
 }

--- a/src/tui/view/component/exchange_pane.rs
+++ b/src/tui/view/component/exchange_pane.rs
@@ -140,9 +140,9 @@ impl<'a> Draw<ExchangePaneProps<'a>> for ExchangePane {
         ])
         .areas(area);
 
-        // Draw whatever metadata is available
+        // Draw timing metadata
         if let Some(metadata) =
-            props.request_state.and_then(RequestState::request_metadata)
+            props.request_state.map(RequestState::request_metadata)
         {
             frame.render_widget(
                 Line::from(vec![
@@ -153,6 +153,7 @@ impl<'a> Draw<ExchangePaneProps<'a>> for ExchangePane {
                 metadata_area,
             );
         }
+        // Draw response metadata
         if let Some(metadata) = props
             .request_state
             .and_then(RequestState::response_metadata)
@@ -168,7 +169,7 @@ impl<'a> Draw<ExchangePaneProps<'a>> for ExchangePane {
             );
         }
 
-        // Render request/response based on state. Lambas help with code dupe
+        // Render request/response based on state. Lambdas help with code dupe
         let selected_tab = self.tabs.data().selected();
         let render_tabs = |frame| self.tabs.draw(frame, (), tabs_area, true);
         let render_request = |frame, request: &Arc<RequestRecord>| {
@@ -187,10 +188,10 @@ impl<'a> Draw<ExchangePaneProps<'a>> for ExchangePane {
                 area,
             ),
             Some(RequestState::Building { .. }) => {
-                frame.render_widget("Initializing request...", area)
+                frame.render_widget("Initializing request...", content_area)
             }
             Some(RequestState::BuildError { error, .. }) => {
-                frame.render_widget(error.generate(), area)
+                frame.render_widget(error.generate(), content_area)
             }
             Some(RequestState::Loading { request, .. }) => {
                 render_tabs(frame);

--- a/src/tui/view/component/root.rs
+++ b/src/tui/view/component/root.rs
@@ -38,8 +38,6 @@ pub struct Root {
     selected_request: PersistedLazy<SelectedRequestKey, SelectedRequestId>,
 
     // ==== Children =====
-    /// We hold onto the primary view even when it's not visible, because we
-    /// don't want the state to reset when changing views
     primary_view: Component<PrimaryView>,
     modal_queue: Component<ModalQueue>,
     notification_text: Option<Component<NotificationText>>,

--- a/src/tui/view/state.rs
+++ b/src/tui/view/state.rs
@@ -180,6 +180,18 @@ impl RequestState {
         }
     }
 
+    /// Get the time of the request state. For in-flight or completed requests,
+    /// this is when it *started*.
+    pub fn time(&self) -> DateTime<Utc> {
+        match self {
+            Self::Building { start_time, .. } => *start_time,
+            Self::BuildError { error } => error.time,
+            Self::Loading { start_time, .. } => *start_time,
+            Self::Response { exchange } => exchange.start_time,
+            Self::RequestError { error } => error.start_time,
+        }
+    }
+
     /// Get metadata about a request. Return `None` if the request hasn't been
     /// successfully built (yet)
     pub fn request_metadata(&self) -> Option<RequestMetadata> {

--- a/src/tui/view/state/request_store.rs
+++ b/src/tui/view/state/request_store.rs
@@ -87,7 +87,7 @@ impl RequestStore {
                 state.profile_id() == profile_id
                     && state.recipe_id() == recipe_id
             })
-            .max_by_key(|state| state.time()))
+            .max_by_key(|state| state.request_metadata().start_time))
     }
 
     /// Load all historical requests for a recipe+profile, then return the
@@ -324,7 +324,8 @@ mod tests {
                 profile_id: Some(profile_id.clone()),
                 recipe_id: recipe_id.clone(),
                 id: build_error_id,
-                time: Utc::now(),
+                start_time: Utc::now(),
+                end_time: Utc::now(),
                 error: anyhow!("oh no!"),
             },
         });


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Previously, the most recent request would not be pre-selected when switching to a new recipe. Instead, the most recent *successful* request would be selected. We simply weren't checking the in-memory cached requests, just the ones from the database.

As part of this I realized it would be pretty easy to also track elapsed time for building and build-error requests, so added that as well.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Added complexity, additional bugs

## QA

_How did you test this?_

Manual testing, added a new unit test

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
