### PR TITLE
Add FPS counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Add `debug` configuration field, to enable developer information
+
 ## [1.8.0] - 2024-08-09
 
 The highlight (no pun intended) of this release is syntax highlighting. Beyond that, the release contains a variety of small fixes and improvements.

--- a/crates/slumber_config/src/lib.rs
+++ b/crates/slumber_config/src/lib.rs
@@ -40,6 +40,8 @@ pub struct Config {
     pub input_bindings: IndexMap<Action, InputBinding>,
     /// Visual configuration for the TUI (e.g. colors)
     pub theme: Theme,
+    /// Enable debug monitor in TUI
+    pub debug: bool,
 }
 
 impl Config {
@@ -84,6 +86,7 @@ impl Default for Config {
             preview_templates: true,
             input_bindings: Default::default(),
             theme: Default::default(),
+            debug: false,
         }
     }
 }

--- a/crates/slumber_tui/src/view/component.rs
+++ b/crates/slumber_tui/src/view/component.rs
@@ -1,3 +1,4 @@
+mod debug;
 mod exchange_pane;
 mod help;
 mod history;

--- a/crates/slumber_tui/src/view/component/debug.rs
+++ b/crates/slumber_tui/src/view/component/debug.rs
@@ -1,0 +1,26 @@
+use crate::view::draw::{Draw, DrawMetadata};
+use ratatui::Frame;
+use std::{cell::Cell, time::Instant};
+
+/// Show developer information, including framerate
+#[derive(Debug)]
+pub struct DebugMonitor {
+    last_frame: Cell<Instant>,
+}
+
+impl Default for DebugMonitor {
+    fn default() -> Self {
+        Self {
+            last_frame: Instant::now().into(),
+        }
+    }
+}
+
+impl Draw for DebugMonitor {
+    fn draw(&self, frame: &mut Frame, _: (), metadata: DrawMetadata) {
+        let now = Instant::now();
+        let duration = now - self.last_frame.replace(now);
+        let fps = 1.0 / duration.as_secs_f32();
+        frame.render_widget(format!("FPS: {fps:.2}"), metadata.area());
+    }
+}

--- a/docs/src/api/configuration/index.md
+++ b/docs/src/api/configuration/index.md
@@ -27,3 +27,4 @@ If the root directory doesn't exist yet, you can create it yourself or have Slum
 | `ignore_certificate_hosts` | `string[]`                          | Hostnames whose TLS certificate errors will be ignored. [More info](../../troubleshooting/tls.md) | `[]`    |
 | `input_bindings`           | `mapping[Action, KeyCombination[]]` | Override default input bindings. [More info](./input_bindings.md)                                 | `{}`    |
 | `theme`                    | [`Theme`](./theme.md)               | Visual customizations                                                                             | `{}`    |
+| `debug`                    | `boolean`                           | Enable developer information                                                                      | `false` |

--- a/slumber.yml
+++ b/slumber.yml
@@ -32,6 +32,9 @@ chains:
   image:
     source: !file
       path: ./static/slumber.png
+  big_file:
+    source: !file
+      path: Cargo.lock
 
 .ignore:
   base: &base
@@ -99,6 +102,12 @@ requests:
     body: !form_multipart
       filename: "logo.png"
       image: "{{chains.image}}"
+
+  big_file: !request
+    name: Big File
+    method: POST
+    url: "{{host}}/anything"
+    body: "{{chains.big_file}}"
 
   delay: !request
     <<: *base


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

The counter is hidden behind a new `debug` config field

<img width="436" alt="image" src="https://github.com/user-attachments/assets/18f03614-1891-4cb4-aa9e-6de8993e6c13">


## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

The FPS is jittery because it only uses the previous frame as a sample.

## QA

_How did you test this?_

Manually

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
