### PR TITLE
Don't enter text in text box if modifiers are applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Support template for header names in the `section` field of `!request` chains
 - Expand `~` to the home directory in `!file` chain sources and when saving response body as a file
 
+### Fixed
+
+- Don't type in text boxes when modifiers keys (other than shift) are enabled
+  - Should mitigate some potential confusing behavior when using terminal key sequences
+
 ## [1.7.0] - 2024-07-22
 
 This release focuses on minor fixes and improvements. There are no new major features or added functionality.

--- a/crates/slumber_tui/src/view/test_util.rs
+++ b/crates/slumber_tui/src/view/test_util.rs
@@ -186,9 +186,18 @@ where
     /// component, then drain events and draw.  See
     /// [Self::update_draw] about return value.
     pub fn send_key(&mut self, code: KeyCode) -> PropagatedEvents {
+        self.send_key_modifiers(code, KeyModifiers::NONE)
+    }
+
+    /// [Self::send_key], but with modifier keys applied
+    pub fn send_key_modifiers(
+        &mut self,
+        code: KeyCode,
+        modifiers: KeyModifiers,
+    ) -> PropagatedEvents {
         let crossterm_event = crossterm::event::Event::Key(KeyEvent {
             code,
-            modifiers: KeyModifiers::NONE,
+            modifiers,
             kind: KeyEventKind::Press,
             state: KeyEventState::empty(),
         });


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

E.g. ctrl+d will no longer type "d". Shift is excluded because shift+d should be "D". If someone types ctrl+d while in a textbox, they probably didn't mean to type the letter d. It can be especially confusing if the user's terminal is set up to bind something else to a key sequence, such as delete -> control+d (which is exactly what confused me). At least now we show nothing instead of typing something nonsensical.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Could potentially break a workflow. Mitigated with tests.

## QA

_How did you test this?_

Added a unit test, tested manually.

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
