### PR TITLE
Add `editor` config field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Use correct binding for `search` action in the placeholder of the response filter textbox
   - Previously it was hardcoded to display the default of `/`
 - Fix response body filter not applying on new responses
+- Support quoted arguments in `$VISUAL`/`$EDITOR` commands
 
 ## [1.8.1] - 2024-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Edit recipe values (query params, headers, etc.) in the TUI to provide one-off values
   - Press `e` on any value you want to edit (you can [customize the key](https://slumber.lucaspickering.me/book/api/configuration/input_bindings.html))
+- Add `editor` field to the config, allowing you to customize what editor Slumber opens for in-app editing
+  - [See docs for more](https://slumber.lucaspickering.me/book/api/configuration/editor.html)
+- Use `vim` as default editor if none is configured
 
 ### Fixed
 
@@ -17,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Use correct binding for `search` action in the placeholder of the response filter textbox
   - Previously it was hardcoded to display the default of `/`
 - Fix response body filter not applying on new responses
-- Support quoted arguments in `$VISUAL`/`$EDITOR` commands
+- Support quoted arguments in editor commands
 
 ## [1.8.1] - 2024-08-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,6 +507,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "editor-command"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4b658b46793314d988e0d08442424cb8c4932fc44a9b092b23ad99bf84c829"
+dependencies = [
+ "shellish_parse",
+]
+
+[[package]]
 name = "either"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2059,6 +2068,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
+name = "shellish_parse"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c29b912ad681a28566f37b936bba1f3580a93b9391c4a0b12cb1c6b4ed79973"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2193,7 +2208,7 @@ dependencies = [
  "cli-clipboard",
  "crossterm",
  "derive_more",
- "env-lock",
+ "editor-command",
  "futures",
  "indexmap",
  "itertools 0.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,10 +519,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
-name = "env-guard"
-version = "0.1.0"
+name = "env-lock"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d7deb3aca2fadee5bc4f1024c1ef9426b91c2b718fc98ae04564c0ed0b12d2"
+checksum = "1debf1b50da3e3685ac8afacc10fec00d5d23a78c31e80166a6375b7602f0ba9"
 
 [[package]]
 name = "equivalent"
@@ -2156,7 +2156,7 @@ dependencies = [
  "chrono",
  "derive_more",
  "dirs",
- "env-guard",
+ "env-lock",
  "futures",
  "indexmap",
  "itertools 0.13.0",
@@ -2193,7 +2193,7 @@ dependencies = [
  "cli-clipboard",
  "crossterm",
  "derive_more",
- "env-guard",
+ "env-lock",
  "futures",
  "indexmap",
  "itertools 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ bytes = {version = "1.6.1", default-features = false}
 chrono = {version = "0.4.31", default-features = false}
 crossterm = {version = "0.28.0", default-features = false, features = ["events"]}
 derive_more = {version = "1.0.0", default-features = false}
-env-lock = "0.1.0"
 futures = "0.3.28"
 indexmap = {version = "2.0.0", default-features = false}
 itertools = "0.13.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ bytes = {version = "1.6.1", default-features = false}
 chrono = {version = "0.4.31", default-features = false}
 crossterm = {version = "0.28.0", default-features = false, features = ["events"]}
 derive_more = {version = "1.0.0", default-features = false}
-env-guard = "0.1.0"
+env-lock = "0.1.0"
 futures = "0.3.28"
 indexmap = {version = "2.0.0", default-features = false}
 itertools = "0.13.0"

--- a/crates/slumber_config/src/lib.rs
+++ b/crates/slumber_config/src/lib.rs
@@ -31,6 +31,9 @@ const FILE: &str = "config.yml";
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct Config {
+    /// Command to use for in-app editing. If provided, overrides
+    /// `VISUAL`/`EDITOR` environment variables
+    pub editor: Option<String>,
     /// TLS cert errors on these hostnames are ignored. Be careful!
     pub ignore_certificate_hosts: Vec<String>,
     /// Should templates be rendered inline in the UI, or should we show the
@@ -82,6 +85,7 @@ impl Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
+            editor: None,
             ignore_certificate_hosts: Default::default(),
             preview_templates: true,
             input_bindings: Default::default(),

--- a/crates/slumber_core/Cargo.toml
+++ b/crates/slumber_core/Cargo.toml
@@ -42,7 +42,7 @@ uuid = {workspace = true, features = ["serde", "v4"]}
 winnow = "0.6.16"
 
 [dev-dependencies]
-env-guard = {workspace = true}
+env-lock = {workspace = true}
 pretty_assertions = {workspace = true}
 regex = {version = "1.10.5", default-features = false}
 rstest = {workspace = true}

--- a/crates/slumber_core/Cargo.toml
+++ b/crates/slumber_core/Cargo.toml
@@ -42,7 +42,7 @@ uuid = {workspace = true, features = ["serde", "v4"]}
 winnow = "0.6.16"
 
 [dev-dependencies]
-env-lock = {workspace = true}
+env-lock = "0.1.0"
 pretty_assertions = {workspace = true}
 regex = {version = "1.10.5", default-features = false}
 rstest = {workspace = true}

--- a/crates/slumber_core/src/template.rs
+++ b/crates/slumber_core/src/template.rs
@@ -224,7 +224,6 @@ mod tests {
         },
     };
     use chrono::Utc;
-    use env_guard::EnvGuard;
     use indexmap::indexmap;
     use rstest::rstest;
     use serde_json::json;
@@ -779,7 +778,7 @@ mod tests {
         // This prevents tests from competing for environment variables, and
         // isolates us from the external env
         let result = {
-            let _guard = EnvGuard::lock([("TEST", env_value)]);
+            let _guard = env_lock::lock_env([("TEST", env_value)]);
             render!("{{chains.chain1}}", context)
         };
         assert_eq!(result.unwrap(), expected);
@@ -1095,7 +1094,7 @@ mod tests {
         // This prevents tests from competing for environ environment variables,
         // and isolates us from the external env
         let result = {
-            let _guard = EnvGuard::lock([("TEST", env_value)]);
+            let _guard = env_lock::lock_env([("TEST", env_value)]);
             render!("{{env.TEST}}", context)
         };
         assert_eq!(result.unwrap(), expected);

--- a/crates/slumber_tui/Cargo.toml
+++ b/crates/slumber_tui/Cargo.toml
@@ -16,6 +16,7 @@ chrono = {workspace = true}
 cli-clipboard = "0.4.0"
 crossterm = {workspace = true, features = ["bracketed-paste", "windows", "events", "event-stream"]}
 derive_more = {workspace = true, features = ["debug", "deref", "deref_mut", "display", "from"]}
+editor-command = "0.1.0"
 futures = {workspace = true}
 indexmap = {workspace = true}
 itertools = {workspace = true}
@@ -38,7 +39,6 @@ unicode-width = "0.1.13"
 uuid = {workspace = true}
 
 [dev-dependencies]
-env-lock = {workspace = true}
 pretty_assertions = {workspace = true}
 rstest = {workspace = true}
 slumber_core = {workspace = true, features = ["test"]}

--- a/crates/slumber_tui/Cargo.toml
+++ b/crates/slumber_tui/Cargo.toml
@@ -38,7 +38,7 @@ unicode-width = "0.1.13"
 uuid = {workspace = true}
 
 [dev-dependencies]
-env-guard = {workspace = true}
+env-lock = {workspace = true}
 pretty_assertions = {workspace = true}
 rstest = {workspace = true}
 slumber_core = {workspace = true, features = ["test"]}

--- a/crates/slumber_tui/src/util.rs
+++ b/crates/slumber_tui/src/util.rs
@@ -255,7 +255,6 @@ async fn confirm(messages_tx: &MessageSender, message: impl ToString) -> bool {
 mod tests {
     use super::*;
     use crate::test_util::{harness, TestHarness};
-    use env_guard::EnvGuard;
     use itertools::Itertools;
     use rstest::rstest;
     use slumber_core::{
@@ -285,7 +284,7 @@ mod tests {
         // Make sure we're not competing with the other tests that want to set
         // these env vars
         let command = {
-            let _guard = EnvGuard::lock([
+            let _guard = env_lock::lock_env([
                 ("VISUAL", env_visual),
                 ("EDITOR", env_editor),
             ]);
@@ -311,8 +310,10 @@ mod tests {
         // Make sure we're not competing with the other tests that want to set
         // these env vars
         let result = {
-            let _guard =
-                EnvGuard::lock([("VISUAL", None::<String>), ("EDITOR", None)]);
+            let _guard = env_lock::lock_env([
+                ("VISUAL", None::<String>),
+                ("EDITOR", None),
+            ]);
             get_editor_command(Path::new("file.yml"))
         };
         assert_err!(result, "No editor configured");

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -38,6 +38,7 @@
 - [Configuration](./api/configuration/index.md)
   - [Input Bindings](./api/configuration/input_bindings.md)
   - [Theme](./api/configuration/theme.md)
+  - [In-App Editing](./api/configuration/editor.md)
 
 # Troubleshooting
 

--- a/docs/src/api/configuration/editor.md
+++ b/docs/src/api/configuration/editor.md
@@ -1,0 +1,18 @@
+# In-App Editing
+
+Slumber supports editing your collection file without leaving the app. To do so, open the actions menu (`x` by default), then select `Edit Collection`. Slumber will open an external editor to modify the file. To determine which editor to use, Slumber checks these places in the following order:
+
+- `editor` field of the [configuration file](./index.md)
+- `VISUAL` environment variable
+- `EDITOR` environment variable
+- Default to `vim`
+
+The `VISUAL` and `EDITOR` environment variables are a common standard to define a user's preferred text editor. For example, it's what [git uses by default](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration) to determine how to edit commit messages. If you want to use the same editor for all programs, you should set these. If you want to use a command specific to Slumber, set the `editor` config field.
+
+Slumber supports passing additional arguments to the editor. For example, if you want to open `VSCode` and have wait for the file to be saved, you can configure your editor like so:
+
+```yaml
+editor: code --wait
+```
+
+The command will be parsed like a shell command (although a shell is never actually invoked). For exact details on parsing behavior, see [shellish_parse](https://docs.rs/shellish_parse/latest/shellish_parse/index.html).

--- a/docs/src/api/configuration/index.md
+++ b/docs/src/api/configuration/index.md
@@ -21,10 +21,11 @@ If the root directory doesn't exist yet, you can create it yourself or have Slum
 
 ## Fields
 
-| Field                      | Type                                | Description                                                                                       | Default |
-| -------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------- | ------- |
-| `preview_templates`        | `boolean`                           | Render template values in the TUI? If false, the raw template will be shown.                      | `true`  |
-| `ignore_certificate_hosts` | `string[]`                          | Hostnames whose TLS certificate errors will be ignored. [More info](../../troubleshooting/tls.md) | `[]`    |
-| `input_bindings`           | `mapping[Action, KeyCombination[]]` | Override default input bindings. [More info](./input_bindings.md)                                 | `{}`    |
-| `theme`                    | [`Theme`](./theme.md)               | Visual customizations                                                                             | `{}`    |
-| `debug`                    | `boolean`                           | Enable developer information                                                                      | `false` |
+| Field                      | Type                                | Description                                                                                       | Default                    |
+| -------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------- | -------------------------- |
+| `debug`                    | `boolean`                           | Enable developer information                                                                      | `false`                    |
+| `editor`                   | `string`                            | Command to use when opening files for in-app editing. [More info](./editor.md)                    | `VISUAL`/`EDITOR` env vars |
+| `ignore_certificate_hosts` | `string[]`                          | Hostnames whose TLS certificate errors will be ignored. [More info](../../troubleshooting/tls.md) | `[]`                       |
+| `input_bindings`           | `mapping[Action, KeyCombination[]]` | Override default input bindings. [More info](./input_bindings.md)                                 | `{}`                       |
+| `preview_templates`        | `boolean`                           | Render template values in the TUI? If false, the raw template will be shown.                      | `true`                     |
+| `theme`                    | [`Theme`](./theme.md)               | Visual customizations                                                                             | `{}`                       |


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

- Add `editor` field to the config, to override the `VISUAL`/`EDITOR` variables
- Add `vim` as default editor
- Use new [editor-command](https://github.com/LucasPickering/editor-command) crate for loading editor command
  - This means we now support complex commands with quotes

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Most risk is mitigated by using the crate, which I tested pretty well. Added complexity means more cognitive overhead for the user.

## QA

_How did you test this?_

Manual testing, lots of unit tests in the subcrate.

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
