### PR TITLE
Remove empty input bindings from binding map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Expand `~` to the home directory in `!file` chain sources and when saving response body as a file
 - Ignore key events with additional key modifiers
   - For example, an action bound to `w` will no longer match `ctrl w`
+- Actions can now be unbound by specifying an empty binding
+  - For example, binding `submit: []` will make the submit action inaccessible
 
 ### Fixed
 

--- a/crates/slumber_config/src/input.rs
+++ b/crates/slumber_config/src/input.rs
@@ -200,6 +200,11 @@ impl Action {
 pub struct InputBinding(Vec<KeyCombination>);
 
 impl InputBinding {
+    /// Does this binding have no actions? If true, it should be thrown away
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
     /// Does a key event contain this key combo?
     pub fn matches(&self, event: &KeyEvent) -> bool {
         self.0.iter().any(|combo| combo.matches(event))
@@ -215,6 +220,12 @@ impl Display for InputBinding {
             write!(f, "{}", combo)?;
         }
         Ok(())
+    }
+}
+
+impl From<Vec<KeyCombination>> for InputBinding {
+    fn from(combo: Vec<KeyCombination>) -> Self {
+        Self(combo)
     }
 }
 


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

This allows users to entirely unbound actions if they want. Not sure why you would, but if you bind an action to nothing, it's probably what you're going for.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Could break current workflow for people.

## QA

_How did you test this?_

Added tests

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
