### PR TITLE
Fix body query not applying after request runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Fix Basic auth being label as Bearer auth in Recipe Authentication pane
 - Use correct binding for `search` action in the placeholder of the response filter textbox
   - Previously it was hardcoded to display the default of `/`
+- Fix response body filter not applying on new responses
 
 ## [1.8.1] - 2024-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - Fix Basic auth being label as Bearer auth in Recipe Authentication pane
+- Use correct binding for `search` action in the placeholder of the response filter textbox
+  - Previously it was hardcoded to display the default of `/`
 
 ## [1.8.1] - 2024-08-11
 

--- a/crates/slumber_tui/src/view/component/profile_select.rs
+++ b/crates/slumber_tui/src/view/component/profile_select.rs
@@ -289,7 +289,7 @@ impl<'a> Draw<ProfileDetailProps<'a>> for ProfileDetail {
         // Whenever the selected profile changes, rebuild the internal state.
         // This is needed because the template preview rendering is async.
         let profile_id = props.profile_id;
-        let fields = self.fields.get_or_update(profile_id.clone(), || {
+        let fields = self.fields.get_or_update(profile_id, || {
             let collection = ViewContext::collection();
             let Some(profile_data) = collection
                 .profiles

--- a/crates/slumber_tui/src/view/component/queryable_body.rs
+++ b/crates/slumber_tui/src/view/component/queryable_body.rs
@@ -1,15 +1,18 @@
 //! Request/response body display component
 
-use crate::view::{
-    common::{
-        text_box::TextBox,
-        text_window::{ScrollbarMargins, TextWindow, TextWindowProps},
+use crate::{
+    context::TuiContext,
+    view::{
+        common::{
+            text_box::TextBox,
+            text_window::{ScrollbarMargins, TextWindow, TextWindowProps},
+        },
+        draw::{Draw, DrawMetadata},
+        event::{Event, EventHandler, Update},
+        state::StateCell,
+        util::highlight,
+        Component, ViewContext,
     },
-    draw::{Draw, DrawMetadata},
-    event::{Event, EventHandler, Update},
-    state::StateCell,
-    util::highlight,
-    Component, ViewContext,
 };
 use anyhow::Context;
 use persisted::PersistedContainer;
@@ -64,9 +67,11 @@ impl QueryableBody {
     /// persistence DB. This is optional because not all callers use the query
     /// box, or want to persist the value.
     pub fn new() -> Self {
+        let input_engine = &TuiContext::get().input_engine;
+        let binding = input_engine.binding_display(Action::Search);
+
         let text_box = TextBox::default()
-            // TODO use hint from input engine
-            .placeholder("'/' to filter body with JSONPath")
+            .placeholder(format!("'{binding}' to filter body with JSONPath"))
             .validator(|text| JsonPath::parse(text).is_ok())
             // Callback trigger an events, so we can modify our own state
             .on_click(|| {

--- a/crates/slumber_tui/src/view/component/queryable_body.rs
+++ b/crates/slumber_tui/src/view/component/queryable_body.rs
@@ -65,6 +65,7 @@ impl QueryableBody {
     /// box, or want to persist the value.
     pub fn new() -> Self {
         let text_box = TextBox::default()
+            // TODO use hint from input engine
             .placeholder("'/' to filter body with JSONPath")
             .validator(|text| JsonPath::parse(text).is_ok())
             // Callback trigger an events, so we can modify our own state
@@ -163,7 +164,7 @@ impl<'a> Draw<QueryableBodyProps<'a>> for QueryableBody {
         .areas(metadata.area());
 
         // Draw the body
-        let text = self.filtered_text.get_or_update(self.query.clone(), || {
+        let text = self.filtered_text.get_or_update(&self.query, || {
             init_text(props.content_type, props.body, self.query.as_ref())
         });
         self.text_window.draw(

--- a/crates/slumber_tui/src/view/component/recipe_pane.rs
+++ b/crates/slumber_tui/src/view/component/recipe_pane.rs
@@ -127,7 +127,7 @@ impl<'a> Draw<RecipePaneProps<'a>> for RecipePane {
         // would require reloading the whole collection which will reset
         // UI state.
         let recipe_state = self.recipe_state.get_or_update(
-            RecipeStateKey {
+            &RecipeStateKey {
                 selected_profile_id: props.selected_profile_id.cloned(),
                 recipe_id: props
                     .selected_recipe_node
@@ -165,7 +165,7 @@ impl<'a> Draw<RecipePaneProps<'a>> for RecipePane {
 }
 
 /// Template preview state will be recalculated when any of these fields change
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 struct RecipeStateKey {
     selected_profile_id: Option<ProfileId>,
     recipe_id: Option<RecipeId>,

--- a/crates/slumber_tui/src/view/component/request_view.rs
+++ b/crates/slumber_tui/src/view/component/request_view.rs
@@ -116,7 +116,7 @@ impl Draw<RequestViewProps> for RequestView {
         props: RequestViewProps,
         metadata: DrawMetadata,
     ) {
-        let state = self.state.get_or_update(props.request.id, || State {
+        let state = self.state.get_or_update(&props.request.id, || State {
             request: Arc::clone(&props.request),
             body: init_body(&props.request),
         });

--- a/crates/slumber_tui/src/view/component/response_view.rs
+++ b/crates/slumber_tui/src/view/component/response_view.rs
@@ -144,7 +144,7 @@ impl<'a> Draw<ResponseBodyViewProps<'a>> for ResponseBodyView {
         metadata: DrawMetadata,
     ) {
         let response = &props.response;
-        let state = self.state.get_or_update(props.request_id, || State {
+        let state = self.state.get_or_update(&props.request_id, || State {
             response: Arc::clone(&props.response),
             body: PersistedLazy::new(
                 ResponseQueryPersistedKey(props.recipe_id.clone()),


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

- Fix response query not applying after running request
  - Turns out draws weren't being triggered by events in the queue, just messages.
- Use dynamic binding for hint in query textbox, instead of hardcoding it to `/`
- Reduce unnecessary key clones when using `StateCell`

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

TUI loop logic gets increasingly complex, that can't be good...

## QA

_How did you test this?_

Manually

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
