### PR TITLE
Improve template infinite loop detection

### DIFF
--- a/src/cli/request.rs
+++ b/src/cli/request.rs
@@ -194,7 +194,6 @@ impl BuildRequestCommand {
             database: database.clone(),
             overrides,
             prompter: Box::new(CliPrompter),
-            state: Default::default(),
         };
         let seed = RequestSeed::new(recipe, BuildOptions::default());
         let request = http_engine.build(seed, &template_context).await?;

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -578,7 +578,6 @@ impl Tui {
             database: self.database.clone(),
             overrides: Default::default(),
             prompter,
-            state: Default::default(),
         })
     }
 }


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Insteading of the extremely naive "count total nested calls" method, this treats template keys as a graph and uses a stack to track for cycles. This introduces a concept of "local render state", which is specific to a particular branch of a single template's render tree.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

This adds complexity. It's an application of a pretty simple graph algorithm though. Mitigated with testing.

## QA

_How did you test this?_

Unit tests, manual testing

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
