### PR TITLE
Cache highlighted text bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+This release is focused on improving rendering performance. The TUI should generally feel more polished and responsive when working with large bodies, and CPU usage will be much lower.
+
 ### Added
 
 - Add `debug` configuration field, to enable developer information
@@ -17,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Fix backlogged events when renders are slow
   - If renders are being particular slow, it was previously possible for input events (e.g. repeated scrolling events) to occur faster than the UI could keep up. This would lead to "lock out" behavior, where you'd stop scrolling and it'd take a while for the UI to catch up.
   - Now, the TUI will skip draws as necessary to keep up with the input queue. In practice the skipping should be hard to notice as it only occurs during rapid TUI movements anyway.
+- Improve rendering performance for large bodies and syntax highlighting
 
 ## [1.8.0] - 2024-08-09
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2206,6 +2206,7 @@ dependencies = [
  "tracing",
  "tree-sitter-highlight",
  "tree-sitter-json",
+ "unicode-width",
  "uuid",
 ]
 

--- a/crates/slumber_tui/Cargo.toml
+++ b/crates/slumber_tui/Cargo.toml
@@ -21,7 +21,7 @@ indexmap = {workspace = true}
 itertools = {workspace = true}
 notify = {version = "6.1.1", default-features = false, features = ["macos_fsevent"]}
 persisted = {version = "0.2.2", features = ["serde"]}
-ratatui = {workspace = true, features = ["crossterm", "underline-color", "unstable-rendered-line-info"]}
+ratatui = {workspace = true, features = ["crossterm", "underline-color", "unstable-widget-ref"]}
 reqwest = {workspace = true}
 serde = {workspace = true}
 serde_json = {workspace = true}
@@ -34,6 +34,7 @@ tokio = {workspace = true, features = ["macros", "signal"]}
 tracing = {workspace = true}
 tree-sitter-highlight = "0.22.6"
 tree-sitter-json = "0.21.0"
+unicode-width = "0.1.13"
 uuid = {workspace = true}
 
 [dev-dependencies]

--- a/crates/slumber_tui/src/view/common/text_window.rs
+++ b/crates/slumber_tui/src/view/common/text_window.rs
@@ -4,46 +4,71 @@ use crate::{
         common::scrollbar::Scrollbar,
         draw::{Draw, DrawMetadata},
         event::{Event, EventHandler, Update},
-        util::highlight,
     },
 };
 use ratatui::{
-    layout::Layout,
+    buffer::Buffer,
+    layout::{Layout, Rect},
     prelude::{Alignment, Constraint},
-    text::{Line, Text},
+    style::Style,
+    text::{Line, StyledGrapheme, Text},
     widgets::{Paragraph, ScrollbarOrientation},
     Frame,
 };
 use slumber_config::Action;
-use slumber_core::http::content_type::ContentType;
 use std::{cell::Cell, cmp};
+use unicode_width::UnicodeWidthStr;
 
 /// A scrollable (but not editable) block of text. Internal state will be
-/// updated on each render, to adjust to the text's width/height.
+/// updated on each render, to adjust to the text's width/height. Generally the
+/// parent should be storing an instant of [Text] and passing the same value to
+/// this on each render. Generating the `Text` could potentially be expensive
+/// (especially if it includes syntax highlighting).
 #[derive(derive_more::Debug, Default)]
 pub struct TextWindow {
-    offset_x: u16,
-    offset_y: u16,
-    text_width: Cell<u16>,
-    text_height: Cell<u16>,
-    window_width: Cell<u16>,
-    window_height: Cell<u16>,
+    offset_x: usize,
+    offset_y: usize,
+    /// How wide is the full text content?
+    text_width: Cell<usize>,
+    /// How tall is the full text content?
+    text_height: Cell<usize>,
+    /// How wide is the visible text area, excluding gutter/scrollbars?
+    window_width: Cell<usize>,
+    /// How tall is the visible text area, exluding gutter/scrollbars?
+    window_height: Cell<usize>,
 }
 
+#[derive(Clone)]
 pub struct TextWindowProps<'a> {
-    /// Text to render
-    pub text: Text<'a>,
-    /// Language of the content; pass to enable syntax highlighting
-    pub content_type: Option<ContentType>,
-    /// Is there a search box below the content? This tells us if we need to
-    /// offset the horizontal scroll box an extra row.
-    pub has_search_box: bool,
+    /// Text to render. We take a reference because this component tends to
+    /// contain a lot of text, and we don't want to force a clone on render
+    pub text: &'a Text<'a>,
+    pub margins: ScrollbarMargins,
+}
+
+/// How far outside the text window should scrollbars be placed? Margin of
+/// 0 uses the outermost row/column of the text area. Positive values
+/// pushes the scrollbar outside the rendered outside, negative moves
+/// it inside.
+#[derive(Clone)]
+pub struct ScrollbarMargins {
+    pub right: i32,
+    pub bottom: i32,
+}
+
+impl Default for ScrollbarMargins {
+    fn default() -> Self {
+        Self {
+            right: 1,
+            bottom: 1,
+        }
+    }
 }
 
 impl TextWindow {
     /// Get the final line that we can't scroll past. This will be the first
     /// line of the last page of text
-    fn max_scroll_line(&self) -> u16 {
+    fn max_scroll_line(&self) -> usize {
         self.text_height
             .get()
             .saturating_sub(self.window_height.get())
@@ -51,33 +76,67 @@ impl TextWindow {
 
     /// Get the final column that we can't scroll (horizontally) past. This will
     /// be the left edge of the rightmost "page" of text
-    fn max_scroll_column(&self) -> u16 {
+    fn max_scroll_column(&self) -> usize {
         self.text_width
             .get()
             .saturating_sub(self.window_width.get())
     }
 
-    fn scroll_up(&mut self, lines: u16) {
+    fn scroll_up(&mut self, lines: usize) {
         self.offset_y = self.offset_y.saturating_sub(lines);
     }
 
-    fn scroll_down(&mut self, lines: u16) {
+    fn scroll_down(&mut self, lines: usize) {
         self.offset_y = cmp::min(self.offset_y + lines, self.max_scroll_line());
     }
 
     /// Scroll to a specific line number. The target line will end up as close
     /// to the top of the page as possible
-    fn scroll_to(&mut self, line: u16) {
+    fn scroll_to(&mut self, line: usize) {
         self.offset_y = cmp::min(line, self.max_scroll_line());
     }
 
-    fn scroll_left(&mut self, columns: u16) {
+    fn scroll_left(&mut self, columns: usize) {
         self.offset_x = self.offset_x.saturating_sub(columns);
     }
 
-    fn scroll_right(&mut self, columns: u16) {
+    fn scroll_right(&mut self, columns: usize) {
         self.offset_x =
             cmp::min(self.offset_x + columns, self.max_scroll_column());
+    }
+
+    /// Render the visible text into the window. The Paragraph widget provides
+    /// all this functionality out of the box, but it needs an owned Text and
+    /// we only have a reference. A clone could potentially be very expensive
+    /// for a large body, so we use our own logic.
+    fn render_chars<'a>(
+        &self,
+        text: &'a Text<'a>,
+        buf: &mut Buffer,
+        area: Rect,
+    ) {
+        let lines = text
+            .lines
+            .iter()
+            .skip(self.offset_y)
+            .take(self.window_height.get())
+            .enumerate();
+        for (y, line) in lines {
+            let graphemes = line
+                .styled_graphemes(Style::default())
+                .skip(self.offset_x)
+                .take(self.window_width.get());
+            let mut x = 0;
+            for StyledGrapheme { symbol, style } in graphemes {
+                if x >= area.width {
+                    break;
+                }
+                buf[(area.left() + x, area.top() + y as u16)]
+                    .set_symbol(symbol)
+                    .set_style(style);
+                x += symbol.width() as u16;
+            }
+        }
     }
 }
 
@@ -94,7 +153,7 @@ impl EventHandler for TextWindow {
             Action::PageUp => self.scroll_up(self.window_height.get()),
             Action::PageDown => self.scroll_down(self.window_height.get()),
             Action::Home => self.scroll_to(0),
-            Action::End => self.scroll_to(u16::MAX),
+            Action::End => self.scroll_to(usize::MAX),
             _ => return Update::Propagate(event),
         }
         Update::Consumed
@@ -111,16 +170,17 @@ impl<'a> Draw<TextWindowProps<'a>> for TextWindow {
     ) {
         let styles = &TuiContext::get().styles;
 
-        // Apply syntax highlighting
-        let text = if let Some(content_type) = props.content_type {
-            highlight::highlight(content_type, props.text)
-        } else {
-            props.text
-        };
-
-        let text = Paragraph::new(text);
         // Assume no line wrapping when calculating line count
-        let text_height = text.line_count(u16::MAX) as u16;
+        // Note: Paragraph has methods for this, but that requires an owned copy
+        // of Text, which involves a lot of cloning
+        let text_height = props.text.lines.len();
+        let text_width = props
+            .text
+            .lines
+            .iter()
+            .map(Line::width)
+            .max()
+            .unwrap_or_default();
 
         let [gutter_area, _, text_area] = Layout::horizontal([
             // Size gutter based on width of max line number
@@ -129,16 +189,19 @@ impl<'a> Draw<TextWindowProps<'a>> for TextWindow {
             Constraint::Min(0),
         ])
         .areas(metadata.area());
+        let has_vertical_scroll = text_height > text_area.height as usize;
+        let has_horizontal_scroll = text_width > text_area.width as usize;
 
         // Store text and window sizes for calculations in the update code
-        self.text_width.set(text.line_width() as u16);
+        self.text_width.set(text_width);
         self.text_height.set(text_height);
-        self.window_width.set(text_area.width);
-        self.window_height.set(text_area.height);
+        self.window_width.set(text_area.width as usize);
+        self.window_height.set(text_area.height as usize);
 
         // Draw line numbers in the gutter
         let first_line = self.offset_y + 1;
-        let last_line = cmp::min(first_line + text_area.height, text_height);
+        let last_line =
+            cmp::min(first_line + self.window_height.get() - 1, text_height);
         frame.render_widget(
             Paragraph::new(
                 (first_line..=last_line)
@@ -151,28 +214,174 @@ impl<'a> Draw<TextWindowProps<'a>> for TextWindow {
         );
 
         // Draw the text content
-        frame.render_widget(
-            text.scroll((self.offset_y, self.offset_x)),
-            text_area,
-        );
+        self.render_chars(props.text, frame.buffer_mut(), text_area);
 
         // Scrollbars
-        frame.render_widget(
-            Scrollbar {
-                content_length: self.text_height.get() as usize,
-                offset: self.offset_y as usize,
-                ..Default::default()
+        if has_vertical_scroll {
+            frame.render_widget(
+                Scrollbar {
+                    content_length: self.text_height.get(),
+                    offset: self.offset_y,
+                    // We substracted the margin from the text area before, so
+                    // we have to add that back now
+                    margin: props.margins.right,
+                    ..Default::default()
+                },
+                text_area,
+            );
+        }
+        if has_horizontal_scroll {
+            frame.render_widget(
+                Scrollbar {
+                    content_length: self.text_width.get(),
+                    offset: self.offset_x,
+                    orientation: ScrollbarOrientation::HorizontalBottom,
+                    // See note on other scrollbar for +1
+                    margin: props.margins.bottom,
+                },
+                text_area,
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        test_util::{harness, TestHarness},
+        view::test_util::TestComponent,
+    };
+    use crossterm::event::{KeyCode, KeyModifiers};
+    use ratatui::text::Span;
+    use rstest::rstest;
+
+    #[rstest]
+    fn test_scroll(#[with(10, 4)] harness: TestHarness) {
+        let text =
+            Text::from("line 1\nline 2 is longer\nline 3\nline 4\nline 5");
+        let mut component = TestComponent::new(
+            harness,
+            TextWindow::default(),
+            TextWindowProps {
+                text: &text,
+                // Don't overflow the frame
+                margins: ScrollbarMargins {
+                    right: 0,
+                    bottom: 0,
+                },
             },
-            text_area,
         );
-        frame.render_widget(
-            Scrollbar {
-                content_length: self.text_width.get() as usize,
-                offset: self.offset_x as usize,
-                orientation: ScrollbarOrientation::HorizontalBottom,
-                margin: if props.has_search_box { 2 } else { 1 },
+        component.assert_buffer_lines([
+            vec![line_num(1), " line 1 ▲".into()],
+            vec![line_num(2), " line 2 █".into()],
+            vec![line_num(3), " line 3 █".into()],
+            vec![line_num(4), " ◀■■■═══▶".into()],
+        ]);
+
+        // Scroll down
+        component.send_key(KeyCode::Down).assert_empty();
+        component.assert_buffer_lines([
+            vec![line_num(2), " line 2 ▲".into()],
+            vec![line_num(3), " line 3 █".into()],
+            vec![line_num(4), " line 4 █".into()],
+            vec![line_num(5), " ◀■■■═══▶".into()],
+        ]);
+
+        // Scroll back up
+        component.send_key(KeyCode::Up).assert_empty();
+        component.send_key(KeyCode::Up).assert_empty(); // Does nothing
+        component.assert_buffer_lines([
+            vec![line_num(1), " line 1 ▲".into()],
+            vec![line_num(2), " line 2 █".into()],
+            vec![line_num(3), " line 3 █".into()],
+            vec![line_num(4), " ◀■■■═══▶".into()],
+        ]);
+
+        // Scroll right
+        component
+            .send_key_modifiers(KeyCode::Right, KeyModifiers::SHIFT)
+            .assert_empty();
+        component
+            .send_key_modifiers(KeyCode::Right, KeyModifiers::SHIFT)
+            .assert_empty();
+        component
+            .send_key_modifiers(KeyCode::Right, KeyModifiers::SHIFT)
+            .assert_empty();
+        component.assert_buffer_lines([
+            vec![line_num(1), " e 1    ▲".into()],
+            vec![line_num(2), " e 2 is █".into()],
+            vec![line_num(3), " e 3    █".into()],
+            vec![line_num(4), " ◀═■■■══▶".into()],
+        ]);
+
+        // Scroll back left
+        component
+            .send_key_modifiers(KeyCode::Left, KeyModifiers::SHIFT)
+            .assert_empty();
+        component
+            .send_key_modifiers(KeyCode::Left, KeyModifiers::SHIFT)
+            .assert_empty();
+        component
+            .send_key_modifiers(KeyCode::Left, KeyModifiers::SHIFT)
+            .assert_empty();
+        component
+            .send_key_modifiers(KeyCode::Left, KeyModifiers::SHIFT)
+            .assert_empty(); // Does nothing
+        component.assert_buffer_lines([
+            vec![line_num(1), " line 1 ▲".into()],
+            vec![line_num(2), " line 2 █".into()],
+            vec![line_num(3), " line 3 █".into()],
+            vec![line_num(4), " ◀■■■═══▶".into()],
+        ]);
+    }
+
+    #[rstest]
+    fn test_unicode(#[with(35, 3)] harness: TestHarness) {
+        let text = Text::from("intro\n💚💙💜 this is a longer line\noutro");
+        let component = TestComponent::new(
+            harness,
+            TextWindow::default(),
+            TextWindowProps {
+                text: &text,
+                // Don't overflow the frame
+                margins: ScrollbarMargins {
+                    right: 0,
+                    bottom: 0,
+                },
             },
-            text_area,
         );
+        component.assert_buffer_lines([
+            vec![line_num(1), " intro                            ".into()],
+            vec![line_num(2), " 💚💙💜 this is a longer line    ".into()],
+            vec![line_num(3), " outro                            ".into()],
+        ]);
+    }
+
+    #[rstest]
+    fn test_unicode_scroll(#[with(10, 2)] harness: TestHarness) {
+        let text = Text::from("💚💙💜💚💙💜");
+        let component = TestComponent::new(
+            harness,
+            TextWindow::default(),
+            TextWindowProps {
+                text: &text,
+                // Don't overflow the frame
+                margins: ScrollbarMargins {
+                    right: 0,
+                    bottom: 0,
+                },
+            },
+        );
+        component.assert_buffer_lines([
+            vec![line_num(1), " 💚💙💜💚".into()],
+            vec![line_num(0), " ◀■■■■══▶".into()],
+        ]);
+    }
+
+    /// Style some text as gutter line numbers
+    fn line_num(n: u16) -> Span<'static> {
+        let s = if n > 0 { n.to_string() } else { " ".into() };
+        Span::styled(s, TuiContext::get().styles.text_window.gutter)
     }
 }

--- a/crates/slumber_tui/src/view/component/profile_select.rs
+++ b/crates/slumber_tui/src/view/component/profile_select.rs
@@ -314,6 +314,7 @@ impl<'a> Draw<ProfileDetailProps<'a>> for ProfileDetail {
                         TemplatePreview::new(
                             template.clone(),
                             Some(profile_id.clone()),
+                            None,
                         ),
                     )
                 })

--- a/crates/slumber_tui/src/view/component/recipe_pane/authentication.rs
+++ b/crates/slumber_tui/src/view/component/recipe_pane/authentication.rs
@@ -29,11 +29,13 @@ impl AuthenticationDisplay {
                     username: TemplatePreview::new(
                         username.clone(),
                         selected_profile_id.cloned(),
+                        None,
                     ),
                     password: password.clone().map(|password| {
                         TemplatePreview::new(
                             password,
                             selected_profile_id.cloned(),
+                            None,
                         )
                     }),
                 }
@@ -42,6 +44,7 @@ impl AuthenticationDisplay {
                 AuthenticationDisplay::Bearer(TemplatePreview::new(
                     token.clone(),
                     selected_profile_id.cloned(),
+                    None,
                 ))
             }
         }

--- a/crates/slumber_tui/src/view/component/recipe_pane/recipe.rs
+++ b/crates/slumber_tui/src/view/component/recipe_pane/recipe.rs
@@ -59,6 +59,7 @@ impl RecipeDisplay {
                     TemplatePreview::new(
                         value.clone(),
                         selected_profile_id.cloned(),
+                        None,
                     ),
                     QueryRowToggleKey {
                         recipe_id: recipe.id.clone(),
@@ -76,6 +77,7 @@ impl RecipeDisplay {
                     TemplatePreview::new(
                         value.clone(),
                         selected_profile_id.cloned(),
+                        None,
                     ),
                     HeaderRowToggleKey {
                         recipe_id: recipe.id.clone(),
@@ -91,6 +93,7 @@ impl RecipeDisplay {
             url: TemplatePreview::new(
                 recipe.url.clone(),
                 selected_profile_id.cloned(),
+                None,
             ),
             query: PersistedLazy::new(
                 QueryRowKey(recipe.id.clone()),

--- a/crates/slumber_tui/src/view/component/response_view.rs
+++ b/crates/slumber_tui/src/view/component/response_view.rs
@@ -219,7 +219,9 @@ mod tests {
             body: b"\x01\x02\x03\xff".to_vec().into(),
             ..ResponseRecord::factory(())
         },
-        "01 02 03 ff"
+        // Remove newline after this fix:
+        // https://github.com/ratatui-org/ratatui/pull/1320
+        "01 02 03 ff\n"
     )]
     #[tokio::test]
     async fn test_copy_body(

--- a/crates/slumber_tui/src/view/util/highlight.rs
+++ b/crates/slumber_tui/src/view/util/highlight.rs
@@ -77,6 +77,19 @@ pub fn highlight(content_type: ContentType, mut text: Text<'_>) -> Text<'_> {
     })
 }
 
+/// Apply syntax highlighting if the content type is `Some`, otherwise just
+/// return the given text
+pub fn highlight_if(
+    content_type: Option<ContentType>,
+    text: Text<'_>,
+) -> Text<'_> {
+    if let Some(content_type) = content_type {
+        highlight(content_type, text)
+    } else {
+        text
+    }
+}
+
 /// Map [ContentType] to a syntax highlighting language
 fn get_config(content_type: ContentType) -> HighlightConfiguration {
     let mut config = match content_type {

--- a/slumber.yml
+++ b/slumber.yml
@@ -107,7 +107,7 @@ requests:
     name: Big File
     method: POST
     url: "{{host}}/anything"
-    body: "{{chains.big_file}}"
+    body: !json { data: "{{chains.big_file}}" }
 
   delay: !request
     <<: *base


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Previously, we were re-calculating syntax highlighting, and generating Text objects, for large bodies on every render. This applied to the recipe body, request body, and response body panes. For large bodies, this led to significant overhead. For a ~182KB body, the response pane went from ~100ms render time down to ~6ms.

This comes at the cost of some additional up-front clones, but I think the tradeoff is worth it.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Potentially more memory usage because of body clones

## QA

_How did you test this?_

Added some unit tests, manual TUI testing. Tested scrolling on large bodies, and with unicode.

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
