### PR TITLE
Apply recursion limit to chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixes
 
 - Fix latest request not being pre-selected correctly if it's not a successful response
+- Detect infinite loops in chain configuration templates
 
 ## [1.6.0] - 2024-07-07
 

--- a/src/cli/request.rs
+++ b/src/cli/request.rs
@@ -194,7 +194,7 @@ impl BuildRequestCommand {
             database: database.clone(),
             overrides,
             prompter: Box::new(CliPrompter),
-            recursion_count: Default::default(),
+            state: Default::default(),
         };
         let seed = RequestSeed::new(recipe, BuildOptions::default());
         let request = http_engine.build(seed, &template_context).await?;

--- a/src/template/error.rs
+++ b/src/template/error.rs
@@ -1,7 +1,7 @@
 use crate::{
     collection::{ChainId, ProfileId, RecipeId},
     http::{QueryError, RequestBuildError, RequestError},
-    template::RECURSION_LIMIT,
+    template::render::RECURSION_LIMIT,
     util::doc_link,
 };
 use std::{io, path::PathBuf, string::FromUtf8Error};

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -578,7 +578,7 @@ impl Tui {
             database: self.database.clone(),
             overrides: Default::default(),
             prompter,
-            recursion_count: Default::default(),
+            state: Default::default(),
         })
     }
 }


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Previously you could write recursive chain configs that would cause a stack overflow. The recursion limit was only being applied to field templates. Now it's applied to everywhere that has a template render another template.

Also refactor render state to be in a nested struct, which improves encapsulation a bit.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Since the recursion limit is very naïve, we could definitely be catching false positives when people have complex but perfectly safe recipes. Mitigated by bumping the recursion limit to 20. Long-term we should come up with a better way of tracking this. Either truly track recursion depth, or smarted recursion detection. 

## QA

_How did you test this?_

Added some unit tests, manual testing in TUI.

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
