### PR TITLE
Improvements to logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Add global `--log` argument to CLI, to print the log file being used for that invocation
+
 ### Changes
 
 - Checkbox row state and folder expand/collapse state are now toggled via the spacebar instead of enter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Detect infinite loops in chain configuration templates
 - Duplicated chains in a recipe will only be rendered once [#118](https://github.com/LucasPickering/slumber/issues/118)
 - Never trigger chained requests when rendering template previews in the TUI
+- Use a different log file for each session [#61](https://github.com/LucasPickering/slumber/issues/61)
 
 ## [1.6.0] - 2024-07-07
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -41,5 +41,6 @@
 
 # Troubleshooting
 
+- [Logs](./troubleshooting/logs.md)
 - [Lost Request History](./troubleshooting/lost_history.md)
 - [TLS Certificate Errors](./troubleshooting/tls.md)

--- a/docs/src/troubleshooting/logs.md
+++ b/docs/src/troubleshooting/logs.md
@@ -4,9 +4,9 @@ Each Slumber session logs information and events to a log file. This can often b
 
 ## Finding the Log File
 
-To find the path to a particular TUI session's log file, hit the `?` to open the help dialog. It will be listed under the General section. To find logs for a CLI command, TODO.
+To find the path to a particular TUI session's log file, hit the `?` to open the help dialog. It will be listed under the General section. To find logs for a CLI command, pass the `--log` argument and it will be printed at startup.
 
-> Note: Each Slumber session, including each invocation of the CLI, will log to its own file. That means there's no easy way to retroactively find the logs for a CLI command if you didn't pass TODO. Instead, you can find the log directory with `slumber show paths`, then search each log file in that directory to find the one associated with the command in question. If the thing you're debugging is reproducible though, it's easier just to run it again with TODO.
+> Note: Each Slumber session, including each invocation of the CLI, will log to its own file. That means there's no easy way to retroactively find the logs for a CLI command if you didn't pass `--log`. Instead, you can find the log directory with `slumber show paths`, then search each log file in that directory to find the one associated with the command in question. If the thing you're debugging is reproducible though, it's easier just to run it again with `--log`.
 
 Once you have the path to a log file, you can watch the logs with `tail -f <log file>`, or get the entire log contents with `cat <log file>`.
 

--- a/docs/src/troubleshooting/logs.md
+++ b/docs/src/troubleshooting/logs.md
@@ -1,0 +1,27 @@
+# Logs
+
+Each Slumber session logs information and events to a log file. This can often be helpful in debugging bugs and other issues with the app. Each session of Slumber logs to its own file, and files are stored in a temporary directory so they are automatically cleaned up periodically by the operating system.
+
+## Finding the Log File
+
+To find the path to a particular TUI session's log file, hit the `?` to open the help dialog. It will be listed under the General section. To find logs for a CLI command, TODO.
+
+> Note: Each Slumber session, including each invocation of the CLI, will log to its own file. That means there's no easy way to retroactively find the logs for a CLI command if you didn't pass TODO. Instead, you can find the log directory with `slumber show paths`, then search each log file in that directory to find the one associated with the command in question. If the thing you're debugging is reproducible though, it's easier just to run it again with TODO.
+
+Once you have the path to a log file, you can watch the logs with `tail -f <log file>`, or get the entire log contents with `cat <log file>`.
+
+## Increasing Verbosity
+
+In some scenarios, the default logging level is not verbose enough to debug issues. To increase the verbosity, set the `RUST_LOG` environment variable when starting Slumber:
+
+```sh
+RUST_LOG=slumber=<level> slumber ...
+```
+
+The `slumber=` filter applies this level only to Slumber's internal logging, instead of all libraries, to cut down on verbosity that will likely not be helpful. The available log levels are, in increasing verbosity:
+
+- `error`
+- `warn`
+- `info`
+- `debug`
+- `trace`

--- a/src/cli/show.rs
+++ b/src/cli/show.rs
@@ -1,6 +1,10 @@
 use crate::{
-    cli::Subcommand, collection::CollectionFile, config::Config, db::Database,
-    util::paths::DataDirectory, GlobalArgs,
+    cli::Subcommand,
+    collection::CollectionFile,
+    config::Config,
+    db::Database,
+    util::paths::{DataDirectory, TempDirectory},
+    GlobalArgs,
 };
 use clap::Parser;
 use serde::Serialize;
@@ -29,10 +33,10 @@ impl Subcommand for ShowCommand {
             ShowTarget::Paths => {
                 let collection_path =
                     CollectionFile::try_path(None, global.file);
-                println!("Data directory: {}", DataDirectory::root());
-                println!("Log file: {}", DataDirectory::log());
-                println!("Config: {}", Config::path());
-                println!("Database: {}", Database::path());
+                println!("Data directory: {}", DataDirectory::get());
+                println!("Temporary directory: {}", TempDirectory::get());
+                println!("Config: {}", Config::path().display());
+                println!("Database: {}", Database::path().display());
                 println!(
                     "Collection: {}",
                     collection_path

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,16 +3,12 @@ use crate::{
         input::{Action, InputBinding},
         view::Theme,
     },
-    util::{
-        parse_yaml,
-        paths::{DataDirectory, FileGuard},
-        ResultExt,
-    },
+    util::{parse_yaml, paths::DataDirectory, ResultExt},
 };
 use anyhow::Context;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
-use std::fs;
+use std::{fs, path::PathBuf};
 use tracing::info;
 
 /// App-level configuration, which is global across all sessions and
@@ -42,7 +38,7 @@ impl Config {
     /// deserialization failed. This is *not* async because it's only run during
     /// startup, when all operations are synchronous.
     pub fn load() -> anyhow::Result<Self> {
-        let path = Self::path().create_parent()?;
+        let path = Self::path();
         info!(?path, "Loading configuration file");
 
         match fs::read(&path) {
@@ -63,8 +59,8 @@ impl Config {
     }
 
     /// Path to the configuration file
-    pub fn path() -> FileGuard {
-        DataDirectory::root().file(Self::FILE)
+    pub fn path() -> PathBuf {
+        DataDirectory::get().file(Self::FILE)
     }
 }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -4,10 +4,7 @@
 use crate::{
     collection::{ProfileId, RecipeId},
     http::{Exchange, ExchangeSummary, RequestId},
-    util::{
-        paths::{DataDirectory, FileGuard},
-        ResultExt,
-    },
+    util::{paths::DataDirectory, ResultExt},
 };
 use anyhow::{anyhow, Context};
 use derive_more::Display;
@@ -62,7 +59,7 @@ impl Database {
     /// anywhere in the app. The migrations will run on first connection, and
     /// not after that.
     pub fn load() -> anyhow::Result<Self> {
-        let path = Self::path().create_parent()?;
+        let path = Self::path();
         info!(?path, "Loading database");
         let mut connection = Connection::open(path)?;
         connection.pragma_update(
@@ -79,8 +76,8 @@ impl Database {
     }
 
     /// Path to the database file
-    pub fn path() -> FileGuard {
-        DataDirectory::root().file(Self::FILE)
+    pub fn path() -> PathBuf {
+        DataDirectory::get().file(Self::FILE)
     }
 
     /// Apply database migrations

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,10 @@ struct GlobalArgs {
     /// (in this order): slumber.yml, slumber.yaml, .slumber.yml, .slumber.yaml
     #[clap(long, short)]
     file: Option<PathBuf>,
+    /// Print the path to the log file for this session, before running the
+    /// given subcommand
+    #[clap(long)]
+    log: bool,
 }
 
 #[tokio::main]
@@ -54,6 +58,10 @@ async fn main() -> anyhow::Result<ExitCode> {
     DataDirectory::init()?;
     TempDirectory::init()?;
     initialize_tracing(args.subcommand.is_some()).unwrap();
+
+    if args.global.log {
+        println!("{}", TempDirectory::get().log().display());
+    }
 
     // Select mode based on whether request ID(s) were given
     match args.subcommand {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,11 @@ mod test_util;
 mod tui;
 mod util;
 
-use crate::{cli::CliCommand, tui::Tui, util::paths::DataDirectory};
+use crate::{
+    cli::CliCommand,
+    tui::Tui,
+    util::paths::{DataDirectory, TempDirectory},
+};
 use clap::Parser;
 use std::{fs::File, io, path::PathBuf, process::ExitCode};
 use tracing::level_filters::LevelFilter;
@@ -47,6 +51,8 @@ struct GlobalArgs {
 async fn main() -> anyhow::Result<ExitCode> {
     // Global initialization
     let args = Args::parse();
+    DataDirectory::init()?;
+    TempDirectory::init()?;
     initialize_tracing(args.subcommand.is_some()).unwrap();
 
     // Select mode based on whether request ID(s) were given
@@ -78,7 +84,7 @@ async fn main() -> anyhow::Result<ExitCode> {
 /// Set up tracing to log to a file. Optionally also log to stderr (for CLI
 /// usage)
 fn initialize_tracing(console_output: bool) -> anyhow::Result<()> {
-    let path = DataDirectory::log().create_parent()?;
+    let path = TempDirectory::get().log();
     let log_file = File::create(path)?;
     let file_subscriber = tracing_subscriber::fmt::layer()
         .with_file(true)

--- a/src/tui/view/component/help.rs
+++ b/src/tui/view/component/help.rs
@@ -10,6 +10,7 @@ use crate::{
             event::EventHandler,
         },
     },
+    util::paths::TempDirectory,
 };
 use itertools::Itertools;
 use ratatui::{
@@ -55,7 +56,7 @@ pub struct HelpModal;
 
 impl HelpModal {
     /// Number of lines in the general section (not including header)
-    const GENERAL_LENGTH: u16 = 3;
+    const GENERAL_LENGTH: u16 = 4;
 
     /// Get the list of bindings that will be shown in the modal
     fn bindings() -> impl Iterator<Item = (Action, &'static InputBinding)> {
@@ -99,15 +100,19 @@ impl Draw for HelpModal {
             title: Some("General"),
             rows: [
                 ("Version", Line::from(CRATE_VERSION)),
-                ("Configuration", Line::from(Config::path().to_string())),
+                ("Configuration", Config::path().display().to_string().into()),
+                (
+                    "Log",
+                    TempDirectory::get().log().display().to_string().into(),
+                ),
                 (
                     "Collection",
-                    Line::from(ViewContext::with_database(|database| {
-                        database
-                            .collection_path()
-                            .map(|path| path.display().to_string())
-                            .unwrap_or_default()
-                    })),
+                    ViewContext::with_database(|database| {
+                        database.collection_path()
+                    })
+                    .map(|path| path.display().to_string())
+                    .unwrap_or_default()
+                    .into(),
                 ),
             ]
             .into_iter()

--- a/src/tui/view/component/queryable_body.rs
+++ b/src/tui/view/component/queryable_body.rs
@@ -113,14 +113,17 @@ impl EventHandler for QueryableBody {
                 }
                 QueryCallback::Submit => {
                     let text = self.query_text_box.data().text();
-                    self.query = text
-                        .parse()
-                        // Log the error, then throw it away
-                        .with_context(|| {
-                            format!("Error parsing query {text:?}")
-                        })
-                        .traced()
-                        .ok();
+                    self.query = if text.is_empty() {
+                        None
+                    } else {
+                        text.parse()
+                            // Log the error, then throw it away
+                            .with_context(|| {
+                                format!("Error parsing query {text:?}")
+                            })
+                            .traced()
+                            .ok()
+                    };
                 }
             }
         } else {

--- a/src/util/paths.rs
+++ b/src/util/paths.rs
@@ -1,72 +1,118 @@
-use anyhow::{anyhow, Context};
+use anyhow::Context;
 use derive_more::Display;
 use std::{
-    fs,
+    env,
+    fs::{self, OpenOptions},
     path::{Path, PathBuf},
+    process,
+    sync::OnceLock,
 };
+
+// Store directories statically so we can create them once at startup and access
+// them subsequently anywhere
+static DATA_DIRECTORY: OnceLock<DataDirectory> = OnceLock::new();
+static TEMP_DIRECTORY: OnceLock<TempDirectory> = OnceLock::new();
 
 /// The root data directory. All files that Slumber creates on the system should
 /// live here.
-///
-/// Intentionally does not implement `Debug`, to prevent accidental debug
-/// printing when looking for Path's `Debug` impl, which just wraps in quotes.
-#[derive(Clone, Display)]
+#[derive(Debug, Display)]
 #[display("{}", _0.display())]
 pub struct DataDirectory(PathBuf);
 
 impl DataDirectory {
-    /// Root directory for all generated files. The value is contextual:
+    /// Initialize directory for all generated files. The path is contextual:
     /// - In development, use a directory from the crate root
     /// - In release, use a platform-specific directory in the user's home
-    pub fn root() -> Self {
-        if cfg!(debug_assertions) {
+    /// This will create the directory, and return an error if that fails
+    pub fn init() -> anyhow::Result<()> {
+        let path = if cfg!(debug_assertions) {
             // If env var isn't defined, this will just become ./data/
-            let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("data/");
-            Self(path)
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("data/")
         } else {
             // According to the docs, this dir will be present on all platforms
             // https://docs.rs/dirs/latest/dirs/fn.data_dir.html
-            Self(dirs::data_dir().unwrap().join("slumber"))
-        }
+            dirs::data_dir().unwrap().join("slumber")
+        };
+
+        // Create the dir
+        fs::create_dir_all(&path).with_context(|| {
+            format!("Error creating data directory {path:?}")
+        })?;
+
+        DATA_DIRECTORY
+            .set(Self(path))
+            .expect("Temporary directory is already initialized");
+        Ok(())
     }
 
-    /// Path to the log file
-    pub fn log() -> FileGuard {
-        // Use a random new file for each session:
-        // https://github.com/LucasPickering/slumber/issues/61
-        Self::root().file("log/slumber.log")
+    /// Get a reference to the global directory for permanent data. See
+    /// [Self::init] for more info.
+    pub fn get() -> &'static Self {
+        DATA_DIRECTORY
+            .get()
+            .expect("Temporary directory is not initialized")
     }
 
-    /// Get the path of a file in the directory.
-    pub fn file(self, path: impl AsRef<Path>) -> FileGuard {
-        FileGuard(self.0.join(path))
+    /// Build a path to a file in this directory
+    pub fn file(&self, path: impl AsRef<Path>) -> PathBuf {
+        self.0.join(path)
     }
 }
 
-/// A wrapper around a path to a specific file in the data directory. The
-/// purpose is to make it easy to print a path without any side effects, but
-/// enforce that the path's parent directory is created before actually using
-/// it. To accomplish that, this implements `Display` but does not provide any
-/// other access to the inner `PathBuf`. To get the parent, use
-/// [Self::create_parent].
-///
-/// Intentionally does not implement Debug, to prevent accidental debug printing
-/// when looking for Path's debug impl, which just wraps in quotes.
-#[derive(Clone, Display)]
-#[display("{}", _0.display())]
-pub struct FileGuard(PathBuf);
+/// A singleton temporary directory, which should be used to store ephemeral
+/// data such as logs. This directory *is* unique to Slumber, but is *not*
+/// unique to this particular process.
+#[derive(Debug, Display)]
+#[display("{}", path.display())]
+pub struct TempDirectory {
+    path: PathBuf,
+    /// Absolute path to the log file
+    log_file: PathBuf,
+}
 
-impl FileGuard {
-    /// Create the parent directory and return the path to the file. This
-    /// enforces that the directory exists before using the path for any
-    /// operations.
-    pub fn create_parent(self) -> anyhow::Result<PathBuf> {
-        let parent = self
-            .0
-            .parent()
-            .ok_or_else(|| anyhow!("Path {:?} has no parent", self.0))?;
-        fs::create_dir_all(parent)
-            .with_context(|| format!("Error creating directory {parent:?}"))?;
-        Ok(self.0)
+impl TempDirectory {
+    /// Initialize the temporary directory. The directory is *not* guaranteed to
+    /// be empty or unique to this process, per [std::env::temp_dir]. It
+    /// *will* however include a `slumber/` suffix so it's safe to assume
+    /// everything in the directory is Slumber-related. Use [Self::get] to get
+    /// the created directory.
+    pub fn init() -> anyhow::Result<()> {
+        // Create the temp dir
+        let path = env::temp_dir().join("slumber");
+        fs::create_dir_all(&path).with_context(|| {
+            format!("Error creating temporary directory {path:?}")
+        })?;
+
+        // Use our PID in the log file so it's unique and easy to find. It's
+        // possible a PID gets re-used, so wipe out the file to be safe.
+        let log_file =
+            path.join(format!("slumber.{pid}.log", pid = process::id()));
+        OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&log_file)
+            .with_context(|| format!("Error creating log file {log_file:?}"))?;
+
+        TEMP_DIRECTORY
+            .set(Self { path, log_file })
+            .expect("Temporary directory is already initialized");
+        Ok(())
+    }
+
+    /// Get a reference to the global directory for temporary data. See
+    /// [Self::init] for more info.
+    pub fn get() -> &'static Self {
+        TEMP_DIRECTORY
+            .get()
+            .expect("Temporary directory is not initialized")
+    }
+
+    /// Get the path to this session's log file. This will create a new file
+    /// that's guaranteed to have a unique name. Each session gets its own file
+    /// in the temp directory, so that multiple sessions don't intersperse their
+    /// logs.
+    pub fn log(&self) -> &PathBuf {
+        &self.log_file
     }
 }


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

- Log to the tmp dir instead of the data dir
- Each session logs to its own file, using the PID as a unique ID
- Add `--log` global CLI flag to print the log file for that session
- Add info on access logs to the docs

The main goal here is to prevent multiple TUI sessions from interspersing their logs into the same file.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

- Logs are harder to find now
- We could potentially be creating a ton of files (especially for CLI usage)

Overall though this should cut down on disk usage because we're writing to a tmp file instead of a permanent dir.

## QA

_How did you test this?_

Manual testing w/ CLI/TUI

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
