### PR TITLE
Remove selected profile ID plumbing

### DIFF
--- a/crates/slumber_tui/src/lib.rs
+++ b/crates/slumber_tui/src/lib.rs
@@ -290,12 +290,16 @@ impl Tui {
 
             Message::TemplatePreview {
                 template,
-                profile_id,
                 on_complete,
             } => {
                 self.render_template_preview(
                     template,
-                    profile_id,
+                    // Note: there's a potential bug here, if the selected
+                    // profile changed since this message was queued. In
+                    // practice is extremely unlikely (potentially impossible),
+                    // and this shortcut saves us a lot of plumbing so it's
+                    // worth it
+                    self.view.selected_profile_id().cloned(),
                     on_complete,
                 )?;
             }

--- a/crates/slumber_tui/src/message.rs
+++ b/crates/slumber_tui/src/message.rs
@@ -122,7 +122,6 @@ pub enum Message {
     /// way back down the component tree.
     TemplatePreview {
         template: Template,
-        profile_id: Option<ProfileId>,
         #[debug(skip)]
         on_complete:
             Box<dyn 'static + Send + Sync + FnOnce(Vec<TemplateChunk>)>,

--- a/crates/slumber_tui/src/view.rs
+++ b/crates/slumber_tui/src/view.rs
@@ -29,7 +29,10 @@ use crate::{
 use anyhow::anyhow;
 use ratatui::Frame;
 use slumber_config::Action;
-use slumber_core::{collection::CollectionFile, db::CollectionDatabase};
+use slumber_core::{
+    collection::{CollectionFile, ProfileId},
+    db::CollectionDatabase,
+};
 use std::{fmt::Debug, sync::Arc};
 use tracing::{error, trace, trace_span};
 
@@ -95,6 +98,11 @@ impl View {
         } else {
             draw_impl(&self.root, frame);
         }
+    }
+
+    /// ID of the selected profile. `None` iff the list is empty
+    pub fn selected_profile_id(&self) -> Option<&ProfileId> {
+        self.root.data().selected_profile_id()
     }
 
     /// Queue an event to update the request state for the given profile+recipe.

--- a/crates/slumber_tui/src/view/common/template_preview.rs
+++ b/crates/slumber_tui/src/view/common/template_preview.rs
@@ -11,7 +11,6 @@ use ratatui::{
     widgets::Widget,
 };
 use slumber_core::{
-    collection::ProfileId,
     http::content_type::ContentType,
     template::{Template, TemplateChunk},
 };
@@ -46,11 +45,7 @@ impl TemplatePreview {
     /// defines which profile to use for the render. Optionally provide content
     /// type to enable syntax highlighting, which will be applied to both
     /// unrendered and rendered content.
-    pub fn new(
-        template: Template,
-        profile_id: Option<ProfileId>,
-        content_type: Option<ContentType>,
-    ) -> Self {
+    pub fn new(template: Template, content_type: Option<ContentType>) -> Self {
         // Calculate raw text
         let text = highlight::highlight_if(
             content_type,
@@ -73,7 +68,6 @@ impl TemplatePreview {
 
             ViewContext::send_message(Message::TemplatePreview {
                 template,
-                profile_id: profile_id.clone(),
                 on_complete: Box::new(on_complete),
             });
         }

--- a/crates/slumber_tui/src/view/component/primary.rs
+++ b/crates/slumber_tui/src/view/component/primary.rs
@@ -146,7 +146,7 @@ impl PrimaryView {
 
     /// ID of the selected profile. `None` iff the list is empty
     pub fn selected_profile_id(&self) -> Option<&ProfileId> {
-        self.profile_pane.data().selected_profile()
+        self.profile_pane.data().selected_profile_id()
     }
 
     /// Draw the "normal" view, when nothing is fullscreened

--- a/crates/slumber_tui/src/view/component/recipe_pane.rs
+++ b/crates/slumber_tui/src/view/component/recipe_pane.rs
@@ -135,10 +135,9 @@ impl<'a> Draw<RecipePaneProps<'a>> for RecipePane {
                     .cloned(),
             },
             || match props.selected_recipe_node {
-                Some(RecipeNode::Recipe(recipe)) => Some(
-                    RecipeDisplay::new(recipe, props.selected_profile_id)
-                        .into(),
-                ),
+                Some(RecipeNode::Recipe(recipe)) => {
+                    Some(RecipeDisplay::new(recipe).into())
+                }
                 Some(RecipeNode::Folder(_)) | None => None,
             },
         );

--- a/crates/slumber_tui/src/view/component/recipe_pane/authentication.rs
+++ b/crates/slumber_tui/src/view/component/recipe_pane/authentication.rs
@@ -21,10 +21,7 @@ use ratatui::{
     Frame,
 };
 use slumber_config::Action;
-use slumber_core::{
-    collection::{Authentication, ProfileId},
-    template::Template,
-};
+use slumber_core::{collection::Authentication, template::Template};
 use strum::{EnumCount, EnumIter};
 
 /// Display authentication settings for a recipe
@@ -32,19 +29,13 @@ use strum::{EnumCount, EnumIter};
 pub struct AuthenticationDisplay {
     state: State,
     overridden: bool,
-    /// Store this to recalculate previews after editing
-    selected_profile_id: Option<ProfileId>,
 }
 
 impl AuthenticationDisplay {
-    pub fn new(
-        authentication: Authentication,
-        selected_profile_id: Option<ProfileId>,
-    ) -> Self {
+    pub fn new(authentication: Authentication) -> Self {
         Self {
-            state: State::new(authentication, selected_profile_id.clone()),
+            state: State::new(authentication),
             overridden: false,
-            selected_profile_id,
         }
     }
 
@@ -101,11 +92,7 @@ impl AuthenticationDisplay {
         else {
             return;
         };
-        let preview = TemplatePreview::new(
-            template.clone(),
-            self.selected_profile_id.clone(),
-            None,
-        );
+        let preview = TemplatePreview::new(template.clone(), None);
         self.overridden = true;
         match &mut self.state {
             State::Basic {
@@ -234,17 +221,9 @@ enum State {
 }
 
 impl State {
-    fn new(
-        authentication: Authentication,
-        selected_profile_id: Option<ProfileId>,
-    ) -> Self {
-        let create_preview = |template: &Template| {
-            TemplatePreview::new(
-                template.clone(),
-                selected_profile_id.clone(),
-                None,
-            )
-        };
+    fn new(authentication: Authentication) -> Self {
+        let create_preview =
+            |template: &Template| TemplatePreview::new(template.clone(), None);
         match authentication {
             Authentication::Basic { username, password } => {
                 let username_preview = create_preview(&username);
@@ -317,10 +296,7 @@ mod tests {
         };
         let mut component = TestComponent::new(
             &terminal,
-            WithModalQueue::new(AuthenticationDisplay::new(
-                authentication,
-                None,
-            )),
+            WithModalQueue::new(AuthenticationDisplay::new(authentication)),
             (),
         );
 
@@ -364,10 +340,7 @@ mod tests {
         };
         let mut component = TestComponent::new(
             &terminal,
-            WithModalQueue::new(AuthenticationDisplay::new(
-                authentication,
-                None,
-            )),
+            WithModalQueue::new(AuthenticationDisplay::new(authentication)),
             (),
         );
 
@@ -391,10 +364,7 @@ mod tests {
         let authentication = Authentication::Bearer("i am a token".into());
         let mut component = TestComponent::new(
             &terminal,
-            WithModalQueue::new(AuthenticationDisplay::new(
-                authentication,
-                None,
-            )),
+            WithModalQueue::new(AuthenticationDisplay::new(authentication)),
             (),
         );
 

--- a/crates/slumber_tui/src/view/component/recipe_pane/body.rs
+++ b/crates/slumber_tui/src/view/component/recipe_pane/body.rs
@@ -11,7 +11,7 @@ use crate::view::{
 use ratatui::Frame;
 use serde::Serialize;
 use slumber_core::{
-    collection::{ProfileId, RecipeBody, RecipeId},
+    collection::{RecipeBody, RecipeId},
     http::content_type::ContentType,
 };
 
@@ -28,16 +28,11 @@ pub enum RecipeBodyDisplay {
 
 impl RecipeBodyDisplay {
     /// Build a component to display the body, based on the body type
-    pub fn new(
-        body: &RecipeBody,
-        selected_profile_id: Option<&ProfileId>,
-        recipe_id: &RecipeId,
-    ) -> Self {
+    pub fn new(body: &RecipeBody, recipe_id: &RecipeId) -> Self {
         match body {
             RecipeBody::Raw(body) => Self::Raw {
                 preview: TemplatePreview::new(
                     body.clone(),
-                    selected_profile_id.cloned(),
                     // Hypothetically we could grab the content type from the
                     // Content-Type header above and plumb it down here, but
                     // more effort than it's worth IMO. This gives users a
@@ -66,7 +61,6 @@ impl RecipeBodyDisplay {
                 Self::Raw {
                     preview: TemplatePreview::new(
                         template,
-                        selected_profile_id.cloned(),
                         Some(ContentType::Json),
                     ),
                     text_window: Component::default(),
@@ -76,7 +70,6 @@ impl RecipeBodyDisplay {
             | RecipeBody::FormMultipart(fields) => {
                 let inner = RecipeFieldTable::new(
                     FormRowKey(recipe_id.clone()),
-                    selected_profile_id.cloned(),
                     fields.iter().map(|(field, value)| {
                         (
                             field.clone(),

--- a/crates/slumber_tui/src/view/component/recipe_pane/recipe.rs
+++ b/crates/slumber_tui/src/view/component/recipe_pane/recipe.rs
@@ -25,7 +25,7 @@ use ratatui::{
 use serde::{Deserialize, Serialize};
 use slumber_config::Action;
 use slumber_core::{
-    collection::{Method, ProfileId, Recipe, RecipeId},
+    collection::{Method, Recipe, RecipeId},
     http::BuildOptions,
 };
 use strum::{EnumCount, EnumIter};
@@ -47,21 +47,13 @@ pub struct RecipeDisplay {
 impl RecipeDisplay {
     /// Initialize new recipe state. Should be called whenever the recipe or
     /// profile changes
-    pub fn new(
-        recipe: &Recipe,
-        selected_profile_id: Option<&ProfileId>,
-    ) -> Self {
+    pub fn new(recipe: &Recipe) -> Self {
         Self {
             tabs: Default::default(),
             method: recipe.method,
-            url: TemplatePreview::new(
-                recipe.url.clone(),
-                selected_profile_id.cloned(),
-                None,
-            ),
+            url: TemplatePreview::new(recipe.url.clone(), None),
             query: RecipeFieldTable::new(
                 QueryRowKey(recipe.id.clone()),
-                selected_profile_id.cloned(),
                 recipe.query.iter().map(|(param, value)| {
                     (
                         param.clone(),
@@ -76,7 +68,6 @@ impl RecipeDisplay {
             .into(),
             headers: RecipeFieldTable::new(
                 HeaderRowKey(recipe.id.clone()),
-                selected_profile_id.cloned(),
                 recipe.headers.iter().map(|(header, value)| {
                     (
                         header.clone(),
@@ -89,18 +80,14 @@ impl RecipeDisplay {
                 }),
             )
             .into(),
-            body: recipe.body.as_ref().map(|body| {
-                RecipeBodyDisplay::new(body, selected_profile_id, &recipe.id)
-                    .into()
-            }),
+            body: recipe
+                .body
+                .as_ref()
+                .map(|body| RecipeBodyDisplay::new(body, &recipe.id).into()),
             // Map authentication type
             authentication: recipe.authentication.as_ref().map(
                 |authentication| {
-                    AuthenticationDisplay::new(
-                        authentication.clone(),
-                        selected_profile_id.cloned(),
-                    )
-                    .into()
+                    AuthenticationDisplay::new(authentication.clone()).into()
                 },
             ),
         }

--- a/crates/slumber_tui/src/view/component/root.rs
+++ b/crates/slumber_tui/src/view/component/root.rs
@@ -23,7 +23,10 @@ use persisted::{PersistedContainer, PersistedKey};
 use ratatui::{layout::Layout, prelude::Constraint, Frame};
 use serde::Serialize;
 use slumber_config::Action;
-use slumber_core::{collection::Collection, http::RequestId};
+use slumber_core::{
+    collection::{Collection, ProfileId},
+    http::RequestId,
+};
 
 /// The root view component
 #[derive(Debug)]
@@ -56,6 +59,11 @@ impl Root {
             modal_queue: Component::default(),
             notification_text: None,
         }
+    }
+
+    /// ID of the selected profile. `None` iff the list is empty
+    pub fn selected_profile_id(&self) -> Option<&ProfileId> {
+        self.primary_view.data().selected_profile_id()
     }
 
     /// Select the given request. This will ensure the request data is loaded


### PR DESCRIPTION

## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

This removes the selected_profile_id field from Message::TemplatePreview, which removes the need to plumb it all over the view. Instead, the main TUI loop will grab the currently selected profile from the view when it starts rendering the preview. 


## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

This *does* introduce the potential for sync bugs, where the selected profile changes between when the preview message is queued and dequeued. In reality that should(?) be impossible, because the TUI drains all messages in the queue between draws. It's theoretically possible is most likely impossible in practice. The consequence is we just show some stale data in the UI so it's not the worst outcome.

## QA

_How did you test this?_

Manual testing in TUI, added some unit tests.

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
