### PR TITLE
Fix query toggle rows persisting out of sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Don't type in text boxes when modifiers keys (other than shift) are enabled
   - Should mitigate some potential confusing behavior when using terminal key sequences
+- Query parameter and header toggle rows no longer lose their state when switching profiles
 
 ## [1.7.0] - 2024-07-22
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1357,9 +1357,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "persisted"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d4a632f5e6ef4a3052d85919b1a4cf28be08f2880fe17dd9a0a148b09a9290"
+checksum = "bf42dd6984f49c1f7cf2807c8195d05702385e9c262721432337f548174c9f5c"
 dependencies = [
  "derive_more",
  "persisted_derive",

--- a/crates/slumber_tui/Cargo.toml
+++ b/crates/slumber_tui/Cargo.toml
@@ -20,7 +20,7 @@ futures = {workspace = true}
 indexmap = {workspace = true}
 itertools = {workspace = true}
 notify = {version = "6.1.1", default-features = false, features = ["macos_fsevent"]}
-persisted = {version = "0.1.0", features = ["serde"]}
+persisted = {version = "0.2.0", features = ["serde"]}
 ratatui = {workspace = true, features = ["crossterm", "underline-color", "unstable-rendered-line-info"]}
 reqwest = {workspace = true}
 serde = {workspace = true}

--- a/crates/slumber_tui/src/view/component/primary.rs
+++ b/crates/slumber_tui/src/view/component/primary.rs
@@ -209,11 +209,12 @@ impl PrimaryView {
 
     fn toggle_fullscreen(&mut self, mode: FullscreenMode) {
         // If we're already in the given mode, exit
-        *self.fullscreen_mode = if Some(mode) == *self.fullscreen_mode {
-            None
-        } else {
-            Some(mode)
-        };
+        *self.fullscreen_mode.borrow_mut() =
+            if Some(mode) == *self.fullscreen_mode {
+                None
+            } else {
+                Some(mode)
+            };
     }
 
     /// Exit fullscreen mode if it doesn't match the selected pane. This is
@@ -223,7 +224,7 @@ impl PrimaryView {
         match (self.selected_pane.selected(), *self.fullscreen_mode) {
             (PrimaryPane::Recipe, Some(FullscreenMode::Recipe))
             | (PrimaryPane::Exchange, Some(FullscreenMode::Exchange)) => {}
-            _ => *self.fullscreen_mode = None,
+            _ => *self.fullscreen_mode.borrow_mut() = None,
         }
     }
 
@@ -335,7 +336,7 @@ impl EventHandler for PrimaryView {
                 }
                 // Exit fullscreen
                 Action::Cancel if self.fullscreen_mode.is_some() => {
-                    *self.fullscreen_mode = None;
+                    *self.fullscreen_mode.borrow_mut() = None;
                 }
                 _ => return Update::Propagate(event),
             },
@@ -450,11 +451,11 @@ mod tests {
     fn test_pane_persistence(harness: TestHarness) {
         ViewContext::store_persisted(
             &SingletonKey::<PrimaryPane>::default(),
-            PrimaryPane::Exchange,
+            &PrimaryPane::Exchange,
         );
         ViewContext::store_persisted(
             &FullscreenModeKey,
-            Some(FullscreenMode::Exchange),
+            &Some(FullscreenMode::Exchange),
         );
 
         let collection = Collection::factory(());

--- a/crates/slumber_tui/src/view/component/queryable_body.rs
+++ b/crates/slumber_tui/src/view/component/queryable_body.rs
@@ -364,7 +364,7 @@ mod tests {
         struct Key;
 
         // Add initial query to the DB
-        ViewContext::store_persisted(&Key, "$.greeting".to_owned());
+        ViewContext::store_persisted(&Key, &"$.greeting".to_owned());
 
         // We already have another test to check that querying works via typing
         // in the box, so we just need to make sure state is initialized

--- a/crates/slumber_tui/src/view/component/recipe_list.rs
+++ b/crates/slumber_tui/src/view/component/recipe_list.rs
@@ -87,13 +87,17 @@ impl RecipeListPane {
         let changed = if let Some(folder) = folder {
             let collapsed = &mut self.collapsed;
             match state {
-                CollapseState::Expand => collapsed.remove(&folder.id),
-                CollapseState::Collapse => collapsed.insert(folder.id.clone()),
+                CollapseState::Expand => {
+                    collapsed.borrow_mut().remove(&folder.id)
+                }
+                CollapseState::Collapse => {
+                    collapsed.borrow_mut().insert(folder.id.clone())
+                }
                 CollapseState::Toggle => {
                     if collapsed.contains(&folder.id) {
-                        collapsed.remove(&folder.id);
+                        collapsed.borrow_mut().remove(&folder.id);
                     } else {
-                        collapsed.insert(folder.id.clone());
+                        collapsed.borrow_mut().insert(folder.id.clone());
                     }
                     true
                 }

--- a/crates/slumber_tui/src/view/component/recipe_pane.rs
+++ b/crates/slumber_tui/src/view/component/recipe_pane.rs
@@ -157,8 +157,8 @@ impl<K: PersistedKey<Value = bool>> RowState<K> {
         }
     }
 
-    fn toggle(row: &mut Self) {
-        *row.enabled ^= true;
+    fn toggle(&mut self) {
+        *self.enabled.borrow_mut() ^= true;
     }
 }
 

--- a/crates/slumber_tui/src/view/component/root.rs
+++ b/crates/slumber_tui/src/view/component/root.rs
@@ -289,7 +289,7 @@ mod tests {
         harness.database.insert_exchange(&new_exchange).unwrap();
         ViewContext::store_persisted(
             &SelectedRequestKey,
-            Some(old_exchange.id),
+            &Some(old_exchange.id),
         );
 
         let component = TestComponent::new(harness, Root::new(&collection), ());

--- a/crates/slumber_tui/src/view/context.rs
+++ b/crates/slumber_tui/src/view/context.rs
@@ -157,7 +157,7 @@ where
             .flatten()
     }
 
-    fn store_persisted(key: &K, value: K::Value) {
+    fn store_persisted(key: &K, value: &K::Value) {
         Self::with_database(|database| {
             database.set_ui(K::type_name(), key, value)
         })

--- a/crates/slumber_tui/src/view/state/select.rs
+++ b/crates/slumber_tui/src/view/state/select.rs
@@ -514,7 +514,7 @@ mod tests {
         let profile = Profile::factory(());
         let profile_id = profile.id.clone();
 
-        ViewContext::store_persisted(&Key, Some(profile_id.clone()));
+        ViewContext::store_persisted(&Key, &Some(profile_id.clone()));
 
         let pid = profile_id.clone();
         let select = PersistedLazy::new(


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

This upgrades persisted to 0.2.0, which changed Persisted to save on every mutation rather than just on drop. This prevents bugs like the query toggle rows not saving when switching profiles. The issue occurs when a new Persisted value is created before the old one is dropped. By saving immediately when the mutation is made, it prevents this. 

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

That this change was *not* made to PersistedLazy because it's much harder to scope down the &mut lifetime to just when the persisted data is modified. I don't think the bug actually occurs anywhere in Slumber with PersistedLazy, but it's still possible.

## QA

_How did you test this?_

Manually confirmed the bug is gone.

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
