### PR TITLE
Disable invalid menu actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- Add syntax highlight to recipe, request, and response display [#264](https://github.com/LucasPickering/slumber/issues/264)
+- Add syntax highlighting to recipe, request, and response display [#264](https://github.com/LucasPickering/slumber/issues/264)
 
 ### Changed
 
 - Upgrade to Rust 1.80
+- Disable unavailable menu actions [#222](https://github.com/LucasPickering/slumber/issues/222)
 
 ## [1.7.0] - 2024-07-22
 

--- a/crates/slumber_tui/src/view/common/actions.rs
+++ b/crates/slumber_tui/src/view/common/actions.rs
@@ -21,8 +21,10 @@ pub struct ActionsModal<T: FixedSelect> {
     actions: Component<FixedSelectState<T, ListState>>,
 }
 
-impl<T: FixedSelect> Default for ActionsModal<T> {
-    fn default() -> Self {
+impl<T: FixedSelect> ActionsModal<T> {
+    /// Create a new actions modal, optionall disabling certain actions based on
+    /// some external condition(s).
+    pub fn new(disabled_actions: &[T]) -> Self {
         let on_submit = move |action: &mut T| {
             // Close the modal *first*, so the parent can handle the
             // callback event. Jank but it works
@@ -32,10 +34,17 @@ impl<T: FixedSelect> Default for ActionsModal<T> {
 
         Self {
             actions: FixedSelectState::builder()
+                .disabled_items(disabled_actions)
                 .on_submit(on_submit)
                 .build()
                 .into(),
         }
+    }
+}
+
+impl<T: FixedSelect> Default for ActionsModal<T> {
+    fn default() -> Self {
+        Self::new(&[])
     }
 }
 
@@ -67,7 +76,7 @@ where
     fn draw(&self, frame: &mut Frame, _: (), metadata: DrawMetadata) {
         self.actions.draw(
             frame,
-            List::new(self.actions.data().items()),
+            List::from(self.actions.data()),
             metadata.area(),
             true,
         );

--- a/crates/slumber_tui/src/view/common/button.rs
+++ b/crates/slumber_tui/src/view/common/button.rs
@@ -82,7 +82,7 @@ impl<T: FixedSelect> Draw for ButtonGroup<T> {
         // The button width is based on the longest button
         let width = items
             .iter()
-            .map(|button| button.to_string().len())
+            .map(|button| button.value.to_string().len())
             .max()
             .unwrap_or(0) as u16;
         let (areas, _) =
@@ -91,6 +91,7 @@ impl<T: FixedSelect> Draw for ButtonGroup<T> {
                 .split_with_spacers(metadata.area());
 
         for (button, area) in items.iter().zip(areas.iter()) {
+            let button = &button.value;
             frame.render_widget(
                 Button {
                     text: &button.to_string(),

--- a/crates/slumber_tui/src/view/common/list.rs
+++ b/crates/slumber_tui/src/view/common/list.rs
@@ -1,48 +1,94 @@
 use crate::{
     context::TuiContext,
-    view::{common::scrollbar::Scrollbar, draw::Generate},
+    view::{
+        common::scrollbar::Scrollbar,
+        draw::Generate,
+        state::{
+            fixed_select::{FixedSelect, FixedSelectState},
+            select::{SelectItem, SelectState},
+        },
+    },
 };
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
+    style::Styled,
     text::Text,
-    widgets::{ListItem, ListState, StatefulWidget, Widget},
+    widgets::{
+        List as TuiList, ListItem as TuiListItem, ListState, StatefulWidget,
+        Widget,
+    },
 };
 use std::marker::PhantomData;
 
 /// A sequence of items, with a scrollbar and optional surrounding pane
-pub struct List<'a, Item, Iter: 'a + IntoIterator<Item = Item>> {
-    items: Iter,
-    _phantom: PhantomData<&'a ()>,
+pub struct List<'a, Item> {
+    items: Vec<ListItem<Item>>,
+    /// This *shouldn't* be required, but without it we hit this ICE:
+    /// https://github.com/rust-lang/rust/issues/124189
+    phantom: PhantomData<&'a ()>,
 }
 
-impl<'a, Item, Iter: 'a + IntoIterator<Item = Item>> List<'a, Item, Iter> {
-    pub fn new(items: Iter) -> Self {
+impl<'a, Item> List<'a, Item> {
+    pub fn from_iter(items: impl 'a + IntoIterator<Item = Item>) -> Self {
         Self {
-            items,
-            _phantom: PhantomData,
+            items: items
+                .into_iter()
+                .map(|value| ListItem {
+                    value,
+                    disabled: false,
+                })
+                .collect(),
+            phantom: PhantomData,
         }
     }
 }
 
-impl<'a, T, Item, Iter> StatefulWidget for List<'a, Item, Iter>
+impl<'a, Item> From<&'a SelectState<Item>> for List<'a, &'a Item> {
+    fn from(select: &'a SelectState<Item>) -> Self {
+        Self {
+            items: select.items().iter().map(ListItem::from).collect(),
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, Item> From<&'a FixedSelectState<Item>> for List<'a, &'a Item>
+where
+    Item: FixedSelect,
+{
+    fn from(select: &'a FixedSelectState<Item>) -> Self {
+        Self {
+            items: select.items().iter().map(ListItem::from).collect(),
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, T, Item> StatefulWidget for List<'a, Item>
 where
     T: Into<Text<'a>>,
     Item: 'a + Generate<Output<'a> = T>,
-    Iter: 'a + IntoIterator<Item = Item>,
 {
     type State = ListState;
 
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut ListState) {
+        let styles = &TuiContext::get().styles;
+
         // Draw list
-        let items: Vec<ListItem<'_>> = self
+        let items: Vec<TuiListItem<'_>> = self
             .items
             .into_iter()
-            .map(|i| ListItem::new(i.generate()))
+            .map(|item| {
+                let mut list_item = TuiListItem::new(item.value.generate());
+                if item.disabled {
+                    list_item = list_item.set_style(styles.list.disabled);
+                }
+                list_item
+            })
             .collect();
         let num_items = items.len();
-        let list = ratatui::widgets::List::new(items)
-            .highlight_style(TuiContext::get().styles.list.highlight);
+        let list = TuiList::new(items).highlight_style(styles.list.highlight);
         StatefulWidget::render(list, area, buf, state);
 
         // Draw scrollbar
@@ -52,5 +98,19 @@ where
             ..Default::default()
         }
         .render(area, buf);
+    }
+}
+
+struct ListItem<T> {
+    value: T,
+    disabled: bool,
+}
+
+impl<'a, T> From<&'a SelectItem<T>> for ListItem<&'a T> {
+    fn from(item: &'a SelectItem<T>) -> Self {
+        Self {
+            value: &item.value,
+            disabled: item.disabled,
+        }
     }
 }

--- a/crates/slumber_tui/src/view/common/scrollbar.rs
+++ b/crates/slumber_tui/src/view/common/scrollbar.rs
@@ -137,7 +137,7 @@ mod tests {
 
         // Render a list once to get a realistic offset calculation
         let mut buffer = Buffer::empty(area);
-        let list = List::new((0..content_length).map(|i| i.to_string()));
+        let list = List::from_iter((0..content_length).map(|i| i.to_string()));
         let mut state = ListState::default().with_selected(Some(selected));
         StatefulWidget::render(list, area, &mut buffer, &mut state);
 

--- a/crates/slumber_tui/src/view/component/history.rs
+++ b/crates/slumber_tui/src/view/component/history.rs
@@ -63,7 +63,7 @@ impl Modal for History {
     fn dimensions(&self) -> (Constraint, Constraint) {
         (
             Constraint::Length(40),
-            Constraint::Length(self.select.data().items().len().min(20) as u16),
+            Constraint::Length(self.select.data().len().min(20) as u16),
         )
     }
 }
@@ -78,7 +78,7 @@ impl Draw for History {
     fn draw(&self, frame: &mut Frame, _: (), metadata: DrawMetadata) {
         self.select.draw(
             frame,
-            List::new(self.select.data().items()),
+            List::from(self.select.data()),
             metadata.area(),
             true,
         );

--- a/crates/slumber_tui/src/view/component/profile_select.rs
+++ b/crates/slumber_tui/src/view/component/profile_select.rs
@@ -84,7 +84,11 @@ impl ProfilePane {
         ViewContext::open_modal(
             ProfileListModal::new(
                 // See self.profiles doc comment for why we need to clone
-                self.profiles.items().to_owned(),
+                self.profiles
+                    .items()
+                    .iter()
+                    .map(|item| item.value.clone())
+                    .collect(),
                 self.profiles.selected().map(|profile| &profile.id),
             ),
             ModalPriority::Low,
@@ -189,7 +193,7 @@ impl Draw for ProfileListModal {
     fn draw(&self, frame: &mut Frame, _: (), metadata: DrawMetadata) {
         // Empty state
         let select = self.select.data();
-        if select.items().is_empty() {
+        if select.is_empty() {
             frame.render_widget(
                 Text::from(vec![
                     "No profiles defined; add one to your collection.".into(),
@@ -201,14 +205,13 @@ impl Draw for ProfileListModal {
         }
 
         let [list_area, _, detail_area] = Layout::vertical([
-            Constraint::Length(select.items().len().min(5) as u16),
+            Constraint::Length(select.len().min(5) as u16),
             Constraint::Length(1), // Padding
             Constraint::Min(0),
         ])
         .areas(metadata.area());
 
-        self.select
-            .draw(frame, List::new(select.items()), list_area, true);
+        self.select.draw(frame, List::from(select), list_area, true);
         if let Some(profile) = select.selected() {
             self.detail.draw(
                 frame,

--- a/crates/slumber_tui/src/view/component/request_view.rs
+++ b/crates/slumber_tui/src/view/component/request_view.rs
@@ -9,7 +9,7 @@ use crate::{
         draw::{Draw, DrawMetadata, Generate, ToStringGenerate},
         event::{Event, EventHandler, Update},
         state::StateCell,
-        Component, ViewContext,
+        Component, ModalPriority, ViewContext,
     },
 };
 use derive_more::Display;
@@ -63,7 +63,20 @@ impl ToStringGenerate for MenuAction {}
 impl EventHandler for RequestView {
     fn update(&mut self, event: Event) -> Update {
         if let Some(Action::OpenActions) = event.action() {
-            ViewContext::open_modal_default::<ActionsModal<MenuAction>>()
+            let disabled = if self
+                .state
+                .get_mut()
+                .and_then(|state| state.body.as_ref())
+                .is_some()
+            {
+                [].as_slice()
+            } else {
+                &[MenuAction::CopyBody]
+            };
+            ViewContext::open_modal(
+                ActionsModal::new(disabled),
+                ModalPriority::Low,
+            );
         } else if let Some(action) = event.local::<MenuAction>() {
             match action {
                 MenuAction::EditCollection => {

--- a/crates/slumber_tui/src/view/styles.rs
+++ b/crates/slumber_tui/src/view/styles.rs
@@ -27,6 +27,8 @@ pub struct Styles {
 pub struct ListStyles {
     /// Highlighted item in a list
     pub highlight: Style,
+    /// Disabled item in a list
+    pub disabled: Style,
 }
 
 /// Styles for the Modal component
@@ -128,6 +130,7 @@ impl Styles {
                     .bg(theme.primary_color)
                     .fg(theme.primary_text_color)
                     .add_modifier(Modifier::BOLD),
+                disabled: Style::default().fg(Color::DarkGray),
             },
             modal: ModalStyles {
                 border: Style::default(),


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

The implementation is mildly jank, but it's simple and clear to the user. Disabled items can still be selected, they just don't trigger callbacks. This was the easiest thing to implement and I think also the most intuitive.

Closes #222

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

The implementation is fairly rigid and also includes some potential `O(n^2)` code, but in reality `n<10` so it's totally fine.

## QA

_How did you test this?_

Added to some unit tests, tested all the actions in the TUI.

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
