### PR TITLE
Optimize template stringification

### DIFF
--- a/crates/slumber_core/src/template.rs
+++ b/crates/slumber_core/src/template.rs
@@ -31,8 +31,7 @@ use std::sync::Arc;
 ///
 /// Invariant: two templates with the same source string will have the same set
 /// of chunks
-#[derive(Clone, Debug, Default, PartialEq, Serialize)]
-#[serde(into = "String", try_from = "String")]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct Template {
     /// Pre-parsed chunks of the template. For raw chunks we store the
     /// presentation text (which is not necessarily the source text, as escape

--- a/crates/slumber_core/src/template/render.rs
+++ b/crates/slumber_core/src/template/render.rs
@@ -77,8 +77,6 @@ impl Template {
         context: &'a TemplateContext,
         stack: &mut RenderKeyStack<'a>,
     ) -> Result<Vec<u8>, TemplateError> {
-        debug!(template = %self, "Rendering template");
-
         // Render each individual template chunk in the string
         let chunks = self.render_chunks_impl(context, stack).await;
 
@@ -118,7 +116,7 @@ impl Template {
     }
 
     /// Internal version of [Self::render_chunks] with local render state
-    #[instrument(skip_all, fields(template = %self))]
+    #[instrument(skip_all, fields(template = %self.display()))]
     async fn render_chunks_impl<'a>(
         &'a self,
         context: &'a TemplateContext,

--- a/crates/slumber_core/src/test_util.rs
+++ b/crates/slumber_core/src/test_util.rs
@@ -214,7 +214,7 @@ macro_rules! assert_err {
 #[macro_export]
 macro_rules! assert_matches {
     ($expr:expr, $pattern:pat $(if $condition:expr)? $(,)?) => {
-        slumber_core::assert_matches!($expr, $pattern $(if $condition)? => ());
+        $crate::assert_matches!($expr, $pattern $(if $condition)? => ());
     };
     ($expr:expr, $pattern:pat $(if $condition:expr)? => $output:expr $(,)?) => {
         match $expr {

--- a/crates/slumber_tui/src/view/common/template_preview.rs
+++ b/crates/slumber_tui/src/view/common/template_preview.rs
@@ -67,9 +67,7 @@ impl Generate for &TemplatePreview {
         Self: 'this,
     {
         match self {
-            TemplatePreview::Disabled { template } => {
-                template.to_string().into()
-            }
+            TemplatePreview::Disabled { template } => template.display().into(),
             // If the preview render is ready, show it. Otherwise fall back
             // to the raw
             TemplatePreview::Enabled {
@@ -77,7 +75,7 @@ impl Generate for &TemplatePreview {
             } => match chunks.get() {
                 Some(chunks) => TextStitcher::stitch_chunks(chunks),
                 // Preview still rendering
-                None => template.to_string().into(),
+                None => template.display().into(),
             },
         }
     }

--- a/crates/slumber_tui/src/view/component/recipe_pane.rs
+++ b/crates/slumber_tui/src/view/component/recipe_pane.rs
@@ -593,8 +593,9 @@ impl RecipeBodyDisplay {
                 // is to just turn this whole JSON struct into a single string
                 // (with unrendered templates), then parse that back as one big
                 // template. If it's stupid but it works, it's not stupid.
-                let value: serde_json::Value =
-                    value.map_ref(|template| template.to_string()).into();
+                let value: serde_json::Value = value
+                    .map_ref(|template| template.display().to_string())
+                    .into();
                 let stringified = format!("{value:#}");
                 // This template is made of valid templates, surrounded by JSON
                 // syntax. In no world should that result in an invalid template


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Stringification now returns Cow instead of String, so we can avoid cloning the template contents for empty and single-raw-span templates. These categories probably cover the vast majority of templates in use so hopefully this is meaningful. No, I didn't measure it.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Could've actually made things slower. There's also potential for an edge case bug, but the test suite is pretty good.

## QA

_How did you test this?_

Updated existing tests

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
