### PR TITLE
Remove regex support from serde_json_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `ignore_certificate_hosts` config field no longer applies to the CLI
   - It has been replaced by the `--insecure` CLI flag on the `request` subcommand
   - This means the config file no longer impacts the CLI at all
-- Remove `slumber show config` sub-subcommand
-- Remove `Config` line from `slumber show paths` output
-  - Config file location can still be retrieved in the help menu of the TUI
+  - Remove `slumber show config` sub-subcommand
+  - Remove `Config` line from `slumber show paths` output
+    - Config file location can still be retrieved in the help menu of the TUI
+- Remove regex functionality for JSONpath filter (`search` and `match` functions)
+  - I doubt these are very useful, and they incur a very large build time cost to compile the regex engine
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1941,13 +1941,11 @@ dependencies = [
 [[package]]
 name = "serde_json_path"
 version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bc0207b6351893eafa1e39aa9aea452abb6425ca7b02dd64faf29109e7a33ba"
+source = "git+https://github.com/LucasPickering/serde_json_path?branch=regex-feature#40c4f8108e6d986070a665f0ffa7578a0e133983"
 dependencies = [
  "inventory",
  "nom",
  "once_cell",
- "regex",
  "serde",
  "serde_json",
  "serde_json_path_core",
@@ -1958,8 +1956,7 @@ dependencies = [
 [[package]]
 name = "serde_json_path_core"
 version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3d64fe53ce1aaa31bea2b2b46d3b6ab6a37e61854bedcbd9f174e188f3f7d79"
+source = "git+https://github.com/LucasPickering/serde_json_path?branch=regex-feature#40c4f8108e6d986070a665f0ffa7578a0e133983"
 dependencies = [
  "inventory",
  "once_cell",
@@ -1971,8 +1968,7 @@ dependencies = [
 [[package]]
 name = "serde_json_path_macros"
 version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a31e8177a443fd3e94917f12946ae7891dfb656e6d4c5e79b8c5d202fbcb723"
+source = "git+https://github.com/LucasPickering/serde_json_path?branch=regex-feature#40c4f8108e6d986070a665f0ffa7578a0e133983"
 dependencies = [
  "inventory",
  "once_cell",
@@ -1983,8 +1979,7 @@ dependencies = [
 [[package]]
 name = "serde_json_path_macros_internal"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75dde5a1d2ed78dfc411fc45592f72d3694436524d3353683ecb3d22009731dc"
+source = "git+https://github.com/LucasPickering/serde_json_path?branch=regex-feature#40c4f8108e6d986070a665f0ffa7578a0e133983"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ reqwest = {version = "0.12.5", default-features = false}
 rstest = {version = "0.21.0", default-features = false}
 serde = {version = "1.0.204", default-features = false}
 serde_json = {version = "1.0.120", default-features = false}
-serde_json_path = "0.6.3"
+serde_json_path = {git = "https://github.com/LucasPickering/serde_json_path", branch = "regex-feature", default-features = false}
 serde_test = "1.0.176"
 serde_yaml = {version = "0.9.0", default-features = false}
 strum = {version = "0.26.3", default-features = false}

--- a/crates/slumber_core/Cargo.toml
+++ b/crates/slumber_core/Cargo.toml
@@ -31,7 +31,7 @@ rusqlite = {version = "0.31.0", default-features = false, features = ["bundled",
 rusqlite_migration = "1.2.0"
 serde = {workspace = true, features = ["derive"]}
 serde_json = {workspace = true}
-serde_json_path = "0.6.3"
+serde_json_path = {workspace = true}
 serde_yaml = {workspace = true}
 strum = {workspace = true, features = ["derive"]}
 thiserror = "1.0.63"


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

This is the last thing relying on `regex` in the release build. Everything else is dev-only. Those will be next.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

This is a breaking change, because a small subset of jsonpaths no longer work. I doubt people are using regex queries very much (if at all). I couldn't even figure out how to use them, and most people are probably just writing fast filters and not thinking too much about it. If there's a lot of uproar it's always easy to re-enable.

## QA

_How did you test this?_

Ran locally to confirm the `regex` crate is no longer in the build

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
