### PR TITLE
Fix slow HTTP tests

### DIFF
--- a/crates/slumber_core/src/test_util.rs
+++ b/crates/slumber_core/src/test_util.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     collection::{ChainSource, HasId},
+    http::HttpEngine,
     template::{Prompt, Prompter},
     util::{get_repo_root, ResultTraced},
 };
@@ -119,6 +120,14 @@ impl Drop for EnvGuard {
 #[fixture]
 pub fn temp_dir() -> TempDir {
     TempDir::new()
+}
+
+/// Create an HTTP engine for building/sending requests. This is a singleton
+/// because creation is expensive (~300ms), and the engine is immutable.
+#[fixture]
+#[once]
+pub fn http_engine() -> HttpEngine {
+    HttpEngine::default()
 }
 
 /// Guard for a temporary directory. Create the directory on creation, delete


### PR DESCRIPTION

## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Turns out creating a reqwest client takes ~150ms, so for our 2 clients it's 300ms per test that needs one. We can de-dupe that, and also skip creation of the danger client if it's never needed.

Previously, the `slumber_core` tests took ~5.2s on my machine, now they take ~0.4s.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

If I fucked this up, we could be using the dangerous client for things we shouldn't, which would be *very* bad. Mitigated by adding a test for the danger client.

## QA

_How did you test this?_

Tests!

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
