### PR TITLE
Edit table recipe values in TUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Edit recipe values (query params, headers, etc.) in the TUI to provide one-off values
+  - Press `e` on any value you want to edit (you can [customize the key](https://slumber.lucaspickering.me/book/api/configuration/input_bindings.html))
+
 ## [1.8.1] - 2024-08-11
 
 This release is focused on improving rendering performance. The TUI should generally feel more polished and responsive when working with large bodies, and CPU usage will be much lower.

--- a/crates/slumber_config/src/input.rs
+++ b/crates/slumber_config/src/input.rs
@@ -141,6 +141,9 @@ pub enum Action {
     Toggle,
     /// Close the current modal/dialog/etc.
     Cancel,
+    /// Trigger the workflow to provide a temporary override for a recipe value
+    /// (body/param/etc.)
+    Edit,
     /// Browse request history
     History,
     /// Start a search/filter operation

--- a/crates/slumber_tui/src/input.rs
+++ b/crates/slumber_tui/src/input.rs
@@ -46,6 +46,14 @@ impl InputEngine {
         self.bindings.get(&action)
     }
 
+    /// Get the binding associated with a particular action as a string. If the
+    /// action is unbound, use a placeholder string instead
+    pub fn binding_display(&self, action: Action) -> String {
+        self.binding(action)
+            .map(InputBinding::to_string)
+            .unwrap_or_else(|| "<unbound>".to_owned())
+    }
+
     /// Append a hotkey hint to a label. If the given action is bound, adding
     /// a hint to the end of the given label. If unbound, return the label
     /// alone.
@@ -165,6 +173,7 @@ impl Default for InputEngine {
                 Action::Submit => KeyCode::Enter.into(),
                 Action::Toggle => KeyCode::Char(' ').into(),
                 Action::Cancel => KeyCode::Esc.into(),
+                Action::Edit => KeyCode::Char('e').into(),
                 Action::SelectProfileList => KeyCode::Char('p').into(),
                 Action::SelectRecipeList => KeyCode::Char('l').into(),
                 Action::SelectRecipe => KeyCode::Char('c').into(),

--- a/crates/slumber_tui/src/test_util.rs
+++ b/crates/slumber_tui/src/test_util.rs
@@ -126,7 +126,7 @@ macro_rules! assert_events {
             $(
                 let Some(event) = events.get(len) else {
                     panic!(
-                        "Expected event {expected} but queue is empty",
+                        "Expected event {expected} but reached end of queue",
                         expected = stringify!($pattern),
                     );
                 };

--- a/crates/slumber_tui/src/view/component/help.rs
+++ b/crates/slumber_tui/src/view/component/help.rs
@@ -37,9 +37,9 @@ impl Generate for HelpFooter {
 
         let text = actions
             .into_iter()
-            .filter_map(|action| {
-                let binding = tui_context.input_engine.binding(action)?;
-                Some(format!("{binding} {action}"))
+            .map(|action| {
+                let binding = tui_context.input_engine.binding_display(action);
+                format!("{binding} {action}")
             })
             .join(" / ");
 

--- a/crates/slumber_tui/src/view/component/recipe_pane/body.rs
+++ b/crates/slumber_tui/src/view/component/recipe_pane/body.rs
@@ -76,7 +76,7 @@ impl RecipeBodyDisplay {
             | RecipeBody::FormMultipart(fields) => {
                 let inner = RecipeFieldTable::new(
                     FormRowKey(recipe_id.clone()),
-                    selected_profile_id,
+                    selected_profile_id.cloned(),
                     fields.iter().map(|(field, value)| {
                         (
                             field.clone(),

--- a/crates/slumber_tui/src/view/component/recipe_pane/table.rs
+++ b/crates/slumber_tui/src/view/component/recipe_pane/table.rs
@@ -1,24 +1,38 @@
-use crate::view::{
-    common::{
-        table::{Table, ToggleRow},
-        template_preview::TemplatePreview,
+use crate::{
+    context::TuiContext,
+    util::ResultReported,
+    view::{
+        common::{
+            table::{Table, ToggleRow},
+            template_preview::TemplatePreview,
+            text_box::TextBox,
+        },
+        component::{misc::TextBoxModal, Component},
+        context::{Persisted, PersistedKey, PersistedLazy},
+        draw::{Draw, DrawMetadata, Generate},
+        event::{Event, EventHandler, Update},
+        state::select::SelectState,
+        ModalPriority, ViewContext,
     },
-    component::Component,
-    context::{Persisted, PersistedKey, PersistedLazy},
-    draw::{Draw, DrawMetadata, Generate},
-    event::EventHandler,
-    state::select::SelectState,
 };
 use itertools::Itertools;
-use ratatui::{layout::Constraint, widgets::TableState, Frame};
+use ratatui::{
+    layout::Constraint,
+    text::Span,
+    widgets::{Row, TableState},
+    Frame,
+};
+use slumber_config::Action;
 use slumber_core::{
     collection::{HasId, ProfileId},
+    http::{BuildFieldOverride, BuildFieldOverrides},
     template::Template,
 };
+use std::str::FromStr;
 
 /// A table of key-value mappings. This is used in a new places in the recipe
 /// pane, and provides some common functionality:
-/// - Persist selected togle
+/// - Persist selected toggle
 /// - Allow toggling rows, and persist toggled state
 /// - Render values as template previwws
 /// - Allow editing values for temporary overrides
@@ -36,6 +50,8 @@ where
             SelectState<RowState<RowToggleKey>, TableState>,
         >,
     >,
+    /// Needed for template previews
+    selected_profile_id: Option<ProfileId>,
 }
 
 impl<RowSelectKey, RowToggleKey> RecipeFieldTable<RowSelectKey, RowToggleKey>
@@ -45,21 +61,23 @@ where
 {
     pub fn new(
         select_key: RowSelectKey,
-        selected_profile_id: Option<&ProfileId>,
+        selected_profile_id: Option<ProfileId>,
         rows: impl IntoIterator<Item = (String, Template, RowToggleKey)>,
     ) -> Self {
         let items = rows
             .into_iter()
-            .map(|(key, value, toggle_key)| {
-                RowState::new(
-                    key,
-                    TemplatePreview::new(
-                        value,
-                        selected_profile_id.cloned(),
-                        None,
-                    ),
-                    toggle_key,
-                )
+            .enumerate()
+            .map(|(i, (key, value, toggle_key))| RowState {
+                index: i, // This will be the unique ID for the row
+                key,
+                value: value.clone(),
+                preview: TemplatePreview::new(
+                    value,
+                    selected_profile_id.clone(),
+                    None,
+                ),
+                overridden: false,
+                enabled: Persisted::new(toggle_key, true),
             })
             .collect();
         let select = SelectState::builder(items)
@@ -67,17 +85,18 @@ where
             .build();
         Self {
             select: PersistedLazy::new(select_key, select).into(),
+            selected_profile_id,
         }
     }
 
-    /// Get the set of disabled rows for this table
-    pub fn to_disabled_indexes(&self) -> Vec<usize> {
+    /// Get the set of disabled/overriden rows for this table
+    pub fn to_build_overrides(&self) -> BuildFieldOverrides {
         self.select
             .data()
             .items()
-            .enumerate()
-            .filter(|(_, row)| !*row.enabled)
-            .map(|(i, _)| i)
+            .filter_map(|row| {
+                row.to_build_override().map(|ovr| (row.index, ovr))
+            })
             .collect()
     }
 }
@@ -88,6 +107,26 @@ where
     RowSelectKey: PersistedKey<Value = Option<String>>,
     RowToggleKey: PersistedKey<Value = bool>,
 {
+    fn update(&mut self, event: Event) -> Update {
+        if let Some(Action::Edit) = event.action() {
+            if let Some(selected_row) = self.select.data().selected() {
+                selected_row.open_edit_modal();
+            }
+            // Consume the event even if we have no rows, for consistency
+        } else if let Some(SaveOverride { row_index, value }) = event.local() {
+            // The row we're modifying *should* still be the selected row,
+            // because it shouldn't be possible to change the selection while
+            // the edit modal is open. It's safer to re-grab the modal by index
+            // though, just to be sure we've got the right one.
+            self.select.data_mut().items_mut()[*row_index]
+                .value
+                .set_override(self.selected_profile_id.clone(), value);
+        } else {
+            return Update::Propagate(event);
+        }
+        Update::Consumed
+    }
+
     fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {
         vec![self.select.as_child()]
     }
@@ -110,13 +149,7 @@ where
                 .select
                 .data()
                 .items()
-                .map(|row| {
-                    ToggleRow::new(
-                        [row.key.as_str().into(), row.value.generate()],
-                        *row.enabled,
-                    )
-                    .generate()
-                })
+                .map(Generate::generate)
                 .collect_vec(),
             header: Some(["", props.key_header, props.value_header]),
             column_widths: &[
@@ -131,6 +164,7 @@ where
     }
 }
 
+#[derive(Clone)]
 pub struct RecipeFieldTableProps<'a> {
     /// Label for the left column in the table
     pub key_header: &'a str,
@@ -142,22 +176,103 @@ pub struct RecipeFieldTableProps<'a> {
 /// use for toggle state
 #[derive(Debug)]
 struct RowState<K: PersistedKey<Value = bool>> {
+    /// Index of this row in the table. This is the unique ID for this row
+    /// **in the context of a single session**. Rows can be added/removed
+    /// during a collection reload, so we can't persist this.
+    index: usize,
+    /// Persistent (but not unique) identifier for this row. Keys can be
+    /// duplicated within one table (e.g. query params), but this is how we
+    /// link instances of a row across collection reloads.
     key: String,
-    value: TemplatePreview,
+    /// We hang onto the source template so we can edit it
+    value: Template,
+    preview: TemplatePreview,
+    /// Has the user modified the template? If so we'll provide this as an
+    /// override when generating build options
+    overridden: bool,
+    /// Is the row enabled/included? This is persisted by row *key* rather than
+    /// index, which **may not be unique**. E.g. a query param could be
+    /// duplicated. This means duplicated keys will all get the same persisted
+    /// toggle state. This is a bug but it's hard to fix, because if we persist
+    /// by index (the actual unique key), then adding/removing any field to the
+    /// table will mess with persistence.
     enabled: Persisted<K>,
 }
 
+impl<K: PersistedKey<Value = bool>> Generate for &RowState<K> {
+    type Output<'this> = Row<'this>
+    where
+        Self: 'this;
+
+    fn generate<'this>(self) -> Self::Output<'this>
+    where
+        Self: 'this,
+    {
+        let styles = &TuiContext::get().styles;
+        let mut preview_text = self.preview.generate();
+        if self.overridden {
+            preview_text.push_span(Span::styled(" (edited)", styles.text.hint));
+        }
+        ToggleRow::new([self.key.as_str().into(), preview_text], *self.enabled)
+            .generate()
+    }
+}
+
 impl<K: PersistedKey<Value = bool>> RowState<K> {
-    fn new(key: String, value: TemplatePreview, persisted_key: K) -> Self {
-        Self {
-            key,
-            value,
-            enabled: Persisted::new(persisted_key, true),
+    fn toggle(&mut self) {
+        *self.enabled.borrow_mut() ^= true;
+    }
+
+    /// Open a modal to create or edit the value's temporary override
+    fn open_edit_modal(&self) {
+        let index = self.index;
+        ViewContext::open_modal(
+            TextBoxModal::new(
+                format!("Edit value for {}", self.key),
+                TextBox::default()
+                    // Edit as a raw template
+                    .default_value(self.value.display().into_owned())
+                    .validator(|value| Template::from_str(value).is_ok()),
+                move |value| {
+                    // Defer the state update into an event, so it can get &mut
+                    ViewContext::push_event(Event::new_local(SaveOverride {
+                        row_index: index,
+                        value,
+                    }))
+                },
+            ),
+            ModalPriority::Low,
+        );
+    }
+
+    /// Override the value template and re-render the preview
+    fn set_override(
+        &mut self,
+        selected_profile_id: Option<ProfileId>,
+        override_value: &str,
+    ) {
+        // The validator on the override text box enforces that it's a valid
+        // template, so we expect this parse to succeed
+        if let Some(template) = override_value
+            .parse::<Template>()
+            .reported(&ViewContext::messages_tx())
+        {
+            self.value = template.clone();
+            self.preview =
+                TemplatePreview::new(template, selected_profile_id, None);
+            self.overridden = true;
         }
     }
 
-    fn toggle(&mut self) {
-        *self.enabled.borrow_mut() ^= true;
+    /// Get the disabled/override state of this row
+    fn to_build_override(&self) -> Option<BuildFieldOverride> {
+        if !*self.enabled {
+            Some(BuildFieldOverride::Omit)
+        } else if self.overridden {
+            Some(BuildFieldOverride::Override(self.value.clone()))
+        } else {
+            None
+        }
     }
 }
 
@@ -181,5 +296,156 @@ where
 {
     fn eq(&self, row_state: &RowState<K>) -> bool {
         self == &row_state.key
+    }
+}
+
+/// Local event to modify a row's override template. Triggered from the edit
+/// modal
+#[derive(Debug)]
+struct SaveOverride {
+    row_index: usize,
+    value: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        test_util::{harness, terminal, TestHarness, TestTerminal},
+        view::test_util::{TestComponent, WithModalQueue},
+    };
+    use crossterm::event::KeyCode;
+    use rstest::rstest;
+    use serde::Serialize;
+    use slumber_core::{collection::RecipeId, test_util::Factory};
+
+    #[derive(Debug, Serialize, persisted::PersistedKey)]
+    #[persisted(Option<String>)]
+    struct TestRowKey(RecipeId);
+
+    #[derive(Debug, Serialize, persisted::PersistedKey)]
+    #[persisted(bool)]
+    struct TestRowToggleKey {
+        recipe_id: RecipeId,
+        key: String,
+    }
+
+    /// User can hide a row from the recipe
+    #[rstest]
+    fn test_disabled_row(_harness: TestHarness, terminal: TestTerminal) {
+        let recipe_id = RecipeId::factory(());
+        let rows = [
+            (
+                "row0".into(),
+                "value0".into(),
+                TestRowToggleKey {
+                    recipe_id: recipe_id.clone(),
+                    key: "row0".into(),
+                },
+            ),
+            (
+                "row1".into(),
+                "value1".into(),
+                TestRowToggleKey {
+                    recipe_id: recipe_id.clone(),
+                    key: "row1".into(),
+                },
+            ),
+        ];
+        let mut component = TestComponent::new(
+            &terminal,
+            RecipeFieldTable::new(TestRowKey(recipe_id.clone()), None, rows),
+            RecipeFieldTableProps {
+                key_header: "Key",
+                value_header: "Value",
+            },
+        );
+
+        // Check initial state
+        assert_eq!(
+            component.data().to_build_overrides(),
+            BuildFieldOverrides::default()
+        );
+
+        // Disable the second row
+        component.send_key(KeyCode::Down).assert_empty();
+        component.send_key(KeyCode::Char(' ')).assert_empty();
+        let selected_row = component.data().select.data().selected().unwrap();
+        assert_eq!(&selected_row.key, "row1");
+        assert!(!*selected_row.enabled);
+        assert_eq!(
+            component.data().to_build_overrides(),
+            [(1, BuildFieldOverride::Omit)].into_iter().collect(),
+        );
+
+        // Re-enable the row
+        component.send_key(KeyCode::Char(' ')).assert_empty();
+        let selected_row = component.data().select.data().selected().unwrap();
+        assert!(*selected_row.enabled);
+        assert_eq!(
+            component.data().to_build_overrides(),
+            BuildFieldOverrides::default(),
+        );
+    }
+
+    /// User can edit the value for a row
+    #[rstest]
+    fn test_override_row(_harness: TestHarness, terminal: TestTerminal) {
+        let recipe_id = RecipeId::factory(());
+        let rows = [
+            (
+                "row0".into(),
+                "value0".into(),
+                TestRowToggleKey {
+                    recipe_id: recipe_id.clone(),
+                    key: "row0".into(),
+                },
+            ),
+            (
+                "row1".into(),
+                "value1".into(),
+                TestRowToggleKey {
+                    recipe_id: recipe_id.clone(),
+                    key: "row1".into(),
+                },
+            ),
+        ];
+        let mut component = TestComponent::new(
+            &terminal,
+            // We'll need a modal queue to handle the edit box
+            WithModalQueue::new(RecipeFieldTable::new(
+                TestRowKey(recipe_id.clone()),
+                None,
+                rows,
+            )),
+            RecipeFieldTableProps {
+                key_header: "Key",
+                value_header: "Value",
+            },
+        );
+
+        // Check initial state
+        assert_eq!(
+            component.data().inner().to_build_overrides(),
+            BuildFieldOverrides::default()
+        );
+
+        // Edit the second row
+        component.send_key(KeyCode::Down).assert_empty();
+        component.send_key(KeyCode::Char('e')).assert_empty(); // Open the modal
+        component.send_text("!!!").assert_empty();
+        component.send_key(KeyCode::Enter).assert_empty();
+
+        let selected_row =
+            component.data().inner().select.data().selected().unwrap();
+        assert_eq!(&selected_row.key, "row1");
+        assert!(selected_row.overridden);
+        assert_eq!(selected_row.value.display(), "value1!!!");
+        assert_eq!(
+            component.data().inner().to_build_overrides(),
+            [(1, BuildFieldOverride::Override("value1!!!".into()))]
+                .into_iter()
+                .collect(),
+        );
     }
 }

--- a/crates/slumber_tui/src/view/state/select.rs
+++ b/crates/slumber_tui/src/view/state/select.rs
@@ -195,6 +195,11 @@ impl<Item, State: SelectStateData> SelectState<Item, State> {
         self.items.iter()
     }
 
+    /// Get mutable references to all items in the list
+    pub fn items_mut(&mut self) -> &mut [SelectItem<Item>] {
+        &mut self.items
+    }
+
     pub fn is_empty(&self) -> bool {
         self.items.is_empty()
     }

--- a/crates/slumber_tui/src/view/styles.rs
+++ b/crates/slumber_tui/src/view/styles.rs
@@ -104,6 +104,8 @@ pub struct TextStyle {
     pub primary: Style,
     /// Text that means BAD BUSINESS
     pub error: Style,
+    /// Subtle text to provide a hint to the user
+    pub hint: Style,
 }
 
 /// Styles for TextBox component
@@ -184,6 +186,7 @@ impl Styles {
                     .bg(theme.primary_color),
                 primary: Style::default().fg(theme.primary_color),
                 error: Style::default().bg(theme.error_color),
+                hint: Style::default().fg(Color::DarkGray),
             },
             text_box: TextBoxStyle {
                 text: Style::default().bg(Color::DarkGray),

--- a/docs/src/api/configuration/input_bindings.md
+++ b/docs/src/api/configuration/input_bindings.md
@@ -54,6 +54,7 @@ input_bindings:
 | `submit`              | `enter`                     |
 | `toggle`              | `space`                     |
 | `cancel`              | `esc`                       |
+| `edit`                | `e`                         |
 | `history`             | `h`                         |
 | `search`              | `/`                         |
 | `reload_collection`   | `f5`                        |


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

First round of TUI editability for recipe values. This enables it for table values: query params, headers, and form fields. Authentcation and raw/json bodies still to come. 

![editable](https://github.com/user-attachments/assets/1fdc2cfe-28be-4eb2-bb52-cf9c9d7fb1d0)


## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Currently the edited values are not persisted, so they are lost if you reload the collection or change recipes/profiles. This is probably not good UX. Persisting wouldn't be that hard, but the hard part is figuring out when to invalidate what we've persisted. It should be whenever the corresponding value in the collection is changed/removed, but that requires us to store the original value in some way as well (or a hash of it?). Needs some more work.

## QA

_How did you test this?_

- Added a few unit tests
  - Updated the `http` test to cover overridden values (in addition to disabled ones)
  - Added a couple tests to `RecipeFieldTable` to test the disable and override workflows
- Manual TUI testing

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
