### PR TITLE
Migrate all DB tables away from MessagePack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- Change layout of internal database for request and UI state storage
+  - This _shouldn't_ have any user impact, it's just a technical improvement. If you notice any issues such as missing or incorrect request history, please [let me know](https://github.com/LucasPickering/slumber/issues/new?assignees=&labels=bug&projects=&template=bug_report.md)
 - Upgrade to Rust 1.80
 - Disable unavailable menu actions [#222](https://github.com/LucasPickering/slumber/issues/222)
 

--- a/crates/slumber_core/src/db.rs
+++ b/crates/slumber_core/src/db.rs
@@ -1,6 +1,8 @@
 //! The database is responsible for persisting data, including requests and
 //! responses.
 
+mod migrations;
+
 use crate::{
     collection::{ProfileId, RecipeId},
     http::{Exchange, ExchangeSummary, RequestId},
@@ -14,7 +16,6 @@ use rusqlite::{
     types::{FromSql, FromSqlError, FromSqlResult, ToSqlOutput, ValueRef},
     Connection, DatabaseName, OptionalExtension, Row, ToSql,
 };
-use rusqlite_migration::{Migrations, M};
 use serde::{de::DeserializeOwned, Serialize};
 use std::{
     fmt::Debug,
@@ -82,53 +83,7 @@ impl Database {
 
     /// Apply database migrations
     fn migrate(connection: &mut Connection) -> anyhow::Result<()> {
-        let migrations = Migrations::new(vec![
-            M::up(
-                // Path is the *canonicalzed* path to a collection file,
-                // guaranteeing it will be stable and unique
-                "CREATE TABLE collections (
-                    id              UUID PRIMARY KEY NOT NULL,
-                    path            BLOB NOT NULL UNIQUE
-                )",
-            )
-            .down("DROP TABLE collections"),
-            M::up(
-                // The request state kind is a bit hard to map to tabular data.
-                // Everything that we need to query on (HTTP status code,
-                // end_time, etc.) is in its own column. Therequest/response
-                // will be serialized into msgpack bytes
-                "CREATE TABLE requests (
-                    id              UUID PRIMARY KEY NOT NULL,
-                    collection_id   UUID NOT NULL,
-                    profile_id      TEXT,
-                    recipe_id       TEXT NOT NULL,
-                    start_time      TEXT NOT NULL,
-                    end_time        TEXT NOT NULL,
-                    request         BLOB NOT NULL,
-                    response        BLOB NOT NULL,
-                    status_code     INTEGER NOT NULL,
-                    FOREIGN KEY(collection_id) REFERENCES collections(id)
-                )",
-            )
-            .down("DROP TABLE requests"),
-            M::up(
-                // keys+values will be serialized as msgpack
-                "CREATE TABLE ui_state (
-                    key             BLOB NOT NULL,
-                    collection_id   UUID NOT NULL,
-                    value           BLOB NOT NULL,
-                    PRIMARY KEY (key, collection_id),
-                    FOREIGN KEY(collection_id) REFERENCES collections(id)
-                )",
-            )
-            .down("DROP TABLE ui_state"),
-            // This is a sledgehammer migration. Added when we switch from
-            // rmp_serde::to_vec to rmp_serde::to_vec_named. This affected the
-            // serialization of all binary blobs, so there's no easy way to
-            // migrate it all. It's easiest just to wipe it all out.
-            M::up("DELETE FROM requests; DELETE FROM ui_state;").down(""),
-        ]);
-        migrations.to_latest(connection)?;
+        migrations::migrations().to_latest(connection)?;
         Ok(())
     }
 

--- a/crates/slumber_core/src/db.rs
+++ b/crates/slumber_core/src/db.rs
@@ -6,7 +6,7 @@ mod migrations;
 
 use crate::{
     collection::{ProfileId, RecipeId},
-    db::convert::{ByteEncoded, CollectionPath, JsonEncoded, SqlWrap},
+    db::convert::{CollectionPath, JsonEncoded, SqlWrap},
     http::{Exchange, ExchangeSummary, RequestId},
     util::{DataDirectory, ResultTraced},
 };
@@ -89,7 +89,9 @@ impl Database {
     pub fn collections(&self) -> anyhow::Result<Vec<PathBuf>> {
         self.connection()
             .prepare("SELECT path FROM collections")?
-            .query_map([], |row| Ok(row.get::<_, ByteEncoded<_>>("path")?.0))
+            .query_map([], |row| {
+                Ok(row.get::<_, CollectionPath>("path")?.into())
+            })
             .context("Error fetching collections")?
             .collect::<rusqlite::Result<Vec<_>>>()
             .context("Error extracting collection data")

--- a/crates/slumber_core/src/db/convert.rs
+++ b/crates/slumber_core/src/db/convert.rs
@@ -1,0 +1,325 @@
+//! Implementations to convert between Rust types and SQL data
+
+use crate::{
+    collection::{ProfileId, RecipeId},
+    db::CollectionId,
+    http::{
+        Exchange, ExchangeSummary, RequestId, RequestRecord, ResponseRecord,
+    },
+    util::ResultTraced,
+};
+use anyhow::Context;
+use bytes::Bytes;
+use derive_more::Display;
+use reqwest::{
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Method, StatusCode,
+};
+use rusqlite::{
+    types::{FromSql, FromSqlError, FromSqlResult, ToSqlOutput, ValueRef},
+    Row, ToSql,
+};
+use serde::{de::DeserializeOwned, Serialize};
+use std::{
+    fmt::Debug,
+    ops::Deref,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+use thiserror::Error;
+use url::Url;
+use uuid::Uuid;
+use winnow::{
+    combinator::{repeat, terminated},
+    token::take_while,
+    PResult, Parser,
+};
+
+impl ToSql for CollectionId {
+    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
+        self.0.to_sql()
+    }
+}
+
+impl FromSql for CollectionId {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+        Ok(Self(Uuid::column_result(value)?))
+    }
+}
+
+impl ToSql for ProfileId {
+    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
+        self.deref().to_sql()
+    }
+}
+
+impl FromSql for ProfileId {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+        Ok(String::column_result(value)?.into())
+    }
+}
+
+impl ToSql for RequestId {
+    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
+        self.0.to_sql()
+    }
+}
+
+impl FromSql for RequestId {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+        Ok(Self(Uuid::column_result(value)?))
+    }
+}
+
+impl ToSql for RecipeId {
+    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
+        self.deref().to_sql()
+    }
+}
+
+impl FromSql for RecipeId {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+        Ok(String::column_result(value)?.into())
+    }
+}
+
+/// Neat little wrapper for a collection path, to make sure it gets
+/// canonicalized and serialized/deserialized consistently
+#[derive(Debug, Display)]
+#[display("{}", _0.0.display())]
+pub struct CollectionPath(ByteEncoded<PathBuf>);
+
+impl From<CollectionPath> for PathBuf {
+    fn from(path: CollectionPath) -> Self {
+        path.0 .0
+    }
+}
+
+impl TryFrom<&Path> for CollectionPath {
+    type Error = anyhow::Error;
+
+    fn try_from(path: &Path) -> Result<Self, Self::Error> {
+        path.canonicalize()
+            .context(format!("Error canonicalizing path {path:?}"))
+            .traced()
+            .map(|path| Self(ByteEncoded(path)))
+    }
+}
+
+impl ToSql for CollectionPath {
+    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
+        self.0.to_sql()
+    }
+}
+
+impl FromSql for CollectionPath {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+        ByteEncoded::<PathBuf>::column_result(value).map(Self)
+    }
+}
+
+/// A wrapper to serialize/deserialize a value as JSON for DB storage
+#[derive(Debug)]
+pub struct JsonEncoded<T>(pub T);
+
+impl<T: Serialize> ToSql for JsonEncoded<T> {
+    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
+        let s = serde_json::to_string(&self.0).map_err(|err| {
+            rusqlite::Error::ToSqlConversionFailure(Box::new(err))
+        })?;
+        Ok(ToSqlOutput::Owned(s.into()))
+    }
+}
+
+impl<T: DeserializeOwned> FromSql for JsonEncoded<T> {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+        let s = value.as_str()?;
+        let value: T = serde_json::from_str(s).map_err(error_other)?;
+        Ok(Self(value))
+    }
+}
+
+/// A wrapper to serialize/deserialize a value as msgpack for DB storage
+///
+/// To be removed in https://github.com/LucasPickering/slumber/issues/306
+#[derive(Debug)]
+pub struct ByteEncoded<T>(pub T);
+
+impl<T: Serialize> ToSql for ByteEncoded<T> {
+    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
+        let bytes = rmp_serde::to_vec_named(&self.0).map_err(|err| {
+            rusqlite::Error::ToSqlConversionFailure(Box::new(err))
+        })?;
+        Ok(ToSqlOutput::Owned(bytes.into()))
+    }
+}
+
+impl<T: DeserializeOwned> FromSql for ByteEncoded<T> {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+        let bytes = value.as_blob()?;
+        let value: T = rmp_serde::from_slice(bytes).map_err(error_other)?;
+        Ok(Self(value))
+    }
+}
+
+/// Convert from `SELECT * FROM requests_v2`
+impl<'a, 'b> TryFrom<&'a Row<'b>> for Exchange {
+    type Error = rusqlite::Error;
+
+    fn try_from(row: &'a Row<'b>) -> Result<Self, Self::Error> {
+        let id: RequestId = row.get("id")?;
+        Ok(Self {
+            id,
+            start_time: row.get("start_time")?,
+            end_time: row.get("end_time")?,
+            request: Arc::new(RequestRecord {
+                id,
+                profile_id: row.get("profile_id")?,
+                recipe_id: row.get("recipe_id")?,
+                // Use wrappers for all of these to specify the conversion
+                method: row.get::<_, SqlWrap<_>>("method")?.0,
+                url: row.get::<_, SqlWrap<_>>("url")?.0,
+                headers: row.get::<_, SqlWrap<HeaderMap>>("request_headers")?.0,
+                body: row
+                    .get::<_, Option<SqlWrap<Bytes>>>("request_body")?
+                    .map(|wrap| wrap.0),
+            }),
+            response: Arc::new(ResponseRecord {
+                status: row.get::<_, SqlWrap<StatusCode>>("status_code")?.0,
+                headers: row
+                    .get::<_, SqlWrap<HeaderMap>>("response_headers")?
+                    .0,
+                body: row.get::<_, SqlWrap<Bytes>>("response_body")?.0.into(),
+            }),
+        })
+    }
+}
+
+/// Convert from `SELECT ... FROM requests_v2`
+impl<'a, 'b> TryFrom<&'a Row<'b>> for ExchangeSummary {
+    type Error = rusqlite::Error;
+
+    fn try_from(row: &'a Row<'b>) -> Result<Self, Self::Error> {
+        Ok(Self {
+            id: row.get("id")?,
+            start_time: row.get("start_time")?,
+            end_time: row.get("end_time")?,
+            status: row.get::<_, SqlWrap<StatusCode>>("status_code")?.0,
+        })
+    }
+}
+
+/// A wrapper to define `ToSql`/`FromSql` impls on foreign types, to get around
+/// the orphan rule
+pub struct SqlWrap<T>(pub T);
+
+impl FromSql for SqlWrap<Method> {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+        value.as_str()?.parse().map(Self).map_err(error_other)
+    }
+}
+
+impl FromSql for SqlWrap<Url> {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+        value.as_str()?.parse().map(Self).map_err(error_other)
+    }
+}
+
+impl FromSql for SqlWrap<Bytes> {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+        // Clone is necessary because the bytes live in sqlite FFI land
+        let bytes = value.as_blob()?.to_owned();
+        Ok(Self(bytes.into()))
+    }
+}
+
+impl FromSql for SqlWrap<StatusCode> {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+        let code: u16 = value.as_i64()?.try_into().map_err(error_other)?;
+        let code = StatusCode::from_u16(code as u16).map_err(error_other)?;
+        Ok(Self(code))
+    }
+}
+
+// Serialize header map using the same format it gets in HTTP: key:value, one
+// entry per line. The spec disallows colors in keys and newlines in values so
+// it's safe to use both as delimiters
+
+/// Char between header name and value
+const HEADER_FIELD_DELIM: u8 = b':';
+/// Char between header lines
+/// https://www.rfc-editor.org/rfc/rfc9110.html#name-field-values
+const HEADER_LINE_DELIM: u8 = b'\n';
+
+impl<'a> ToSql for SqlWrap<&'a HeaderMap> {
+    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
+        // We know the exact capacity we'll need so we can avoid reallocations
+        let capacity = self
+            .0
+            .iter()
+            .map(|(name, value)| {
+                // Include extra bytes for the delimiters
+                name.as_str().as_bytes().len() + 1 + value.as_bytes().len() + 1
+            })
+            .sum();
+        let mut buf: Vec<u8> = Vec::with_capacity(capacity);
+
+        for (name, value) in self.0.iter() {
+            buf.extend(name.as_str().as_bytes());
+            buf.push(HEADER_FIELD_DELIM);
+            buf.extend(value.as_bytes());
+            buf.push(HEADER_LINE_DELIM);
+        }
+
+        Ok(buf.into())
+    }
+}
+
+impl FromSql for SqlWrap<HeaderMap> {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+        fn header_line(
+            input: &mut &[u8],
+        ) -> PResult<(HeaderName, HeaderValue)> {
+            (
+                terminated(
+                    take_while(1.., |c| c != HEADER_FIELD_DELIM)
+                        .try_map(HeaderName::from_bytes),
+                    HEADER_FIELD_DELIM,
+                ),
+                terminated(
+                    take_while(1.., |c| c != HEADER_LINE_DELIM)
+                        .try_map(HeaderValue::from_bytes),
+                    HEADER_LINE_DELIM,
+                ),
+            )
+                .parse_next(input)
+        }
+
+        let bytes = value.as_blob()?;
+        let lines = repeat(0.., header_line)
+            .fold(HeaderMap::new, |mut acc, (name, value)| {
+                acc.insert(name, value);
+                acc
+            })
+            .parse(bytes)
+            .map_err(|error| {
+                /// This is the only way I could figure out to convert the parse
+                /// error to something that implements `std:error:Error`
+                /// https://github.com/winnow-rs/winnow/discussions/329
+                #[derive(Debug, Error)]
+                #[error("{0}")]
+                struct HeaderParseError(String);
+
+                error_other(HeaderParseError(error.to_string()))
+            })?;
+        Ok(Self(lines))
+    }
+}
+
+/// Create an `Other` variant of [FromSqlError]
+fn error_other<T>(error: T) -> FromSqlError
+where
+    T: 'static + std::error::Error + Send + Sync,
+{
+    FromSqlError::Other(Box::new(error))
+}

--- a/crates/slumber_core/src/db/migrations.rs
+++ b/crates/slumber_core/src/db/migrations.rs
@@ -1,0 +1,53 @@
+//! TODO
+
+use rusqlite::Transaction;
+use rusqlite_migration::{HookResult, Migrations, M};
+
+/// Get all DB migrations in history
+pub fn migrations() -> Migrations<'static> {
+    // There's no need for any down migrations here, because we have no
+    // mechanism for going backwards
+    Migrations::new(vec![
+        M::up(
+            // Path is the *canonicalzed* path to a collection file,
+            // guaranteeing it will be stable and unique
+            "CREATE TABLE collections (
+                id              UUID PRIMARY KEY NOT NULL,
+                path            BLOB NOT NULL UNIQUE
+            )",
+        ),
+        M::up(
+            // The request state kind is a bit hard to map to tabular data.
+            // Everything that we need to query on (HTTP status code,
+            // end_time, etc.) is in its own column. Therequest/response
+            // will be serialized into msgpack bytes
+            "CREATE TABLE requests (
+                id              UUID PRIMARY KEY NOT NULL,
+                collection_id   UUID NOT NULL,
+                profile_id      TEXT,
+                recipe_id       TEXT NOT NULL,
+                start_time      TEXT NOT NULL,
+                end_time        TEXT NOT NULL,
+                request         BLOB NOT NULL,
+                response        BLOB NOT NULL,
+                status_code     INTEGER NOT NULL,
+                FOREIGN KEY(collection_id) REFERENCES collections(id)
+            )",
+        ),
+        M::up(
+            // keys+values will be serialized as msgpack
+            "CREATE TABLE ui_state (
+                key             BLOB NOT NULL,
+                collection_id   UUID NOT NULL,
+                value           BLOB NOT NULL,
+                PRIMARY KEY (key, collection_id),
+                FOREIGN KEY(collection_id) REFERENCES collections(id)
+            )",
+        ),
+        // This is a sledgehammer migration. Added when we switch from
+        // rmp_serde::to_vec to rmp_serde::to_vec_named. This affected the
+        // serialization of all binary blobs, so there's no easy way to
+        // migrate it all. It's easiest just to wipe it all out.
+        M::up("DELETE FROM requests; DELETE FROM ui_state;"),
+    ])
+}

--- a/crates/slumber_core/src/db/migrations.rs
+++ b/crates/slumber_core/src/db/migrations.rs
@@ -1,7 +1,16 @@
-//! TODO
-
-use rusqlite::Transaction;
+use crate::{
+    db::{
+        convert::{ByteEncoded, SqlWrap},
+        CollectionId,
+    },
+    http::Exchange,
+    util::ResultTraced,
+};
+use anyhow::Context;
+use rusqlite::{named_params, Row, Transaction};
 use rusqlite_migration::{HookResult, Migrations, M};
+use std::sync::Arc;
+use tracing::info;
 
 /// Get all DB migrations in history
 pub fn migrations() -> Migrations<'static> {
@@ -17,9 +26,10 @@ pub fn migrations() -> Migrations<'static> {
             )",
         ),
         M::up(
+            // WARNING: this has been totally abolished by a later migration
             // The request state kind is a bit hard to map to tabular data.
             // Everything that we need to query on (HTTP status code,
-            // end_time, etc.) is in its own column. Therequest/response
+            // end_time, etc.) is in its own column. The request/response
             // will be serialized into msgpack bytes
             "CREATE TABLE requests (
                 id              UUID PRIMARY KEY NOT NULL,
@@ -49,5 +59,385 @@ pub fn migrations() -> Migrations<'static> {
         // serialization of all binary blobs, so there's no easy way to
         // migrate it all. It's easiest just to wipe it all out.
         M::up("DELETE FROM requests; DELETE FROM ui_state;"),
+        // New table that flattens everything into its own column. This makes
+        // it easy to browse data in the sqlite CLI, and gives better control
+        // over migrations in the future if we add more fields.
+        M::up_with_hook(
+            "CREATE TABLE requests_v2 (
+                id                  UUID PRIMARY KEY NOT NULL,
+                collection_id       UUID NOT NULL,
+                profile_id          TEXT,
+                recipe_id           TEXT NOT NULL,
+                start_time          TEXT NOT NULL,
+                end_time            TEXT NOT NULL,
+
+                method              TEXT NOT NULL,
+                url                 TEXT_NOT NULL,
+                request_headers     BLOB NOT NULL,
+                request_body        BLOB,
+
+                status_code         INTEGER NOT NULL,
+                response_headers    BLOB NOT NULL,
+                response_body       BLOB NOT NULL,
+
+                FOREIGN KEY(collection_id) REFERENCES collections(id)
+            )",
+            migrate_requests_v2_up,
+        ),
+        // UI state is now JSON encoded, instead of msgpack. This makes it
+        // easier to browse, and the size payment should be minimal because
+        // the key/value structure is simple
+        M::up_with_hook(
+            "CREATE TABLE ui_state_v2 (
+                collection_id   UUID NOT NULL,
+                key_type        TEXT NOT NULL,
+                key             TEXT NOT NULL,
+                value           TEXT NOT NULL,
+                PRIMARY KEY (collection_id, key_type, key),
+                FOREIGN KEY(collection_id) REFERENCES collections(id)
+            )",
+            migrate_ui_state_v2_up,
+        ),
     ])
+}
+
+/// Post-up hook to copy data from the `requests` table to `requests_v2`. This
+/// will leave the old table around, so we can recover user data if something
+/// goes wrong. We'll delete it in a later migration.
+fn migrate_requests_v2_up(transaction: &Transaction) -> HookResult {
+    fn load_exchange(
+        row: &Row<'_>,
+    ) -> Result<(CollectionId, Exchange), rusqlite::Error> {
+        let collection_id = row.get("collection_id")?;
+        let exchange = Exchange {
+            id: row.get("id")?,
+            start_time: row.get("start_time")?,
+            end_time: row.get("end_time")?,
+            // Deserialize from bytes
+            request: Arc::new(row.get::<_, ByteEncoded<_>>("request")?.0),
+            response: Arc::new(row.get::<_, ByteEncoded<_>>("response")?.0),
+        };
+        Ok((collection_id, exchange))
+    }
+
+    info!("Migrating table `requests` -> `requests_v2`");
+    let mut select_stmt = transaction.prepare("SELECT * FROM requests")?;
+    let mut insert_stmt = transaction.prepare(
+        "INSERT INTO requests_v2 (
+            id,
+            collection_id,
+            profile_id,
+            recipe_id,
+            start_time,
+            end_time,
+            method,
+            url,
+            request_headers,
+            request_body,
+            status_code,
+            response_headers,
+            response_body
+        ) VALUES (
+            :id,
+            :collection_id,
+            :profile_id,
+            :recipe_id,
+            :start_time,
+            :end_time,
+            :method,
+            :url,
+            :request_headers,
+            :request_body,
+            :status_code,
+            :response_headers,
+            :response_body
+        )",
+    )?;
+
+    for result in select_stmt.query_map([], load_exchange)? {
+        let Ok((collection_id, exchange)) = result
+            .context("Error migrating from `requests` -> `requests_v2`")
+            .traced()
+        else {
+            // Skip any conversions that fail so we don't kill everything
+            continue;
+        };
+
+        info!(
+            %collection_id,
+            ?exchange,
+            "Copying row from `requests` -> `requests_v2`",
+        );
+        insert_stmt.execute(named_params! {
+            ":id": exchange.id,
+            ":collection_id": collection_id,
+            ":profile_id": &exchange.request.profile_id,
+            ":recipe_id": &exchange.request.recipe_id,
+            ":start_time": &exchange.start_time,
+            ":end_time": &exchange.end_time,
+
+            ":method": exchange.request.method.as_str(),
+            ":url": exchange.request.url.as_str(),
+            ":request_headers": SqlWrap(&exchange.request.headers),
+            ":request_body": exchange.request.body.as_deref(),
+
+            ":status_code": exchange.response.status.as_u16(),
+            ":response_headers": SqlWrap(&exchange.response.headers),
+            ":response_body": exchange.response.body.bytes(),
+        })?;
+    }
+
+    Ok(())
+}
+
+/// Copy rows from ui_state -> ui_state_v2. Drop the old table since, unlike
+/// requests, it's not a huge deal if we lose some data
+fn migrate_ui_state_v2_up(transaction: &Transaction) -> HookResult {
+    #[derive(Debug)]
+    struct V1Row {
+        collection_id: CollectionId,
+        key_type: String,
+        key: serde_json::Value,
+        value: serde_json::Value,
+    }
+
+    fn load_row(row: &Row) -> Result<V1Row, rusqlite::Error> {
+        // Key is encoded as a tuple of (type name, key)
+        let ByteEncoded((key_type, key)): ByteEncoded<(
+            String,
+            serde_json::Value,
+        )> = row.get("key")?;
+        Ok(V1Row {
+            collection_id: row.get("collection_id")?,
+            key_type,
+            key,
+            value: row.get::<_, ByteEncoded<serde_json::Value>>("value")?.0,
+        })
+    }
+
+    info!("Migrating table `ui_state` -> `ui_state_v2`");
+    let mut select_stmt = transaction.prepare("SELECT * FROM ui_state")?;
+    let mut insert_stmt = transaction.prepare(
+        "INSERT INTO ui_state_v2 (collection_id, key_type, key, value)
+        VALUES (:collection_id, :key_type, :key, :value)",
+    )?;
+
+    for result in select_stmt.query_map([], load_row)? {
+        let Ok(row) = result
+            .context("Error migrating from `ui_state` -> `ui_state_v2`")
+            .traced()
+        else {
+            // Skip any conversions that fail so we don't kill everything
+            continue;
+        };
+
+        info!(?row, "Copying row from `ui_state` -> `ui_state_v2`");
+        insert_stmt.execute(named_params! {
+            ":collection_id": row.collection_id,
+            ":key_type": row.key_type,
+            ":key": row.key.to_string(),
+            ":value": row.value.to_string(),
+        })?;
+    }
+
+    info!("Dropping table `ui_state`");
+    transaction.execute("DROP TABLE ui_state", [])?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        db::convert::{CollectionPath, JsonEncoded},
+        http::{RequestRecord, ResponseRecord},
+        test_util::Factory,
+        util::get_repo_root,
+    };
+    use itertools::Itertools;
+    use reqwest::{Method, StatusCode};
+    use rstest::{fixture, rstest};
+    use rusqlite::Connection;
+    use serde_json::json;
+
+    const MIGRATION_COLLECTIONS: usize = 1;
+    const MIGRATION_ALL_V1: usize = 4;
+    const MIGRATION_REQUESTS_V2: usize = MIGRATION_ALL_V1 + 1;
+    const MIGRATION_UI_STATE_V2: usize = MIGRATION_REQUESTS_V2 + 1;
+
+    #[fixture]
+    fn connection() -> Connection {
+        let mut connection = Connection::open_in_memory().unwrap();
+        migrations()
+            .to_version(&mut connection, MIGRATION_COLLECTIONS)
+            .unwrap();
+
+        let collection_id = CollectionId::new();
+        let collection_path: CollectionPath = get_repo_root()
+            .join("slumber.yml")
+            .as_path()
+            .try_into()
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO collections (id, path) VALUES (:id, :path)",
+                named_params! {
+                    ":id": collection_id,
+                    ":path": collection_path,
+                },
+            )
+            .unwrap();
+
+        connection
+    }
+
+    /// Test copying data requests -> requests_v2
+    #[rstest]
+    fn test_migrate_requests_v2(mut connection: Connection) {
+        let migrations = migrations();
+        migrations
+            .to_version(&mut connection, MIGRATION_ALL_V1)
+            .unwrap();
+
+        let exchanges = [
+            Exchange::factory((
+                RequestRecord {
+                    method: Method::GET,
+                    ..RequestRecord::factory(())
+                },
+                ResponseRecord::factory(StatusCode::NOT_FOUND),
+            )),
+            Exchange::factory((
+                RequestRecord {
+                    method: Method::POST,
+                    ..RequestRecord::factory(())
+                },
+                ResponseRecord {
+                    body: json!({"username": "ted"}).into(),
+                    ..ResponseRecord::factory(StatusCode::CREATED)
+                },
+            )),
+            Exchange::factory((
+                RequestRecord {
+                    method: Method::DELETE,
+                    ..RequestRecord::factory(())
+                },
+                ResponseRecord::factory(StatusCode::BAD_REQUEST),
+            )),
+        ];
+        for exchange in &exchanges {
+            connection
+                .execute(
+                    "INSERT INTO
+                        requests (
+                            collection_id,
+                            id,
+                            profile_id,
+                            recipe_id,
+                            start_time,
+                            end_time,
+                            request,
+                            response,
+                            status_code
+                        )
+                        VALUES (
+                            (SELECT id FROM collections),
+                            :id, :profile_id, :recipe_id, :start_time,
+                            :end_time, :request, :response, :status_code)",
+                    named_params! {
+                        ":id": exchange.id,
+                        ":profile_id": &exchange.request.profile_id,
+                        ":recipe_id": &exchange.request.recipe_id,
+                        ":start_time": &exchange.start_time,
+                        ":end_time": &exchange.end_time,
+                        ":request": &ByteEncoded(&*exchange.request),
+                        ":response": &ByteEncoded(&*exchange.response),
+                        ":status_code": exchange.response.status.as_u16(),
+                    },
+                )
+                .unwrap();
+        }
+
+        migrations
+            .to_version(&mut connection, MIGRATION_REQUESTS_V2)
+            .unwrap();
+
+        // Make sure we didn't delete anything from the old table
+        let count = connection
+            .query_row("SELECT COUNT(*) FROM requests", [], |row| {
+                row.get::<_, usize>(0)
+            })
+            .unwrap();
+        assert_eq!(count, exchanges.len());
+
+        let mut stmt = connection.prepare("SELECT * FROM requests_v2").unwrap();
+        let migrated: Vec<Exchange> = stmt
+            .query_map::<Exchange, _, _>([], |row| row.try_into())
+            .unwrap()
+            .try_collect()
+            .unwrap();
+        assert_eq!(&migrated, &exchanges);
+    }
+
+    /// Test copying data ui_state -> ui_state_v2
+    #[rstest]
+    fn test_migrate_ui_state_v2(mut connection: Connection) {
+        let migrations = migrations();
+        migrations
+            .to_version(&mut connection, MIGRATION_ALL_V1)
+            .unwrap();
+
+        let rows = [
+            ("Scalar".to_owned(), json!(null), json!(3)),
+            ("StringKey".to_owned(), json!("k1"), json!({"a": 1})),
+            ("StringKey".to_owned(), json!("k2"), json!({"b": 2})),
+            ("StringKey".to_owned(), json!("k3"), json!({"c": 3})),
+            ("MapKey".to_owned(), json!({"key": "k1"}), json!([1, 2, 3])),
+            ("MapKey".to_owned(), json!({"key": "k2"}), json!([4, 5, 6])),
+            ("MapKey".to_owned(), json!({"key": "k3"}), json!([7, 8, 9])),
+        ];
+
+        for (key_type, key, value) in &rows {
+            connection
+                .execute(
+                    "INSERT INTO
+                        ui_state (collection_id, key, value)
+                        VALUES ((SELECT id FROM collections), :key, :value)",
+                    named_params! {
+                        ":key": ByteEncoded((key_type, key)),
+                        ":value": ByteEncoded(value),
+                    },
+                )
+                .unwrap();
+        }
+
+        migrations
+            .to_version(&mut connection, MIGRATION_UI_STATE_V2)
+            .unwrap();
+
+        // Make sure we dropped the old table
+        let count = connection
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master \
+                WHERE type = 'table' AND name = 'ui_state'",
+                [],
+                |row| row.get::<_, usize>(0),
+            )
+            .unwrap();
+        assert_eq!(count, 0, "Expected `ui_state` table to be dropped");
+
+        let mut stmt = connection.prepare("SELECT * FROM ui_state_v2").unwrap();
+        let migrated: Vec<(String, serde_json::Value, serde_json::Value)> =
+            stmt.query_map([], |row| {
+                Ok((
+                    row.get("key_type")?,
+                    row.get::<_, JsonEncoded<_>>("key")?.0,
+                    row.get::<_, JsonEncoded<_>>("value")?.0,
+                ))
+            })
+            .unwrap()
+            .try_collect()
+            .unwrap();
+        assert_eq!(&migrated, &rows);
+    }
 }

--- a/crates/slumber_core/src/template.rs
+++ b/crates/slumber_core/src/template.rs
@@ -359,11 +359,7 @@ mod tests {
             ..ResponseRecord::factory(())
         };
         database
-            .insert_exchange(&Exchange {
-                request: request.into(),
-                response: response.into(),
-                ..Exchange::factory(())
-            })
+            .insert_exchange(&Exchange::factory((request, response)))
             .unwrap();
         let selector = selector.map(|s| s.parse().unwrap());
         let recipe = Recipe {

--- a/crates/slumber_tui/src/view/component/root.rs
+++ b/crates/slumber_tui/src/view/component/root.rs
@@ -324,7 +324,11 @@ mod tests {
         harness.database.insert_exchange(&new_exchange).unwrap();
         harness
             .database
-            .set_ui(&SelectedRequestKey, RequestId::new())
+            .set_ui(
+                SelectedRequestKey::type_name(),
+                &SelectedRequestKey,
+                RequestId::new(),
+            )
             .unwrap();
 
         let component = TestComponent::new(harness, Root::new(&collection), ());

--- a/crates/slumber_tui/src/view/context.rs
+++ b/crates/slumber_tui/src/view/context.rs
@@ -151,7 +151,7 @@ where
     K::Value: Debug + Serialize + DeserializeOwned,
 {
     fn load_persisted(key: &K) -> Option<K::Value> {
-        Self::with_database(|database| database.get_ui((K::type_name(), key)))
+        Self::with_database(|database| database.get_ui(K::type_name(), key))
             // Error is already traced in the DB, nothing to do with it here
             .ok()
             .flatten()
@@ -159,7 +159,7 @@ where
 
     fn store_persisted(key: &K, value: K::Value) {
         Self::with_database(|database| {
-            database.set_ui((K::type_name(), key), value)
+            database.set_ui(K::type_name(), key, value)
         })
         // Error is already traced in the DB, nothing to do with it here
         .ok();


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Previously, MessagePack was used extensively in the internal Slumber DB to store complex values (requests, responses, UI state, etc.). This seemed like a good idea at the time because it allowed me to jam complex data into single DB columns without having to write migrations when adding fields. I chose MessagePack over JSON because it was more compact. Over time though I've realized storing the data as big binary blobs makes it hard to debug, and also adds an extra package (`rmp_serde`) to the dep tree.

This MR makes 3 major changes:

- Add a new table `requests_v2`, which stores all request and response fields as columns. This will make it easier to browse data now, and migrate data in the future. I'm sure there's also a performance benefit to skipping the extra serde layer
- Add a new table `ui_state_v2` that stores data in JSON instead of MessagePack. JSON will be a bit less compact, but is can be easily read in the CLI for debugging, and the size difference will be minimal.
- Convert the column `collections.path` from MessagePack to just the raw path bytes. It was being serialized as those exact bytes anyway, just with two extra bytes for the msgpack header.

I wrote migrations for all 3 so there should be no discernible impact to the user. The plan is to remove these migrations at some point in the future so we can drop the `rmp_serde` dependency (#306). It'll also allow us to remove some serde derive impls, which should improve compile time marginally. Right now I'm thinking ~6 months from now. That will necessitate a major version update.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

There's potential for data loss here. Mitigated that by leaving the `requests` table around. This means we'll have duplicate data which wastes disk space. We can drop that table in the future once the migration has been tested more.

## QA

_How did you test this?_

Manually tested migrations locally, added unit tests for each one.

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
