### PR TITLE
Reduce idle CPU, skip draws when falling behind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Add `debug` configuration field, to enable developer information
 
+### Fixed
+
+- Reduce CPU usage while idling
+  - Previously, Slumber would re-render every 250ms while idling, which could lead to high CPU usage, dependending on what's on the screen. Now it will only update when changes occur, meaning idle CPU usage will be nearly 0
+
 ## [1.8.0] - 2024-08-09
 
 The highlight (no pun intended) of this release is syntax highlighting. Beyond that, the release contains a variety of small fixes and improvements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Reduce CPU usage while idling
   - Previously, Slumber would re-render every 250ms while idling, which could lead to high CPU usage, dependending on what's on the screen. Now it will only update when changes occur, meaning idle CPU usage will be nearly 0
+- Fix backlogged events when renders are slow
+  - If renders are being particular slow, it was previously possible for input events (e.g. repeated scrolling events) to occur faster than the UI could keep up. This would lead to "lock out" behavior, where you'd stop scrolling and it'd take a while for the UI to catch up.
+  - Now, the TUI will skip draws as necessary to keep up with the input queue. In practice the skipping should be hard to notice as it only occurs during rapid TUI movements anyway.
 
 ## [1.8.0] - 2024-08-09
 

--- a/crates/slumber_tui/src/message.rs
+++ b/crates/slumber_tui/src/message.rs
@@ -127,6 +127,10 @@ pub enum Message {
         on_complete:
             Box<dyn 'static + Send + Sync + FnOnce(Vec<TemplateChunk>)>,
     },
+    /// An empty event to trigger a draw when a template preview is done being
+    /// rendered. This is a bit hacky, but it's an explicit way to tell the TUI
+    /// "we know something in the view has changed asyncronously".
+    TemplatePreviewComplete,
 }
 
 /// Configuration that defines how to render a request


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

- Instead of drawing every 250ms minimum, we only draw on a regular cadence if a request is in-flight. This drops the idle CPU usage essentially to 0, at the cost of a bit of extra logic
- If we're getting a lot of inbound events (e.g. while scrolling) and the UI is struggling to keep up, we'll start skipping draws until the message/input queue is empty. This means the UI will start to look a bit jittery. 
  - The current behavior is that we'll queue up a bunch of outdated draws, meaning when the user stops doing their repeated input, they'll be locked out of interaction until the queue is drained.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

The low-idle change means we have to be proactive about updating the view when async work is going on that can affect it. That means more surface area for bugs, but the tradeoff is well worth it IMO. Idling at ~30% really isn't acceptable.

## QA

_How did you test this?_

Manual testing in TUI

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
