### PR TITLE
Upgrade derive_more to fix installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Fix `cargo install slumber` when not using `--locked`
 - Don't type in text boxes when modifiers keys (other than shift) are enabled
   - Should mitigate some potential confusing behavior when using terminal key sequences
 - Query parameter and header toggle rows no longer lose their state when switching profiles

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,18 +441,18 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "1.0.0-beta.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7abbfc297053be59290e3152f8cbcd52c8642e0728b69ee187d991d4c1af08d"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "1.0.0-beta.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bba3e9872d7c58ce7ef0fcf1844fcc3e23ef2a58377b50df35dd98e42a5726e"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1357,9 +1357,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "persisted"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf42dd6984f49c1f7cf2807c8195d05702385e9c262721432337f548174c9f5c"
+checksum = "b864f7c07dfaa7d338ae51e68645c0cc3a854ae30336494577f9b6aa49c1c089"
 dependencies = [
  "derive_more",
  "persisted_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.0"
 bytes = {version = "1.6.1", default-features = false}
 chrono = {version = "0.4.31", default-features = false}
 crossterm = {version = "0.27.0", default-features = false}
-derive_more = {version = "1.0.0-beta.6", default-features = false}
+derive_more = {version = "1.0.0", default-features = false}
 futures = "0.3.28"
 indexmap = {version = "2.0.0", default-features = false}
 itertools = "0.13.0"

--- a/crates/slumber_tui/Cargo.toml
+++ b/crates/slumber_tui/Cargo.toml
@@ -20,7 +20,7 @@ futures = {workspace = true}
 indexmap = {workspace = true}
 itertools = {workspace = true}
 notify = {version = "6.1.1", default-features = false, features = ["macos_fsevent"]}
-persisted = {version = "0.2.0", features = ["serde"]}
+persisted = {version = "0.2.2", features = ["serde"]}
 ratatui = {workspace = true, features = ["crossterm", "underline-color", "unstable-rendered-line-info"]}
 reqwest = {workspace = true}
 serde = {workspace = true}

--- a/oranda.json
+++ b/oranda.json
@@ -8,7 +8,7 @@
     "artifacts": {
       "package_managers": {
         "preferred": {
-          "cargo": "cargo install slumber"
+          "cargo": "cargo install slumber --locked"
         },
         "additional": {
           "binstall": "cargo binstall slumber"


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Upgrade `derive_more` to 1.0.0, and `persisted` to 0.2.2. This should fix `cargo install slumber`. Also update the docs to suggest `cargo install slumber --locked`, to avoid this issue in the future.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

## QA

_How did you test this?_

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
