### PR TITLE
Hide Collection behind Arc

### DIFF
--- a/crates/slumber_cli/src/commands/request.rs
+++ b/crates/slumber_cli/src/commands/request.rs
@@ -165,19 +165,6 @@ impl BuildRequestCommand {
             })?;
         }
 
-        // Find recipe by ID
-        let recipe = collection
-            .recipes
-            .get_recipe(&self.recipe_id)
-            .ok_or_else(|| {
-                anyhow!(
-                    "No recipe with ID `{}`; options are: {}",
-                    self.recipe_id,
-                    collection.recipes.recipe_ids().format(", ")
-                )
-            })?
-            .clone();
-
         // Build the request
         let overrides: IndexMap<_, _> = self.overrides.into_iter().collect();
         let template_context = TemplateContext {
@@ -195,7 +182,7 @@ impl BuildRequestCommand {
             prompter: Box::new(CliPrompter),
             state: Default::default(),
         };
-        let seed = RequestSeed::new(recipe, BuildOptions::default());
+        let seed = RequestSeed::new(self.recipe_id, BuildOptions::default());
         let request = http_engine.build(seed, &template_context).await?;
         Ok((database, request))
     }

--- a/crates/slumber_cli/src/commands/show.rs
+++ b/crates/slumber_cli/src/commands/show.rs
@@ -53,7 +53,7 @@ impl Subcommand for ShowCommand {
                     CollectionFile::try_path(None, global.file)?;
                 let collection_file =
                     CollectionFile::load(collection_path).await?;
-                println!("{}", to_yaml(&collection_file.collection));
+                println!("{}", to_yaml(&*collection_file.collection));
             }
         }
         Ok(ExitCode::SUCCESS)

--- a/crates/slumber_core/src/collection/insomnia.rs
+++ b/crates/slumber_core/src/collection/insomnia.rs
@@ -641,7 +641,7 @@ mod tests {
                 .await
                 .unwrap()
                 .collection;
-        assert_eq!(imported, expected);
+        assert_eq!(imported, *expected);
     }
 
     #[test]

--- a/crates/slumber_core/src/collection/openapi.rs
+++ b/crates/slumber_core/src/collection/openapi.rs
@@ -658,7 +658,7 @@ mod tests {
                 .await
                 .unwrap()
                 .collection;
-        assert_eq!(imported, expected);
+        assert_eq!(imported, *expected);
     }
 
     /// Test various cases of [RequestBuilder::process_body]

--- a/crates/slumber_core/src/http/models.rs
+++ b/crates/slumber_core/src/http/models.rs
@@ -4,7 +4,7 @@
 //! exchange is incomplete or failed.
 
 use crate::{
-    collection::{ProfileId, Recipe, RecipeId},
+    collection::{ProfileId, RecipeId},
     http::{
         cereal,
         content_type::{ContentType, ResponseContent},
@@ -65,16 +65,16 @@ pub struct RequestSeed {
     /// Unique ID for this request
     pub id: RequestId,
     /// Recipe from which the request should be rendered
-    pub recipe: Recipe,
+    pub recipe_id: RecipeId,
     /// Configuration for the build
     pub options: BuildOptions,
 }
 
 impl RequestSeed {
-    pub fn new(recipe: Recipe, options: BuildOptions) -> Self {
+    pub fn new(recipe_id: RecipeId, options: BuildOptions) -> Self {
         Self {
             id: RequestId::new(),
-            recipe,
+            recipe_id,
             options,
         }
     }
@@ -220,7 +220,7 @@ impl RequestRecord {
         Self {
             id: seed.id,
             profile_id,
-            recipe_id: seed.recipe.id,
+            recipe_id: seed.recipe_id,
 
             method: request.method().clone(),
             url: request.url().clone(),

--- a/crates/slumber_core/src/template.rs
+++ b/crates/slumber_core/src/template.rs
@@ -47,7 +47,7 @@ pub struct Template {
 #[derive(Debug)]
 pub struct TemplateContext {
     /// Entire request collection
-    pub collection: Collection,
+    pub collection: Arc<Collection>,
     /// ID of the profile whose data should be used for rendering. Generally
     /// the caller should check the ID is valid before passing it, to
     /// provide a better error to the user if not.
@@ -191,7 +191,7 @@ impl crate::test_util::Factory for TemplateContext {
     fn factory(_: ()) -> Self {
         use crate::test_util::TestPrompter;
         Self {
-            collection: Collection::default(),
+            collection: Default::default(),
             selected_profile: None,
             http_engine: None,
             database: CollectionDatabase::factory(()),
@@ -251,7 +251,8 @@ mod tests {
                 profiles: by_id([profile]),
                 chains: by_id([chain]),
                 ..Collection::factory(())
-            },
+            }
+            .into(),
             selected_profile: Some(profile_id),
             overrides,
             ..TemplateContext::factory(())
@@ -401,7 +402,8 @@ mod tests {
                 chains: by_id([chain]),
                 profiles: by_id([profile]),
                 ..Collection::factory(())
-            },
+            }
+            .into(),
             database,
             ..TemplateContext::factory(())
         };
@@ -565,7 +567,8 @@ mod tests {
                 recipes: recipes.into(),
                 chains: by_id([chain]),
                 ..Collection::factory(())
-            },
+            }
+            .into(),
             database,
             ..TemplateContext::factory(())
         };
@@ -631,7 +634,8 @@ mod tests {
                 recipes: by_id([recipe]).into(),
                 chains: by_id([chain]),
                 ..Collection::factory(())
-            },
+            }
+            .into(),
             http_engine: Some(http_engine.clone()),
             database,
             ..TemplateContext::factory(())
@@ -662,7 +666,8 @@ mod tests {
             collection: Collection {
                 chains: by_id([chain]),
                 ..Collection::factory(())
-            },
+            }
+            .into(),
             ..TemplateContext::factory(())
         };
 
@@ -706,7 +711,8 @@ mod tests {
             collection: Collection {
                 chains: by_id([chain]),
                 ..Collection::factory(())
-            },
+            }
+            .into(),
             ..TemplateContext::factory(())
         };
 
@@ -733,7 +739,8 @@ mod tests {
             collection: Collection {
                 chains: by_id([chain]),
                 ..Collection::factory(())
-            },
+            }
+            .into(),
             ..TemplateContext::factory(())
         };
 
@@ -760,7 +767,8 @@ mod tests {
             collection: Collection {
                 chains: by_id([chain]),
                 ..Collection::factory(())
-            },
+            }
+            .into(),
             ..TemplateContext::factory(())
         };
         // This prevents tests from competing for environment variables, and
@@ -791,7 +799,8 @@ mod tests {
             collection: Collection {
                 chains: by_id([chain]),
                 ..Collection::factory(())
-            },
+            }
+            .into(),
             ..TemplateContext::factory(())
         };
 
@@ -815,7 +824,8 @@ mod tests {
             collection: Collection {
                 chains: by_id([chain]),
                 ..Collection::factory(())
-            },
+            }
+            .into(),
             ..TemplateContext::factory(())
         };
 
@@ -846,7 +856,8 @@ mod tests {
             collection: Collection {
                 chains: by_id([chain]),
                 ..Collection::factory(())
-            },
+            }
+            .into(),
 
             prompter: Box::new(TestPrompter::new(response)),
             ..TemplateContext::factory(())
@@ -868,7 +879,8 @@ mod tests {
             collection: Collection {
                 chains: by_id([chain]),
                 ..Collection::factory(())
-            },
+            }
+            .into(),
             // Prompter gives no response
             prompter: Box::<TestPrompter>::default(),
             ..TemplateContext::factory(())
@@ -895,7 +907,8 @@ mod tests {
             collection: Collection {
                 chains: by_id([chain]),
                 ..Collection::factory(())
-            },
+            }
+            .into(),
 
             prompter: Box::new(TestPrompter::new(["first", "second"])),
             ..TemplateContext::factory(())
@@ -923,7 +936,8 @@ mod tests {
             collection: Collection {
                 chains: by_id([chain]),
                 ..Collection::factory(())
-            },
+            }
+            .into(),
 
             prompter: Box::<TestPrompter>::default(),
             ..TemplateContext::factory(())
@@ -962,7 +976,8 @@ mod tests {
             collection: Collection {
                 chains: by_id([chain]),
                 ..Collection::factory(())
-            },
+            }
+            .into(),
             // Prompter gives no response
             prompter: Box::new(TestPrompter::new(["hello!"])),
             ..TemplateContext::factory(())
@@ -1009,7 +1024,8 @@ mod tests {
             collection: Collection {
                 chains: by_id([file_chain, command_chain]),
                 ..Collection::factory(())
-            },
+            }
+            .into(),
             ..TemplateContext::factory(())
         };
         assert_eq!(
@@ -1046,7 +1062,8 @@ mod tests {
             collection: Collection {
                 chains: by_id([file_chain, command_chain]),
                 ..Collection::factory(())
-            },
+            }
+            .into(),
             ..TemplateContext::factory(())
         };
         let expected = if cfg!(unix) {
@@ -1091,7 +1108,8 @@ mod tests {
             collection: Collection {
                 chains: by_id([chain]),
                 ..Collection::factory(())
-            },
+            }
+            .into(),
             ..TemplateContext::factory(())
         };
 
@@ -1116,7 +1134,8 @@ mod tests {
             collection: Collection {
                 chains: by_id([chain]),
                 ..Collection::factory(())
-            },
+            }
+            .into(),
             ..TemplateContext::factory(())
         };
 
@@ -1175,7 +1194,8 @@ mod tests {
             collection: Collection {
                 profiles: by_id([profile]),
                 ..Collection::factory(())
-            },
+            }
+            .into(),
             selected_profile: Some(profile_id),
             ..TemplateContext::factory(())
         }
@@ -1228,7 +1248,8 @@ mod tests {
                 profiles: by_id([profile]),
                 chains: by_id(chains),
                 ..Collection::factory(())
-            },
+            }
+            .into(),
             selected_profile: Some(profile_id),
             ..TemplateContext::factory(())
         };

--- a/crates/slumber_core/src/template/render.rs
+++ b/crates/slumber_core/src/template/render.rs
@@ -484,7 +484,7 @@ impl<'a> ChainTemplateSource<'a> {
                     .ok_or(TriggeredRequestError::NotAllowed)?;
                 let ticket = http_engine
                     .build(
-                        RequestSeed::new(recipe.clone(), build_options),
+                        RequestSeed::new(recipe_id.clone(), build_options),
                         context,
                     )
                     .await

--- a/crates/slumber_tui/src/view.rs
+++ b/crates/slumber_tui/src/view.rs
@@ -27,7 +27,7 @@ use anyhow::anyhow;
 use ratatui::Frame;
 use slumber_config::Action;
 use slumber_core::{collection::CollectionFile, db::CollectionDatabase};
-use std::fmt::Debug;
+use std::{fmt::Debug, sync::Arc};
 use tracing::{error, trace, trace_span};
 
 /// Primary entrypoint for the view. This contains the main draw functions, as
@@ -52,7 +52,11 @@ impl View {
         database: CollectionDatabase,
         messages_tx: MessageSender,
     ) -> Self {
-        ViewContext::init(database, messages_tx);
+        ViewContext::init(
+            Arc::clone(&collection_file.collection),
+            database,
+            messages_tx,
+        );
         let mut view = Self {
             root: Root::new(&collection_file.collection).into(),
         };

--- a/crates/slumber_tui/src/view/common/template_preview.rs
+++ b/crates/slumber_tui/src/view/common/template_preview.rs
@@ -246,7 +246,7 @@ mod tests {
             ..Collection::factory(())
         };
         let context = TemplateContext {
-            collection,
+            collection: collection.into(),
             selected_profile: Some(profile_id),
             ..TemplateContext::factory(())
         };

--- a/crates/slumber_tui/src/view/component/recipe_pane.rs
+++ b/crates/slumber_tui/src/view/component/recipe_pane.rs
@@ -1,188 +1,174 @@
+mod authentication;
+mod body;
+mod recipe;
+
 use crate::{
     context::TuiContext,
+    message::RequestConfig,
     view::{
-        common::{
-            actions::ActionsModal,
-            table::{Table, ToggleRow},
-            tabs::Tabs,
-            template_preview::TemplatePreview,
-            text_window::{TextWindow, TextWindowProps},
-            Pane,
-        },
-        component::primary::PrimaryPane,
-        context::{Persisted, PersistedKey, PersistedLazy},
+        common::{actions::ActionsModal, Pane},
+        component::{primary::PrimaryPane, recipe_pane::recipe::RecipeDisplay},
         draw::{Draw, DrawMetadata, Generate, ToStringGenerate},
         event::{Event, EventHandler, Update},
-        state::{select::SelectState, StateCell},
+        state::StateCell,
         Component, ModalPriority, ViewContext,
     },
 };
 use derive_more::Display;
-use itertools::Itertools;
-use persisted::SingletonKey;
 use ratatui::{
-    layout::Layout,
-    prelude::Constraint,
     text::{Line, Text},
-    widgets::{Paragraph, Row, TableState},
     Frame,
 };
-use serde::{Deserialize, Serialize};
 use slumber_config::Action;
 use slumber_core::{
-    collection::{
-        Authentication, Folder, HasId, ProfileId, Recipe, RecipeBody, RecipeId,
-        RecipeNode,
-    },
-    http::{content_type::ContentType, BuildOptions},
-    template::Template,
+    collection::{Folder, HasId, ProfileId, RecipeId, RecipeNode},
     util::doc_link,
 };
 use strum::{EnumCount, EnumIter};
 
-/// Display a request recipe
+/// Display for the current recipe node, which could be a recipe, a folder, or
+/// empty
 #[derive(Debug, Default)]
 pub struct RecipePane {
-    tabs: Component<PersistedLazy<SingletonKey<Tab>, Tabs<Tab>>>,
     /// All UI state derived from the recipe is stored together, and reset when
     /// the recipe or profile changes
-    recipe_state: StateCell<RecipeStateKey, RecipeState>,
+    recipe_state: StateCell<RecipeStateKey, Option<Component<RecipeDisplay>>>,
 }
 
 #[derive(Clone)]
 pub struct RecipePaneProps<'a> {
+    /// ID of the recipe *or* folder selected
     pub selected_recipe_node: Option<&'a RecipeNode>,
     pub selected_profile_id: Option<&'a ProfileId>,
+}
+
+impl RecipePane {
+    /// Get a definition of the request that should be sent from the current
+    /// recipe settings
+    pub fn request_config(&self) -> Option<RequestConfig> {
+        let state_key = self.recipe_state.get_key()?;
+        let recipe_id = state_key.recipe_id.clone()?;
+        let profile_id = state_key.selected_profile_id.clone();
+        let recipe_state = self.recipe_state.get()?;
+        let options = recipe_state.as_ref()?.data().build_options();
+        Some(RequestConfig {
+            recipe_id,
+            profile_id,
+            options,
+        })
+    }
+}
+
+impl EventHandler for RecipePane {
+    fn update(&mut self, event: Event) -> Update {
+        if let Some(action) = event.action() {
+            match action {
+                Action::LeftClick => {
+                    ViewContext::push_event(Event::new_local(
+                        PrimaryPane::Recipe,
+                    ));
+                }
+                Action::OpenActions => {
+                    let state = self.recipe_state.get_mut();
+                    ViewContext::open_modal(
+                        ActionsModal::new(RecipeMenuAction::disabled_actions(
+                            state.is_some(),
+                            state
+                                .and_then(Option::as_mut)
+                                .is_some_and(|state| state.data().has_body()),
+                        )),
+                        ModalPriority::Low,
+                    )
+                }
+                _ => return Update::Propagate(event),
+            }
+        } else {
+            return Update::Propagate(event);
+        }
+        Update::Consumed
+    }
+
+    fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {
+        self.recipe_state
+            .get_mut()
+            .and_then(|state| Some(state.as_mut()?.as_child()))
+            .into_iter()
+            .collect()
+    }
+}
+
+impl<'a> Draw<RecipePaneProps<'a>> for RecipePane {
+    fn draw(
+        &self,
+        frame: &mut Frame,
+        props: RecipePaneProps<'a>,
+        metadata: DrawMetadata,
+    ) {
+        // Render outermost block
+        let title = TuiContext::get().input_engine.add_hint(
+            match props.selected_recipe_node {
+                Some(RecipeNode::Folder(_)) => "Folder",
+                Some(RecipeNode::Recipe(_)) | None => "Recipe",
+            },
+            Action::SelectRecipe,
+        );
+        let block = Pane {
+            title: &title,
+            has_focus: metadata.has_focus(),
+        };
+        let block = block.generate();
+        let inner_area = block.inner(metadata.area());
+        frame.render_widget(block, metadata.area());
+
+        // Whenever the recipe or profile changes, generate a preview for
+        // each templated value. Almost anything that could change the
+        // preview will either involve changing one of those two things, or
+        // would require reloading the whole collection which will reset
+        // UI state.
+        let recipe_state = self.recipe_state.get_or_update(
+            RecipeStateKey {
+                selected_profile_id: props.selected_profile_id.cloned(),
+                recipe_id: props
+                    .selected_recipe_node
+                    .map(RecipeNode::id)
+                    .cloned(),
+            },
+            || match props.selected_recipe_node {
+                Some(RecipeNode::Recipe(recipe)) => Some(
+                    RecipeDisplay::new(recipe, props.selected_profile_id)
+                        .into(),
+                ),
+                Some(RecipeNode::Folder(_)) | None => None,
+            },
+        );
+
+        match props.selected_recipe_node {
+            None => frame.render_widget(
+                Text::from(vec![
+                    "No recipes defined; add one to your collection".into(),
+                    doc_link("api/request_collection/request_recipe").into(),
+                ]),
+                inner_area,
+            ),
+            Some(RecipeNode::Folder(folder)) => {
+                frame.render_widget(folder.generate(), inner_area);
+            }
+            Some(RecipeNode::Recipe(_)) => {
+                // Unwrap is safe because we just initialized state above
+                recipe_state
+                    .as_ref()
+                    .unwrap()
+                    .draw(frame, (), inner_area, true)
+            }
+        };
+    }
 }
 
 /// Template preview state will be recalculated when any of these fields change
 #[derive(Debug, PartialEq)]
 struct RecipeStateKey {
     selected_profile_id: Option<ProfileId>,
-    recipe_id: RecipeId,
-}
-
-/// A table of toggleable key:value rows. This has two persisted states:
-/// - Track key of selected row (one entry per table)
-/// - Track toggle state of each row (one entry per row)
-type PersistedTable<RowSelectKey, RowToggleKey> = PersistedLazy<
-    RowSelectKey,
-    SelectState<RowState<RowToggleKey>, TableState>,
->;
-
-#[derive(Debug)]
-struct RecipeState {
-    url: TemplatePreview,
-    query: Component<PersistedTable<QueryRowKey, QueryRowToggleKey>>,
-    headers: Component<PersistedTable<HeaderRowKey, HeaderRowToggleKey>>,
-    body: Option<Component<RecipeBodyDisplay>>,
-    authentication: Option<Component<AuthenticationDisplay>>,
-}
-
-#[derive(
-    Copy,
-    Clone,
-    Debug,
-    Default,
-    Display,
-    EnumCount,
-    EnumIter,
-    PartialEq,
-    Serialize,
-    Deserialize,
-)]
-enum Tab {
-    #[default]
-    Body,
-    Query,
-    Headers,
-    Authentication,
-}
-
-/// Persistence key for selected query param, per recipe. Value is the query
-/// param name
-#[derive(Debug, Serialize, persisted::PersistedKey)]
-#[persisted(Option<String>)]
-struct QueryRowKey(RecipeId);
-
-/// Persistence key for toggle state for a single query param in the table
-#[derive(Debug, Serialize, persisted::PersistedKey)]
-#[persisted(bool)]
-struct QueryRowToggleKey {
-    recipe_id: RecipeId,
-    param: String,
-}
-
-/// Persistence key for selected header, per recipe. Value is the header name
-#[derive(Debug, Serialize, persisted::PersistedKey)]
-#[persisted(Option<String>)]
-struct HeaderRowKey(RecipeId);
-
-/// Persistence key for toggle state for a single header in the table
-#[derive(Debug, Serialize, persisted::PersistedKey)]
-#[persisted(bool)]
-struct HeaderRowToggleKey {
-    recipe_id: RecipeId,
-    header: String,
-}
-
-/// Persistence key for selected form field, per recipe. Value is the field name
-#[derive(Debug, Serialize, persisted::PersistedKey)]
-#[persisted(Option<String>)]
-struct FormRowKey(RecipeId);
-
-/// Persistence key for toggle state for a single form field in the table
-#[derive(Debug, Serialize, persisted::PersistedKey)]
-#[persisted(bool)]
-struct FormRowToggleKey {
-    recipe_id: RecipeId,
-    field: String,
-}
-
-/// One row in the query/header table. Generic param is the persistence key to
-/// use for toggle state
-#[derive(Debug)]
-struct RowState<K: PersistedKey<Value = bool>> {
-    key: String,
-    value: TemplatePreview,
-    enabled: Persisted<K>,
-}
-
-impl<K: PersistedKey<Value = bool>> RowState<K> {
-    fn new(key: String, value: TemplatePreview, persisted_key: K) -> Self {
-        Self {
-            key,
-            value,
-            enabled: Persisted::new(persisted_key, true),
-        }
-    }
-
-    fn toggle(&mut self) {
-        *self.enabled.borrow_mut() ^= true;
-    }
-}
-
-/// Needed for SelectState persistence
-impl<K: PersistedKey<Value = bool>> HasId for RowState<K> {
-    type Id = String;
-
-    fn id(&self) -> &Self::Id {
-        &self.key
-    }
-
-    fn set_id(&mut self, id: Self::Id) {
-        self.key = id;
-    }
-}
-
-/// Needed for SelectState persistence
-impl<K> PartialEq<RowState<K>> for String
-where
-    K: PersistedKey<Value = bool>,
-{
-    fn eq(&self, row_state: &RowState<K>) -> bool {
-        self == &row_state.key
-    }
+    recipe_id: Option<RecipeId>,
 }
 
 /// Items in the actions popup menu. This is also used by the recipe list
@@ -220,517 +206,6 @@ impl RecipeMenuAction {
 }
 
 impl ToStringGenerate for RecipeMenuAction {}
-
-impl RecipePane {
-    /// Generate a [BuildOptions] instance based on current UI state
-    pub fn build_options(&self) -> BuildOptions {
-        if let Some(state) = self.recipe_state.get() {
-            /// Convert select state into the set of disabled keys
-            fn to_disabled_indexes<K: PersistedKey<Value = bool>>(
-                select_state: &SelectState<RowState<K>, TableState>,
-            ) -> Vec<usize> {
-                select_state
-                    .items()
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, row)| !*row.value.enabled)
-                    .map(|(i, _)| i)
-                    .collect()
-            }
-
-            let disabled_form_fields = state
-                .body
-                .as_ref()
-                .and_then(|body| match body.data() {
-                    RecipeBodyDisplay::Raw { .. } => None,
-                    RecipeBodyDisplay::Form(form) => {
-                        Some(to_disabled_indexes(form.data()))
-                    }
-                })
-                .unwrap_or_default();
-
-            BuildOptions {
-                disabled_headers: to_disabled_indexes(state.headers.data()),
-                disabled_query_parameters: to_disabled_indexes(
-                    state.query.data(),
-                ),
-                disabled_form_fields,
-            }
-        } else {
-            // Shouldn't be possible, because state is initialized on first
-            // render
-            BuildOptions::default()
-        }
-    }
-}
-
-impl EventHandler for RecipePane {
-    fn update(&mut self, event: Event) -> Update {
-        if let Some(action) = event.action() {
-            match action {
-                Action::LeftClick => {
-                    ViewContext::push_event(Event::new_local(
-                        PrimaryPane::Recipe,
-                    ));
-                }
-                Action::OpenActions => {
-                    let state = self.recipe_state.get_mut();
-                    ViewContext::open_modal(
-                        ActionsModal::new(RecipeMenuAction::disabled_actions(
-                            state.is_some(),
-                            state.map(|state| state.body.as_ref()).is_some(),
-                        )),
-                        ModalPriority::Low,
-                    )
-                }
-                _ => return Update::Propagate(event),
-            }
-        } else {
-            return Update::Propagate(event);
-        }
-        Update::Consumed
-    }
-
-    fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {
-        let mut children = vec![self.tabs.as_child()];
-
-        // Send events to the tab pane as well
-        if let Some(state) = self.recipe_state.get_mut() {
-            children.extend(
-                [
-                    state.body.as_mut().map(Component::as_child),
-                    Some(state.query.as_child()),
-                    Some(state.headers.as_child()),
-                ]
-                .into_iter()
-                .flatten(),
-            );
-        }
-
-        children
-    }
-}
-
-impl<'a> Draw<RecipePaneProps<'a>> for RecipePane {
-    fn draw(
-        &self,
-        frame: &mut Frame,
-        props: RecipePaneProps<'a>,
-        metadata: DrawMetadata,
-    ) {
-        // Render outermost block
-        let title = TuiContext::get().input_engine.add_hint(
-            if let Some(RecipeNode::Folder(_)) = props.selected_recipe_node {
-                "Folder"
-            } else {
-                "Recipe"
-            },
-            Action::SelectRecipe,
-        );
-        let block = Pane {
-            title: &title,
-            has_focus: metadata.has_focus(),
-        };
-        let block = block.generate();
-        let inner_area = block.inner(metadata.area());
-        frame.render_widget(block, metadata.area());
-
-        // Empty states
-        let recipe = match props.selected_recipe_node {
-            None => {
-                frame.render_widget(
-                    Text::from(vec![
-                        "No recipes defined; add one to your collection".into(),
-                        doc_link("api/request_collection/request_recipe")
-                            .into(),
-                    ]),
-                    inner_area,
-                );
-                return;
-            }
-            Some(RecipeNode::Folder(folder)) => {
-                frame.render_widget(folder.generate(), inner_area);
-                return;
-            }
-            Some(RecipeNode::Recipe(recipe)) => recipe,
-        };
-
-        // Render request contents
-        let method = recipe.method.to_string();
-
-        let [metadata_area, tabs_area, content_area] = Layout::vertical([
-            Constraint::Length(1),
-            Constraint::Length(1),
-            Constraint::Min(0),
-        ])
-        .areas(inner_area);
-
-        let [method_area, url_area] = Layout::horizontal(
-            // Method gets just as much as it needs, URL gets the rest
-            [Constraint::Max(method.len() as u16 + 1), Constraint::Min(0)],
-        )
-        .areas(metadata_area);
-
-        // Whenever the recipe or profile changes, generate a preview for
-        // each templated value. Almost anything that could change the
-        // preview will either involve changing one of those two things, or
-        // would require reloading the whole collection which will reset
-        // UI state.
-        let recipe_state = self.recipe_state.get_or_update(
-            RecipeStateKey {
-                selected_profile_id: props.selected_profile_id.cloned(),
-                recipe_id: recipe.id.clone(),
-            },
-            || RecipeState::new(recipe, props.selected_profile_id),
-        );
-
-        // First line: Method + URL
-        frame.render_widget(Paragraph::new(method), method_area);
-        frame.render_widget(&recipe_state.url, url_area);
-
-        // Navigation tabs
-        self.tabs.draw(frame, (), tabs_area, true);
-
-        // Request content
-        match self.tabs.data().selected() {
-            Tab::Body => {
-                if let Some(body) = &recipe_state.body {
-                    body.draw(frame, (), content_area, true);
-                }
-            }
-            Tab::Query => recipe_state.query.draw(
-                frame,
-                to_table(recipe_state.query.data(), ["", "Parameter", "Value"])
-                    .generate(),
-                content_area,
-                true,
-            ),
-            Tab::Headers => recipe_state.headers.draw(
-                frame,
-                to_table(recipe_state.headers.data(), ["", "Header", "Value"])
-                    .generate(),
-                content_area,
-                true,
-            ),
-            Tab::Authentication => {
-                if let Some(authentication) = &recipe_state.authentication {
-                    authentication.draw(frame, (), content_area, true)
-                }
-            }
-        }
-    }
-}
-
-impl RecipeState {
-    /// Initialize new recipe state. Should be called whenever the recipe or
-    /// profile changes
-    fn new(recipe: &Recipe, selected_profile_id: Option<&ProfileId>) -> Self {
-        let query_items = recipe
-            .query
-            .iter()
-            .map(|(param, value)| {
-                RowState::new(
-                    param.clone(),
-                    TemplatePreview::new(
-                        value.clone(),
-                        selected_profile_id.cloned(),
-                    ),
-                    QueryRowToggleKey {
-                        recipe_id: recipe.id.clone(),
-                        param: param.clone(),
-                    },
-                )
-            })
-            .collect();
-        let header_items = recipe
-            .headers
-            .iter()
-            .map(|(header, value)| {
-                RowState::new(
-                    header.clone(),
-                    TemplatePreview::new(
-                        value.clone(),
-                        selected_profile_id.cloned(),
-                    ),
-                    HeaderRowToggleKey {
-                        recipe_id: recipe.id.clone(),
-                        header: header.clone(),
-                    },
-                )
-            })
-            .collect();
-
-        Self {
-            url: TemplatePreview::new(
-                recipe.url.clone(),
-                selected_profile_id.cloned(),
-            ),
-            query: PersistedLazy::new(
-                QueryRowKey(recipe.id.clone()),
-                SelectState::builder(query_items)
-                    .on_toggle(RowState::toggle)
-                    .build(),
-            )
-            .into(),
-            headers: PersistedLazy::new(
-                HeaderRowKey(recipe.id.clone()),
-                SelectState::builder(header_items)
-                    .on_toggle(RowState::toggle)
-                    .build(),
-            )
-            .into(),
-            body: recipe.body.as_ref().map(|body| {
-                RecipeBodyDisplay::new(
-                    body,
-                    selected_profile_id.cloned(),
-                    &recipe.id,
-                )
-                .into()
-            }),
-            // Map authentication type
-            authentication: recipe.authentication.as_ref().map(
-                |authentication| {
-                    AuthenticationDisplay::new(
-                        authentication,
-                        selected_profile_id,
-                    )
-                    .into()
-                },
-            ),
-        }
-    }
-}
-
-/// Display authentication settings
-#[derive(Debug)]
-enum AuthenticationDisplay {
-    Basic {
-        username: TemplatePreview,
-        password: Option<TemplatePreview>,
-    },
-    Bearer(TemplatePreview),
-}
-
-impl AuthenticationDisplay {
-    fn new(
-        authentication: &Authentication<Template>,
-        selected_profile_id: Option<&ProfileId>,
-    ) -> Self {
-        match authentication {
-            Authentication::Basic { username, password } => {
-                AuthenticationDisplay::Basic {
-                    username: TemplatePreview::new(
-                        username.clone(),
-                        selected_profile_id.cloned(),
-                    ),
-                    password: password.clone().map(|password| {
-                        TemplatePreview::new(
-                            password,
-                            selected_profile_id.cloned(),
-                        )
-                    }),
-                }
-            }
-            Authentication::Bearer(token) => {
-                AuthenticationDisplay::Bearer(TemplatePreview::new(
-                    token.clone(),
-                    selected_profile_id.cloned(),
-                ))
-            }
-        }
-    }
-}
-
-impl Draw for AuthenticationDisplay {
-    fn draw(&self, frame: &mut Frame, _: (), metadata: DrawMetadata) {
-        match self {
-            AuthenticationDisplay::Basic { username, password } => {
-                let table = Table {
-                    rows: vec![
-                        ["Type".into(), "Bearer".into()],
-                        ["Username".into(), username.generate()],
-                        [
-                            "Password".into(),
-                            password
-                                .as_ref()
-                                .map(Generate::generate)
-                                .unwrap_or_default(),
-                        ],
-                    ],
-                    column_widths: &[Constraint::Length(8), Constraint::Min(0)],
-                    ..Default::default()
-                };
-                frame.render_widget(table.generate(), metadata.area())
-            }
-            AuthenticationDisplay::Bearer(token) => {
-                let table = Table {
-                    rows: vec![
-                        ["Type".into(), "Bearer".into()],
-                        ["Token".into(), token.generate()],
-                    ],
-                    column_widths: &[Constraint::Length(5), Constraint::Min(0)],
-                    ..Default::default()
-                };
-                frame.render_widget(table.generate(), metadata.area())
-            }
-        }
-    }
-}
-
-/// Render recipe body. The variant is based on the incoming body type, and
-/// determines the representation
-#[derive(Debug)]
-enum RecipeBodyDisplay {
-    Raw {
-        /// Needed for syntax highlighting
-        content_type: Option<ContentType>,
-        preview: TemplatePreview,
-        text_window: Component<TextWindow>,
-    },
-    Form(Component<PersistedTable<FormRowKey, FormRowToggleKey>>),
-}
-
-impl RecipeBodyDisplay {
-    /// Build a component to display the body, based on the body type
-    fn new(
-        body: &RecipeBody,
-        selected_profile_id: Option<ProfileId>,
-        recipe_id: &RecipeId,
-    ) -> Self {
-        match body {
-            RecipeBody::Raw(body) => Self::Raw {
-                // Hypothetically we could grab the content type from the
-                // Content-Type header above and plumb it down here, but more
-                // effort than it's worth IMO. This gives users a solid reason
-                // to use !json anyway
-                content_type: None,
-                preview: TemplatePreview::new(
-                    body.clone(),
-                    selected_profile_id,
-                ),
-                text_window: Component::default(),
-            },
-            RecipeBody::Json(value) => {
-                // We want to pretty-print the JSON body. We *could* map from
-                // JsonBody<Template> -> JsonBody<TemplatePreview> then
-                // stringify that on every render, but then we'd have to
-                // implement JSON pretty printing ourselves. The easier method
-                // is to just turn this whole JSON struct into a single string
-                // (with unrendered templates), then parse that back as one big
-                // template. If it's stupid but it works, it's not stupid.
-                let value: serde_json::Value = value
-                    .map_ref(|template| template.display().to_string())
-                    .into();
-                let stringified = format!("{value:#}");
-                // This template is made of valid templates, surrounded by JSON
-                // syntax. In no world should that result in an invalid template
-                let template = stringified
-                    .parse()
-                    .expect("Unexpected template parse failure");
-                Self::Raw {
-                    content_type: Some(ContentType::Json),
-                    preview: TemplatePreview::new(
-                        template,
-                        selected_profile_id,
-                    ),
-                    text_window: Component::default(),
-                }
-            }
-            RecipeBody::FormUrlencoded(fields)
-            | RecipeBody::FormMultipart(fields) => {
-                let form_items = fields
-                    .iter()
-                    .map(|(field, value)| {
-                        RowState::new(
-                            field.clone(),
-                            TemplatePreview::new(
-                                value.clone(),
-                                selected_profile_id.clone(),
-                            ),
-                            FormRowToggleKey {
-                                recipe_id: recipe_id.clone(),
-                                field: field.clone(),
-                            },
-                        )
-                    })
-                    .collect();
-                let select = SelectState::builder(form_items)
-                    .on_toggle(RowState::toggle)
-                    .build();
-                Self::Form(
-                    PersistedLazy::new(FormRowKey(recipe_id.clone()), select)
-                        .into(),
-                )
-            }
-        }
-    }
-}
-
-impl EventHandler for RecipeBodyDisplay {
-    fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {
-        match self {
-            RecipeBodyDisplay::Raw { text_window, .. } => {
-                vec![text_window.as_child()]
-            }
-            RecipeBodyDisplay::Form(form) => vec![form.as_child()],
-        }
-    }
-}
-
-impl Draw for RecipeBodyDisplay {
-    fn draw(&self, frame: &mut Frame, _: (), metadata: DrawMetadata) {
-        match self {
-            RecipeBodyDisplay::Raw {
-                content_type,
-                preview,
-                text_window,
-            } => text_window.draw(
-                frame,
-                TextWindowProps {
-                    text: preview.generate(),
-                    content_type: *content_type,
-                    has_search_box: false,
-                },
-                metadata.area(),
-                true,
-            ),
-            RecipeBodyDisplay::Form(form) => form.draw(
-                frame,
-                to_table(form.data(), ["", "Field", "Value"]).generate(),
-                metadata.area(),
-                true,
-            ),
-        }
-    }
-}
-
-/// Convert table select state into a renderable table
-fn to_table<'a, K: PersistedKey<Value = bool>>(
-    state: &'a SelectState<RowState<K>, TableState>,
-    header: [&'a str; 3],
-) -> Table<'a, 3, Row<'a>> {
-    Table {
-        rows: state
-            .items()
-            .iter()
-            .map(|item| {
-                let item = &item.value;
-                ToggleRow::new(
-                    [item.key.as_str().into(), item.value.generate()],
-                    *item.enabled,
-                )
-                .generate()
-            })
-            .collect_vec(),
-        header: Some(header),
-        column_widths: &[
-            Constraint::Min(3),
-            Constraint::Percentage(50),
-            Constraint::Percentage(50),
-        ],
-        ..Default::default()
-    }
-}
 
 /// Render folder as a tree
 impl<'a> Generate for &'a Folder {

--- a/crates/slumber_tui/src/view/component/recipe_pane/authentication.rs
+++ b/crates/slumber_tui/src/view/component/recipe_pane/authentication.rs
@@ -1,0 +1,85 @@
+use crate::view::{
+    common::{table::Table, template_preview::TemplatePreview},
+    draw::{Draw, DrawMetadata, Generate},
+};
+use ratatui::{prelude::Constraint, Frame};
+use slumber_core::{
+    collection::{Authentication, ProfileId},
+    template::Template,
+};
+
+/// Display authentication settings for a recipe
+#[derive(Debug)]
+pub enum AuthenticationDisplay {
+    Basic {
+        username: TemplatePreview,
+        password: Option<TemplatePreview>,
+    },
+    Bearer(TemplatePreview),
+}
+
+impl AuthenticationDisplay {
+    pub fn new(
+        authentication: &Authentication<Template>,
+        selected_profile_id: Option<&ProfileId>,
+    ) -> Self {
+        match authentication {
+            Authentication::Basic { username, password } => {
+                AuthenticationDisplay::Basic {
+                    username: TemplatePreview::new(
+                        username.clone(),
+                        selected_profile_id.cloned(),
+                    ),
+                    password: password.clone().map(|password| {
+                        TemplatePreview::new(
+                            password,
+                            selected_profile_id.cloned(),
+                        )
+                    }),
+                }
+            }
+            Authentication::Bearer(token) => {
+                AuthenticationDisplay::Bearer(TemplatePreview::new(
+                    token.clone(),
+                    selected_profile_id.cloned(),
+                ))
+            }
+        }
+    }
+}
+
+impl Draw for AuthenticationDisplay {
+    fn draw(&self, frame: &mut Frame, _: (), metadata: DrawMetadata) {
+        match self {
+            AuthenticationDisplay::Basic { username, password } => {
+                let table = Table {
+                    rows: vec![
+                        ["Type".into(), "Bearer".into()],
+                        ["Username".into(), username.generate()],
+                        [
+                            "Password".into(),
+                            password
+                                .as_ref()
+                                .map(Generate::generate)
+                                .unwrap_or_default(),
+                        ],
+                    ],
+                    column_widths: &[Constraint::Length(8), Constraint::Min(0)],
+                    ..Default::default()
+                };
+                frame.render_widget(table.generate(), metadata.area())
+            }
+            AuthenticationDisplay::Bearer(token) => {
+                let table = Table {
+                    rows: vec![
+                        ["Type".into(), "Bearer".into()],
+                        ["Token".into(), token.generate()],
+                    ],
+                    column_widths: &[Constraint::Length(5), Constraint::Min(0)],
+                    ..Default::default()
+                };
+                frame.render_widget(table.generate(), metadata.area())
+            }
+        }
+    }
+}

--- a/crates/slumber_tui/src/view/component/recipe_pane/body.rs
+++ b/crates/slumber_tui/src/view/component/recipe_pane/body.rs
@@ -1,0 +1,158 @@
+use crate::view::{
+    common::{
+        template_preview::TemplatePreview,
+        text_window::{TextWindow, TextWindowProps},
+    },
+    component::recipe_pane::recipe::{to_table, PersistedTable, RowState},
+    context::PersistedLazy,
+    draw::{Draw, DrawMetadata, Generate},
+    event::EventHandler,
+    state::select::SelectState,
+    Component,
+};
+use ratatui::Frame;
+use serde::Serialize;
+use slumber_core::{
+    collection::{ProfileId, RecipeBody, RecipeId},
+    http::content_type::ContentType,
+};
+
+/// Render recipe body. The variant is based on the incoming body type, and
+/// determines the representation
+#[derive(Debug)]
+pub enum RecipeBodyDisplay {
+    Raw {
+        /// Needed for syntax highlighting
+        content_type: Option<ContentType>,
+        preview: TemplatePreview,
+        text_window: Component<TextWindow>,
+    },
+    Form(Component<PersistedTable<FormRowKey, FormRowToggleKey>>),
+}
+
+impl RecipeBodyDisplay {
+    /// Build a component to display the body, based on the body type
+    pub fn new(
+        body: &RecipeBody,
+        selected_profile_id: Option<ProfileId>,
+        recipe_id: &RecipeId,
+    ) -> Self {
+        match body {
+            RecipeBody::Raw(body) => Self::Raw {
+                // Hypothetically we could grab the content type from the
+                // Content-Type header above and plumb it down here, but more
+                // effort than it's worth IMO. This gives users a solid reason
+                // to use !json anyway
+                content_type: None,
+                preview: TemplatePreview::new(
+                    body.clone(),
+                    selected_profile_id,
+                ),
+                text_window: Component::default(),
+            },
+            RecipeBody::Json(value) => {
+                // We want to pretty-print the JSON body. We *could* map from
+                // JsonBody<Template> -> JsonBody<TemplatePreview> then
+                // stringify that on every render, but then we'd have to
+                // implement JSON pretty printing ourselves. The easier method
+                // is to just turn this whole JSON struct into a single string
+                // (with unrendered templates), then parse that back as one big
+                // template. If it's stupid but it works, it's not stupid.
+                let value: serde_json::Value = value
+                    .map_ref(|template| template.display().to_string())
+                    .into();
+                let stringified = format!("{value:#}");
+                // This template is made of valid templates, surrounded by JSON
+                // syntax. In no world should that result in an invalid template
+                let template = stringified
+                    .parse()
+                    .expect("Unexpected template parse failure");
+                Self::Raw {
+                    content_type: Some(ContentType::Json),
+                    preview: TemplatePreview::new(
+                        template,
+                        selected_profile_id,
+                    ),
+                    text_window: Component::default(),
+                }
+            }
+            RecipeBody::FormUrlencoded(fields)
+            | RecipeBody::FormMultipart(fields) => {
+                let form_items = fields
+                    .iter()
+                    .map(|(field, value)| {
+                        RowState::new(
+                            field.clone(),
+                            TemplatePreview::new(
+                                value.clone(),
+                                selected_profile_id.clone(),
+                            ),
+                            FormRowToggleKey {
+                                recipe_id: recipe_id.clone(),
+                                field: field.clone(),
+                            },
+                        )
+                    })
+                    .collect();
+                let select = SelectState::builder(form_items)
+                    .on_toggle(RowState::toggle)
+                    .build();
+                Self::Form(
+                    PersistedLazy::new(FormRowKey(recipe_id.clone()), select)
+                        .into(),
+                )
+            }
+        }
+    }
+}
+
+impl EventHandler for RecipeBodyDisplay {
+    fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {
+        match self {
+            RecipeBodyDisplay::Raw { text_window, .. } => {
+                vec![text_window.as_child()]
+            }
+            RecipeBodyDisplay::Form(form) => vec![form.as_child()],
+        }
+    }
+}
+
+impl Draw for RecipeBodyDisplay {
+    fn draw(&self, frame: &mut Frame, _: (), metadata: DrawMetadata) {
+        match self {
+            RecipeBodyDisplay::Raw {
+                content_type,
+                preview,
+                text_window,
+            } => text_window.draw(
+                frame,
+                TextWindowProps {
+                    text: preview.generate(),
+                    content_type: *content_type,
+                    has_search_box: false,
+                },
+                metadata.area(),
+                true,
+            ),
+            RecipeBodyDisplay::Form(form) => form.draw(
+                frame,
+                to_table(form.data(), ["", "Field", "Value"]).generate(),
+                metadata.area(),
+                true,
+            ),
+        }
+    }
+}
+
+/// Persistence key for selected form field, per recipe. Value is the field name
+#[derive(Debug, Serialize, persisted::PersistedKey)]
+#[persisted(Option<String>)]
+pub struct FormRowKey(RecipeId);
+
+/// Persistence key for toggle state for a single form field in the table
+#[derive(Debug, Serialize, persisted::PersistedKey)]
+#[persisted(bool)]
+pub struct FormRowToggleKey {
+    recipe_id: RecipeId,
+    field: String,
+}

--- a/crates/slumber_tui/src/view/component/recipe_pane/recipe.rs
+++ b/crates/slumber_tui/src/view/component/recipe_pane/recipe.rs
@@ -1,0 +1,365 @@
+use crate::view::{
+    common::{
+        table::{Table, ToggleRow},
+        tabs::Tabs,
+        template_preview::TemplatePreview,
+    },
+    component::recipe_pane::{
+        authentication::AuthenticationDisplay, body::RecipeBodyDisplay,
+    },
+    context::{Persisted, PersistedKey, PersistedLazy},
+    draw::{Draw, DrawMetadata, Generate},
+    event::EventHandler,
+    state::select::SelectState,
+    Component,
+};
+use derive_more::Display;
+use itertools::Itertools;
+use persisted::SingletonKey;
+use ratatui::{
+    layout::Layout,
+    prelude::Constraint,
+    widgets::{Paragraph, Row, TableState},
+    Frame,
+};
+use serde::{Deserialize, Serialize};
+use slumber_core::{
+    collection::{HasId, Method, ProfileId, Recipe, RecipeId},
+    http::BuildOptions,
+};
+use strum::{EnumCount, EnumIter};
+
+/// Display a recipe. Note a recipe *node*, this is for genuine bonafide recipe.
+/// This maintains internal state specific to a recipe, so it should be
+/// recreated every time the recipe/profile changes.
+#[derive(Debug)]
+pub struct RecipeDisplay {
+    tabs: Component<PersistedLazy<SingletonKey<Tab>, Tabs<Tab>>>,
+    url: TemplatePreview,
+    method: Method,
+    query: Component<PersistedTable<QueryRowKey, QueryRowToggleKey>>,
+    headers: Component<PersistedTable<HeaderRowKey, HeaderRowToggleKey>>,
+    body: Option<Component<RecipeBodyDisplay>>,
+    authentication: Option<Component<AuthenticationDisplay>>,
+}
+
+impl RecipeDisplay {
+    /// Initialize new recipe state. Should be called whenever the recipe or
+    /// profile changes
+    pub fn new(
+        recipe: &Recipe,
+        selected_profile_id: Option<&ProfileId>,
+    ) -> Self {
+        let query_items = recipe
+            .query
+            .iter()
+            .map(|(param, value)| {
+                RowState::new(
+                    param.clone(),
+                    TemplatePreview::new(
+                        value.clone(),
+                        selected_profile_id.cloned(),
+                    ),
+                    QueryRowToggleKey {
+                        recipe_id: recipe.id.clone(),
+                        param: param.clone(),
+                    },
+                )
+            })
+            .collect();
+        let header_items = recipe
+            .headers
+            .iter()
+            .map(|(header, value)| {
+                RowState::new(
+                    header.clone(),
+                    TemplatePreview::new(
+                        value.clone(),
+                        selected_profile_id.cloned(),
+                    ),
+                    HeaderRowToggleKey {
+                        recipe_id: recipe.id.clone(),
+                        header: header.clone(),
+                    },
+                )
+            })
+            .collect();
+
+        Self {
+            tabs: Default::default(),
+            method: recipe.method,
+            url: TemplatePreview::new(
+                recipe.url.clone(),
+                selected_profile_id.cloned(),
+            ),
+            query: PersistedLazy::new(
+                QueryRowKey(recipe.id.clone()),
+                SelectState::builder(query_items)
+                    .on_toggle(RowState::toggle)
+                    .build(),
+            )
+            .into(),
+            headers: PersistedLazy::new(
+                HeaderRowKey(recipe.id.clone()),
+                SelectState::builder(header_items)
+                    .on_toggle(RowState::toggle)
+                    .build(),
+            )
+            .into(),
+            body: recipe.body.as_ref().map(|body| {
+                RecipeBodyDisplay::new(
+                    body,
+                    selected_profile_id.cloned(),
+                    &recipe.id,
+                )
+                .into()
+            }),
+            // Map authentication type
+            authentication: recipe.authentication.as_ref().map(
+                |authentication| {
+                    AuthenticationDisplay::new(
+                        authentication,
+                        selected_profile_id,
+                    )
+                    .into()
+                },
+            ),
+        }
+    }
+
+    /// Generate a [BuildOptions] instance based on current UI state
+    pub fn build_options(&self) -> BuildOptions {
+        /// Convert select state into the set of disabled keys
+        fn to_disabled_indexes<K: PersistedKey<Value = bool>>(
+            select_state: &SelectState<RowState<K>, TableState>,
+        ) -> Vec<usize> {
+            select_state
+                .items()
+                .iter()
+                .enumerate()
+                .filter(|(_, row)| !*row.value.enabled)
+                .map(|(i, _)| i)
+                .collect()
+        }
+
+        let disabled_form_fields = self
+            .body
+            .as_ref()
+            .and_then(|body| match body.data() {
+                RecipeBodyDisplay::Raw { .. } => None,
+                RecipeBodyDisplay::Form(form) => {
+                    Some(to_disabled_indexes(form.data()))
+                }
+            })
+            .unwrap_or_default();
+
+        BuildOptions {
+            disabled_headers: to_disabled_indexes(self.headers.data()),
+            disabled_query_parameters: to_disabled_indexes(self.query.data()),
+            disabled_form_fields,
+        }
+    }
+
+    /// Does the recipe have a body defined?
+    pub fn has_body(&self) -> bool {
+        self.body.is_some()
+    }
+}
+
+impl EventHandler for RecipeDisplay {
+    fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {
+        [
+            Some(self.tabs.as_child()),
+            self.body.as_mut().map(Component::as_child),
+            Some(self.query.as_child()),
+            Some(self.headers.as_child()),
+        ]
+        .into_iter()
+        .flatten()
+        .collect()
+    }
+}
+
+impl Draw for RecipeDisplay {
+    fn draw(&self, frame: &mut Frame, _: (), metadata: DrawMetadata) {
+        // Render request contents
+        let method = self.method.to_string();
+
+        let [metadata_area, tabs_area, content_area] = Layout::vertical([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Min(0),
+        ])
+        .areas(metadata.area());
+
+        let [method_area, url_area] = Layout::horizontal(
+            // Method gets just as much as it needs, URL gets the rest
+            [Constraint::Max(method.len() as u16 + 1), Constraint::Min(0)],
+        )
+        .areas(metadata_area);
+
+        // First line: Method + URL
+        frame.render_widget(Paragraph::new(method), method_area);
+        frame.render_widget(&self.url, url_area);
+
+        // Navigation tabs
+        self.tabs.draw(frame, (), tabs_area, true);
+
+        // Request content
+        match self.tabs.data().selected() {
+            Tab::Body => {
+                if let Some(body) = &self.body {
+                    body.draw(frame, (), content_area, true);
+                }
+            }
+            Tab::Query => self.query.draw(
+                frame,
+                to_table(self.query.data(), ["", "Parameter", "Value"])
+                    .generate(),
+                content_area,
+                true,
+            ),
+            Tab::Headers => self.headers.draw(
+                frame,
+                to_table(self.headers.data(), ["", "Header", "Value"])
+                    .generate(),
+                content_area,
+                true,
+            ),
+            Tab::Authentication => {
+                if let Some(authentication) = &self.authentication {
+                    authentication.draw(frame, (), content_area, true)
+                }
+            }
+        }
+    }
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    Display,
+    EnumCount,
+    EnumIter,
+    PartialEq,
+    Serialize,
+    Deserialize,
+)]
+enum Tab {
+    #[default]
+    Body,
+    Query,
+    Headers,
+    Authentication,
+}
+
+/// A table of toggleable key:value rows. This has two persisted states:
+/// - Track key of selected row (one entry per table)
+/// - Track toggle state of each row (one entry per row)
+pub type PersistedTable<RowSelectKey, RowToggleKey> = PersistedLazy<
+    RowSelectKey,
+    SelectState<RowState<RowToggleKey>, TableState>,
+>;
+
+/// Persistence key for selected query param, per recipe. Value is the query
+/// param name
+#[derive(Debug, Serialize, persisted::PersistedKey)]
+#[persisted(Option<String>)]
+struct QueryRowKey(RecipeId);
+
+/// Persistence key for toggle state for a single query param in the table
+#[derive(Debug, Serialize, persisted::PersistedKey)]
+#[persisted(bool)]
+struct QueryRowToggleKey {
+    recipe_id: RecipeId,
+    param: String,
+}
+
+/// Persistence key for selected header, per recipe. Value is the header name
+#[derive(Debug, Serialize, persisted::PersistedKey)]
+#[persisted(Option<String>)]
+struct HeaderRowKey(RecipeId);
+
+/// Persistence key for toggle state for a single header in the table
+#[derive(Debug, Serialize, persisted::PersistedKey)]
+#[persisted(bool)]
+struct HeaderRowToggleKey {
+    recipe_id: RecipeId,
+    header: String,
+}
+
+/// One row in the query/header table. Generic param is the persistence key to
+/// use for toggle state
+#[derive(Debug)]
+pub struct RowState<K: PersistedKey<Value = bool>> {
+    key: String,
+    value: TemplatePreview,
+    enabled: Persisted<K>,
+}
+
+impl<K: PersistedKey<Value = bool>> RowState<K> {
+    pub fn new(key: String, value: TemplatePreview, persisted_key: K) -> Self {
+        Self {
+            key,
+            value,
+            enabled: Persisted::new(persisted_key, true),
+        }
+    }
+
+    pub fn toggle(&mut self) {
+        *self.enabled.borrow_mut() ^= true;
+    }
+}
+
+/// Needed for SelectState persistence
+impl<K: PersistedKey<Value = bool>> HasId for RowState<K> {
+    type Id = String;
+
+    fn id(&self) -> &Self::Id {
+        &self.key
+    }
+
+    fn set_id(&mut self, id: Self::Id) {
+        self.key = id;
+    }
+}
+
+/// Needed for SelectState persistence
+impl<K> PartialEq<RowState<K>> for String
+where
+    K: PersistedKey<Value = bool>,
+{
+    fn eq(&self, row_state: &RowState<K>) -> bool {
+        self == &row_state.key
+    }
+}
+
+/// Convert table select state into a renderable table
+pub fn to_table<'a, K: PersistedKey<Value = bool>>(
+    state: &'a SelectState<RowState<K>, TableState>,
+    header: [&'a str; 3],
+) -> Table<'a, 3, Row<'a>> {
+    Table {
+        rows: state
+            .items()
+            .iter()
+            .map(|item| {
+                let item = &item.value;
+                ToggleRow::new(
+                    [item.key.as_str().into(), item.value.generate()],
+                    *item.enabled,
+                )
+                .generate()
+            })
+            .collect_vec(),
+        header: Some(header),
+        column_widths: &[
+            Constraint::Min(3),
+            Constraint::Percentage(50),
+            Constraint::Percentage(50),
+        ],
+        ..Default::default()
+    }
+}

--- a/crates/slumber_tui/src/view/component/root.rs
+++ b/crates/slumber_tui/src/view/component/root.rs
@@ -106,16 +106,16 @@ impl Root {
     /// the harness.database load failed.
     fn open_history(&mut self) -> anyhow::Result<()> {
         let primary_view = self.primary_view.data();
-        if let Some(recipe) = primary_view.selected_recipe() {
+        if let Some(recipe_id) = primary_view.selected_recipe_id() {
             // Make sure all requests for this profile+recipe are loaded
             let requests = self
                 .request_store
-                .load_summaries(primary_view.selected_profile_id(), &recipe.id)?
+                .load_summaries(primary_view.selected_profile_id(), recipe_id)?
                 .map(RequestStateSummary::from)
                 .collect();
 
             ViewContext::open_modal(
-                History::new(recipe, requests, self.selected_request.0),
+                History::new(recipe_id, requests, self.selected_request.0),
                 ModalPriority::Low,
             );
         }
@@ -343,9 +343,8 @@ mod tests {
 
     #[rstest]
     fn test_edit_collection(harness: TestHarness) {
-        let collection = Collection::factory(());
-        let mut component =
-            TestComponent::new(harness, Root::new(&collection), ());
+        let root = Root::new(&harness.collection);
+        let mut component = TestComponent::new(harness, root, ());
 
         component.harness_mut().clear_messages(); // Clear init junk
 

--- a/crates/slumber_tui/src/view/state.rs
+++ b/crates/slumber_tui/src/view/state.rs
@@ -58,8 +58,18 @@ impl<K, V> StateCell<K, V> {
         Ref::map(self.state.borrow(), |state| &state.as_ref().unwrap().1)
     }
 
-    /// Get a reference to the state value. This can panic, if the state value
-    /// is already borrowed elsewhere. Returns `None` iff the state cell is
+    /// Get a reference to the state key. This can panic, if the state is
+    /// already borrowed elsewhere. Returns `None` iff the state cell is
+    /// uninitialized.
+    pub fn get_key(&self) -> Option<Ref<'_, K>> {
+        Ref::filter_map(self.state.borrow(), |state| {
+            state.as_ref().map(|(k, _)| k)
+        })
+        .ok()
+    }
+
+    /// Get a reference to the state value. This can panic, if the state  is
+    /// already borrowed elsewhere. Returns `None` iff the state cell is
     /// uninitialized.
     pub fn get(&self) -> Option<Ref<'_, V>> {
         Ref::filter_map(self.state.borrow(), |state| {


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Previously we cloned the entire collection for every template render. While I haven't noticed a particular performance issue with this, I also haven't worked with very large collections. This should be a pretty low-risk optimization, because the Arc is only ever cloned when passed between tasks, when the big clone would've happened previously.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

There is a bug in this, related to `PersistedLazy`. When changing selected recipes, the selected tab in the recipe pane will flip-flop between the two most recent values. This is an unrelated bug that just started showing up in this PR because of the change in state structure.

## QA

_How did you test this?_

Manual testing.

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
