### PR TITLE
Expand ~ in user-provided paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   - This _shouldn't_ have any user impact, it's just a technical improvement. If you notice any issues such as missing or incorrect request history, please [let me know](https://github.com/LucasPickering/slumber/issues/new?assignees=&labels=bug&projects=&template=bug_report.md)
 - Upgrade to Rust 1.80
 - Disable unavailable menu actions [#222](https://github.com/LucasPickering/slumber/issues/222)
-- Support template for header names in the `section` field of response chains
+- Support template for header names in the `section` field of `!request` chains
+- Expand `~` to the home directory in `!file` chain sources and when saving response body as a file
 
 ## [1.7.0] - 2024-07-22
 

--- a/crates/slumber_core/src/template/render.rs
+++ b/crates/slumber_core/src/template/render.rs
@@ -11,7 +11,7 @@ use crate::{
         Prompt, Template, TemplateChunk, TemplateContext, TemplateError,
         TemplateKey,
     },
-    util::{FutureCache, FutureCacheOutcome, ResultTraced},
+    util::{expand_home, FutureCache, FutureCacheOutcome, ResultTraced},
 };
 use async_trait::async_trait;
 use chrono::Utc;
@@ -585,6 +585,8 @@ impl<'a> ChainTemplateSource<'a> {
             .render_chain_config("path", context, stack)
             .await?
             .into();
+        let path = expand_home(path).into_owned(); // Expand ~
+
         // Guess content type based on file extension
         let content_type = ContentType::from_path(&path).ok();
         let content =


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Expand `~` into the user's home dir in paths provided by the user. This *excludes* paths provided via CLI, because the shell will provide path expansion for that.

I could only think of two places that match this description:

- `!file` chain sources, the `path` field
- The prompt to enter a file name when saving a file

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Expansion could be wrong. Mitigated with tests. I might've missed a spot. Easy to fix later if I did.

## QA

_How did you test this?_

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
