### PR TITLE
Require exact modifier match for key bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Disable unavailable menu actions [#222](https://github.com/LucasPickering/slumber/issues/222)
 - Support template for header names in the `section` field of `!request` chains
 - Expand `~` to the home directory in `!file` chain sources and when saving response body as a file
+- Ignore key events with additional key modifiers
+  - For example, an action bound to `w` will no longer match `ctrl w`
 
 ### Fixed
 

--- a/crates/slumber_config/src/input.rs
+++ b/crates/slumber_config/src/input.rs
@@ -244,7 +244,7 @@ impl KeyCombination {
     const SEPARATOR: char = ' ';
 
     pub fn matches(self, event: &KeyEvent) -> bool {
-        event.code == self.code && event.modifiers.contains(self.modifiers)
+        event.code == self.code && event.modifiers == self.modifiers
     }
 }
 

--- a/crates/slumber_tui/src/view/common/text_box.rs
+++ b/crates/slumber_tui/src/view/common/text_box.rs
@@ -139,14 +139,14 @@ impl TextBox {
             KeyCode::Backspace => self.state.delete_left(),
             KeyCode::Delete => self.state.delete_right(),
             KeyCode::Left => {
-                if key_event.modifiers.contains(KeyModifiers::CONTROL) {
+                if key_event.modifiers == KeyModifiers::CONTROL {
                     self.state.home();
                 } else {
                     self.state.left();
                 }
             }
             KeyCode::Right => {
-                if key_event.modifiers.contains(KeyModifiers::CONTROL) {
+                if key_event.modifiers == KeyModifiers::CONTROL {
                     self.state.end();
                 } else {
                     self.state.right();


### PR DESCRIPTION

## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Instead of requiring that *at least* the binding's modifiers were pressed to match, we now require that *exactly* the bindings modifiers are pressed. I.e. Shift+Enter will no longer match Enter, and Ctrl+Shift+W will no longer match Ctrl+W.

This should be more intuitive to users, because people generally don't intentionally hit more keys than they need. This opens the door for overlapping keybindings where one is a subset of the other.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Missed keypresses

## QA

_How did you test this?_

Manual testing, added a test

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
