### PR TITLE
Add debug monitor to track view metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Add `debug` configuration field, to enable developer information
+
 ## [1.8.0] - 2024-08-09
 
 The highlight (no pun intended) of this release is syntax highlighting. Beyond that, the release contains a variety of small fixes and improvements.

--- a/crates/slumber_config/src/lib.rs
+++ b/crates/slumber_config/src/lib.rs
@@ -40,6 +40,8 @@ pub struct Config {
     pub input_bindings: IndexMap<Action, InputBinding>,
     /// Visual configuration for the TUI (e.g. colors)
     pub theme: Theme,
+    /// Enable debug monitor in TUI
+    pub debug: bool,
 }
 
 impl Config {
@@ -84,6 +86,7 @@ impl Default for Config {
             preview_templates: true,
             input_bindings: Default::default(),
             theme: Default::default(),
+            debug: false,
         }
     }
 }

--- a/crates/slumber_tui/src/view/debug.rs
+++ b/crates/slumber_tui/src/view/debug.rs
@@ -1,0 +1,51 @@
+use ratatui::{
+    layout::{Alignment, Constraint, Layout},
+    style::{Color, Style},
+    text::Text,
+    widgets::Paragraph,
+    Frame,
+};
+use std::{cell::Cell, time::Instant};
+
+/// Globally track debug/performance information. This implements
+/// [tracing::Subscriber] to collect data.
+#[derive(Debug)]
+pub struct DebugMonitor {
+    /// Track the start of the previous draw, so we can calculate frame rate
+    last_draw_start: Cell<Instant>,
+}
+
+impl DebugMonitor {
+    /// Draw the view using the given closure, then render computed metrics on
+    /// top at the end.
+    pub fn draw(&self, frame: &mut Frame, draw_fn: impl FnOnce(&mut Frame)) {
+        // Track elapsed time for the draw function
+        let start = Instant::now();
+        draw_fn(frame);
+        let duration = start.elapsed();
+        let fps = 1.0 / (start - self.last_draw_start.get()).as_secs_f32();
+        self.last_draw_start.set(start);
+
+        // Draw in the bottom-right, on top of the help text
+        let [_, area] =
+            Layout::vertical([Constraint::Min(0), Constraint::Length(1)])
+                .areas(frame.size());
+        let text = Text::from(format!(
+            "FPS: {fps:.1} / Render: {duration}ms",
+            duration = duration.as_millis()
+        ))
+        .style(Style::default().fg(Color::Black).bg(Color::Green));
+        frame.render_widget(
+            Paragraph::new(text).alignment(Alignment::Right),
+            area,
+        )
+    }
+}
+
+impl Default for DebugMonitor {
+    fn default() -> Self {
+        Self {
+            last_draw_start: Instant::now().into(),
+        }
+    }
+}

--- a/docs/src/api/configuration/index.md
+++ b/docs/src/api/configuration/index.md
@@ -27,3 +27,4 @@ If the root directory doesn't exist yet, you can create it yourself or have Slum
 | `ignore_certificate_hosts` | `string[]`                          | Hostnames whose TLS certificate errors will be ignored. [More info](../../troubleshooting/tls.md) | `[]`    |
 | `input_bindings`           | `mapping[Action, KeyCombination[]]` | Override default input bindings. [More info](./input_bindings.md)                                 | `{}`    |
 | `theme`                    | [`Theme`](./theme.md)               | Visual customizations                                                                             | `{}`    |
+| `debug`                    | `boolean`                           | Enable developer information                                                                      | `false` |

--- a/slumber.yml
+++ b/slumber.yml
@@ -32,6 +32,9 @@ chains:
   image:
     source: !file
       path: ./static/slumber.png
+  big_file:
+    source: !file
+      path: Cargo.lock
 
 .ignore:
   base: &base
@@ -99,6 +102,12 @@ requests:
     body: !form_multipart
       filename: "logo.png"
       image: "{{chains.image}}"
+
+  big_file: !request
+    name: Big File
+    method: POST
+    url: "{{host}}/anything"
+    body: "{{chains.big_file}}"
 
   delay: !request
     <<: *base


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

The monitor displays FPS and render time. The two are related but not the same: render time just tracks the `view.draw` call; FPS includes the entire loop duration, meaning it also captures idle and message processing time.

The debug info is hidden behind a new `debug` config field. I chose to document this because it will be discoverable via the error message anyway, if you add an invalid field to your config.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

The fact that this is documented makes it harder to remove in the future. The documented part is just a boolean though, so we could easily change the exact meaning of `debug`.

## QA

_How did you test this?_

manually in TUI

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
