### PR TITLE
Support template for headers in response chain section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   - This _shouldn't_ have any user impact, it's just a technical improvement. If you notice any issues such as missing or incorrect request history, please [let me know](https://github.com/LucasPickering/slumber/issues/new?assignees=&labels=bug&projects=&template=bug_report.md)
 - Upgrade to Rust 1.80
 - Disable unavailable menu actions [#222](https://github.com/LucasPickering/slumber/issues/222)
+- Support template for header names in the `section` field of response chains
 
 ## [1.7.0] - 2024-07-22
 

--- a/crates/slumber_core/src/collection/models.rs
+++ b/crates/slumber_core/src/collection/models.rs
@@ -542,7 +542,9 @@ impl ChainSource {
 pub enum ChainRequestSection {
     #[default]
     Body,
-    Header(String),
+    /// Pull a value from a response's headers. If the given header appears
+    /// multiple times, the first value will be used
+    Header(Template),
 }
 
 /// Define when a recipe with a chained request should auto-execute the

--- a/docs/src/api/request_collection/chain_source.md
+++ b/docs/src/api/request_collection/chain_source.md
@@ -90,10 +90,10 @@ trigger: !always
 
 This defines which section of the response (headers or body) should be used to load the value from.
 
-| Variant  | Type     | Description                                                                                                                  |
-| -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `body`   | None     | The body of the response                                                                                                     |
-| `header` | `string` | A specific header from the response. If the header appears multiple times in the response, only the first value will be used |
+| Variant  | Type       | Description                                                                                                                  |
+| -------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `body`   | None       | The body of the response                                                                                                     |
+| `header` | `Template` | A specific header from the response. If the header appears multiple times in the response, only the first value will be used |
 
 #### Examples
 


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

The `section` field of respones chain sources now supports templates rather than plain strings. 

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

This is not a breaking change because anything that would be a template key, and therefore would change the behavior here, is not a valid HTTP header name so it would've already been broken.

## QA

_How did you test this?_

Unit test

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
