### PR TITLE
Don't send requests for preview renders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Fix latest request not being pre-selected correctly if it's not a successful response
 - Detect infinite loops in chain configuration templates
 - Duplicated chains in a recipe will only be rendered once [#118](https://github.com/LucasPickering/slumber/issues/118)
+- Never trigger chained requests when rendering template previews in the TUI
 
 ## [1.6.0] - 2024-07-07
 


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Previously, rendering a template preview would trigger HTTP requests to be sent if the trigger said to. This is NOT right; previews should be idempotent (with the exception of commands, which we have no control over). Oopsies!

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Pretty low, this is reusing existing infrastructure.

## QA

_How did you test this?_

TUI

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
