### PR TITLE
Fix bugs with `PersistedLazy` not saving correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   - Previously it was hardcoded to display the default of `/`
 - Fix response body filter not applying on new responses
 - Support quoted arguments in editor commands
+- Fix certain UI values not persisting correctly
 
 ## [1.8.1] - 2024-08-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,9 +1384,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "persisted"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b864f7c07dfaa7d338ae51e68645c0cc3a854ae30336494577f9b6aa49c1c089"
+checksum = "dc99f0d02a8bf234e45d51304c97edfdbc5d49cffde9380da5bc41e3ca93bbf7"
 dependencies = [
  "derive_more",
  "persisted_derive",
@@ -1395,9 +1395,9 @@ dependencies = [
 
 [[package]]
 name = "persisted_derive"
-version = "0.1.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9cc105f327f85b3d3be328bea742a6817b6776fa4c87760664244a905bb578b"
+checksum = "ef115d443975f882ec890bc76199ebe6ba04f53f4830e061bbc562c56b7579b8"
 dependencies = [
  "quote",
  "syn 2.0.65",

--- a/crates/slumber_tui/Cargo.toml
+++ b/crates/slumber_tui/Cargo.toml
@@ -21,7 +21,7 @@ futures = {workspace = true}
 indexmap = {workspace = true}
 itertools = {workspace = true}
 notify = {version = "6.1.1", default-features = false, features = ["macos_fsevent"]}
-persisted = {version = "0.2.2", features = ["serde"]}
+persisted = {version = "0.3.0", features = ["serde"]}
 ratatui = {workspace = true, features = ["crossterm", "underline-color", "unstable-widget-ref"]}
 reqwest = {workspace = true}
 serde = {workspace = true}

--- a/crates/slumber_tui/src/util.rs
+++ b/crates/slumber_tui/src/util.rs
@@ -4,7 +4,6 @@ use crate::{
     view::Confirm,
 };
 use anyhow::Context;
-use derive_more::DerefMut;
 use editor_command::EditorBuilder;
 use futures::{future, FutureExt};
 use slumber_core::{
@@ -13,7 +12,6 @@ use slumber_core::{
 };
 use std::{
     io,
-    ops::Deref,
     path::{Path, PathBuf},
     process::Command,
 };
@@ -41,48 +39,6 @@ where
                 None
             }
         }
-    }
-}
-
-/// A value that can be replaced in-place. This is useful for two purposes:
-/// - Transferring ownership of values from old to new
-/// - Dropping the old value before creating the new one
-///
-/// This struct has one invariant: The value is always defined, *except* while
-/// the replacement closure is executing. Better make sure that guy doesn't
-/// panic!
-#[derive(Debug)]
-pub struct Replaceable<T>(Option<T>);
-
-impl<T> Replaceable<T> {
-    pub fn new(value: T) -> Self {
-        Self(Some(value))
-    }
-
-    /// Replace the old value with the new one. The function that generates the
-    /// new value consumes the old one.
-    ///
-    /// The only time this value will panic on access is while the passed
-    /// closure is executing (or during unwind if it panicked).
-    pub fn replace(&mut self, f: impl FnOnce(T) -> T) {
-        let old = self.0.take().expect("Replaceable value not present!");
-        self.0 = Some(f(old));
-    }
-}
-
-/// Access the inner value. If mid-replacement, this will panic
-impl<T> Deref for Replaceable<T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        self.0.as_ref().expect("Replacement in progress or failed")
-    }
-}
-
-/// Access the inner value. If mid-replacement, this will panic
-impl<T> DerefMut for Replaceable<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.0.as_mut().expect("Replacement in progress or failed")
     }
 }
 

--- a/crates/slumber_tui/src/view/common/actions.rs
+++ b/crates/slumber_tui/src/view/common/actions.rs
@@ -2,7 +2,7 @@ use crate::view::{
     common::{list::List, modal::Modal},
     component::Component,
     draw::{Draw, DrawMetadata, Generate},
-    event::{Event, EventHandler},
+    event::{Child, Event, EventHandler},
     state::fixed_select::{FixedSelect, FixedSelectState},
     ViewContext,
 };
@@ -63,8 +63,8 @@ where
 }
 
 impl<T: FixedSelect> EventHandler for ActionsModal<T> {
-    fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {
-        vec![self.actions.as_child()]
+    fn children(&mut self) -> Vec<Component<Child<'_>>> {
+        vec![self.actions.to_child_mut()]
     }
 }
 

--- a/crates/slumber_tui/src/view/common/tabs.rs
+++ b/crates/slumber_tui/src/view/common/tabs.rs
@@ -55,11 +55,11 @@ where
 {
     type Value = T;
 
-    fn get_persisted(&self) -> Self::Value {
-        self.tabs.get_persisted()
+    fn get_to_persist(&self) -> Self::Value {
+        self.tabs.get_to_persist()
     }
 
-    fn set_persisted(&mut self, value: Self::Value) {
-        self.tabs.set_persisted(value)
+    fn restore_persisted(&mut self, value: Self::Value) {
+        self.tabs.restore_persisted(value)
     }
 }

--- a/crates/slumber_tui/src/view/common/text_box.rs
+++ b/crates/slumber_tui/src/view/common/text_box.rs
@@ -320,11 +320,11 @@ impl TextState {
 impl PersistedContainer for TextBox {
     type Value = String;
 
-    fn get_persisted(&self) -> Self::Value {
+    fn get_to_persist(&self) -> Self::Value {
         self.state.text.clone()
     }
 
-    fn set_persisted(&mut self, value: Self::Value) {
+    fn restore_persisted(&mut self, value: Self::Value) {
         self.set_text(value);
     }
 }

--- a/crates/slumber_tui/src/view/component/exchange_pane.rs
+++ b/crates/slumber_tui/src/view/component/exchange_pane.rs
@@ -13,7 +13,7 @@ use crate::{
         },
         context::PersistedLazy,
         draw::{Draw, DrawMetadata, Generate},
-        event::{Event, EventHandler, Update},
+        event::{Child, Event, EventHandler, Update},
         RequestState, ViewContext,
     },
 };
@@ -85,12 +85,12 @@ impl EventHandler for ExchangePane {
         Update::Consumed
     }
 
-    fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {
+    fn children(&mut self) -> Vec<Component<Child<'_>>> {
         vec![
-            self.request.as_child(),
-            self.response_body.as_child(),
+            self.request.to_child_mut(),
+            self.response_body.to_child_mut(),
             // Tabs last so the children get priority
-            self.tabs.as_child(),
+            self.tabs.to_child_mut(),
         ]
     }
 }

--- a/crates/slumber_tui/src/view/component/history.rs
+++ b/crates/slumber_tui/src/view/component/history.rs
@@ -5,7 +5,7 @@ use crate::{
         common::{list::List, modal::Modal},
         component::Component,
         draw::{Draw, DrawMetadata, Generate},
-        event::{Event, EventHandler},
+        event::{Child, Event, EventHandler},
         state::{select::SelectState, RequestStateSummary},
         ViewContext,
     },
@@ -76,8 +76,8 @@ impl Modal for History {
 }
 
 impl EventHandler for History {
-    fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {
-        vec![self.select.as_child()]
+    fn children(&mut self) -> Vec<Component<Child<'_>>> {
+        vec![self.select.to_child_mut()]
     }
 }
 

--- a/crates/slumber_tui/src/view/component/misc.rs
+++ b/crates/slumber_tui/src/view/component/misc.rs
@@ -9,7 +9,7 @@ use crate::view::{
     },
     component::Component,
     draw::{Draw, DrawMetadata, Generate},
-    event::{Event, EventHandler, Update},
+    event::{Child, Event, EventHandler, Update},
     state::Notification,
     Confirm, ModalPriority, ViewContext,
 };
@@ -126,8 +126,8 @@ impl Modal for TextBoxModal {
 }
 
 impl EventHandler for TextBoxModal {
-    fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {
-        vec![self.text_box.as_child()]
+    fn children(&mut self) -> Vec<Component<Child<'_>>> {
+        vec![self.text_box.to_child_mut()]
     }
 }
 
@@ -216,8 +216,8 @@ impl EventHandler for ConfirmModal {
         Update::Consumed
     }
 
-    fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {
-        vec![self.buttons.as_child()]
+    fn children(&mut self) -> Vec<Component<Child<'_>>> {
+        vec![self.buttons.to_child_mut()]
     }
 }
 

--- a/crates/slumber_tui/src/view/component/profile_select.rs
+++ b/crates/slumber_tui/src/view/component/profile_select.rs
@@ -10,7 +10,7 @@ use crate::{
         },
         context::Persisted,
         draw::{Draw, DrawMetadata, Generate},
-        event::{Event, EventHandler, Update},
+        event::{Child, Event, EventHandler, Update},
         state::{select::SelectState, StateCell},
         Component, ViewContext,
     },
@@ -61,7 +61,7 @@ impl ProfilePane {
         match &*selected_profile_id {
             Some(id) if profiles.contains_key(id) => {}
             _ => {
-                *selected_profile_id.borrow_mut() =
+                *selected_profile_id.get_mut() =
                     profiles.first().map(|(id, _)| id.clone())
             }
         }
@@ -89,7 +89,7 @@ impl EventHandler for ProfilePane {
             self.open_modal();
         } else if let Some(SelectProfile(profile_id)) = event.local() {
             // Handle message from the modal
-            *self.selected_profile_id.borrow_mut() = Some(profile_id.clone());
+            *self.selected_profile_id.get_mut() = Some(profile_id.clone());
             // Refresh template previews
             ViewContext::push_event(Event::HttpSelectRequest(None));
         } else {
@@ -180,8 +180,8 @@ impl Modal for ProfileListModal {
 }
 
 impl EventHandler for ProfileListModal {
-    fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {
-        vec![self.select.as_child()]
+    fn children(&mut self) -> Vec<Component<Child<'_>>> {
+        vec![self.select.to_child_mut()]
     }
 }
 

--- a/crates/slumber_tui/src/view/component/queryable_body.rs
+++ b/crates/slumber_tui/src/view/component/queryable_body.rs
@@ -8,7 +8,7 @@ use crate::{
             text_window::{ScrollbarMargins, TextWindow, TextWindowProps},
         },
         draw::{Draw, DrawMetadata},
-        event::{Event, EventHandler, Update},
+        event::{Child, Event, EventHandler, Update},
         state::StateCell,
         util::highlight,
         Component, ViewContext,
@@ -146,8 +146,11 @@ impl EventHandler for QueryableBody {
         Update::Consumed
     }
 
-    fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {
-        vec![self.query_text_box.as_child(), self.text_window.as_child()]
+    fn children(&mut self) -> Vec<Component<Child<'_>>> {
+        vec![
+            self.query_text_box.to_child_mut(),
+            self.text_window.to_child_mut(),
+        ]
     }
 }
 
@@ -196,12 +199,12 @@ impl<'a> Draw<QueryableBodyProps<'a>> for QueryableBody {
 impl PersistedContainer for QueryableBody {
     type Value = String;
 
-    fn get_persisted(&self) -> Self::Value {
-        self.query_text_box.data().get_persisted()
+    fn get_to_persist(&self) -> Self::Value {
+        self.query_text_box.data().get_to_persist()
     }
 
-    fn set_persisted(&mut self, value: Self::Value) {
-        self.query_text_box.data_mut().set_persisted(value)
+    fn restore_persisted(&mut self, value: Self::Value) {
+        self.query_text_box.data_mut().restore_persisted(value)
     }
 }
 

--- a/crates/slumber_tui/src/view/component/recipe_list.rs
+++ b/crates/slumber_tui/src/view/component/recipe_list.rs
@@ -5,7 +5,7 @@ use crate::{
         component::{primary::PrimaryPane, recipe_pane::RecipeMenuAction},
         context::{Persisted, PersistedLazy},
         draw::{Draw, DrawMetadata, Generate},
-        event::{Event, EventHandler, Update},
+        event::{Child, Event, EventHandler, Update},
         state::select::SelectState,
         Component, ViewContext,
     },
@@ -89,17 +89,15 @@ impl RecipeListPane {
         let changed = if let Some(folder) = folder {
             let collapsed = &mut self.collapsed;
             match state {
-                CollapseState::Expand => {
-                    collapsed.borrow_mut().remove(&folder.id)
-                }
+                CollapseState::Expand => collapsed.get_mut().remove(&folder.id),
                 CollapseState::Collapse => {
-                    collapsed.borrow_mut().insert(folder.id.clone())
+                    collapsed.get_mut().insert(folder.id.clone())
                 }
                 CollapseState::Toggle => {
                     if collapsed.contains(&folder.id) {
-                        collapsed.borrow_mut().remove(&folder.id);
+                        collapsed.get_mut().remove(&folder.id);
                     } else {
-                        collapsed.borrow_mut().insert(folder.id.clone());
+                        collapsed.get_mut().insert(folder.id.clone());
                     }
                     true
                 }
@@ -118,7 +116,7 @@ impl RecipeListPane {
             if let Some(selected) = select.selected() {
                 new_select_state.select(selected.id());
             }
-            **select = new_select_state;
+            *select.get_mut() = new_select_state;
         }
 
         changed
@@ -173,8 +171,8 @@ impl EventHandler for RecipeListPane {
         Update::Consumed
     }
 
-    fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {
-        vec![self.select.as_child()]
+    fn children(&mut self) -> Vec<Component<Child<'_>>> {
+        vec![self.select.to_child_mut()]
     }
 }
 

--- a/crates/slumber_tui/src/view/component/recipe_pane.rs
+++ b/crates/slumber_tui/src/view/component/recipe_pane.rs
@@ -10,7 +10,7 @@ use crate::{
         common::{actions::ActionsModal, Pane},
         component::{primary::PrimaryPane, recipe_pane::recipe::RecipeDisplay},
         draw::{Draw, DrawMetadata, Generate, ToStringGenerate},
-        event::{Event, EventHandler, Update},
+        event::{Child, Event, EventHandler, Update},
         state::StateCell,
         Component, ViewContext,
     },
@@ -89,10 +89,10 @@ impl EventHandler for RecipePane {
         Update::Consumed
     }
 
-    fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {
+    fn children(&mut self) -> Vec<Component<Child<'_>>> {
         self.recipe_state
             .get_mut()
-            .and_then(|state| Some(state.as_mut()?.as_child()))
+            .and_then(|state| Some(state.as_mut()?.to_child_mut()))
             .into_iter()
             .collect()
     }

--- a/crates/slumber_tui/src/view/component/recipe_pane/authentication.rs
+++ b/crates/slumber_tui/src/view/component/recipe_pane/authentication.rs
@@ -7,7 +7,7 @@ use crate::{
         },
         component::{misc::TextBoxModal, Component},
         draw::{Draw, DrawMetadata, Generate},
-        event::{Event, EventHandler, Update},
+        event::{Child, Event, EventHandler, Update},
         state::fixed_select::FixedSelectState,
         ViewContext,
     },
@@ -137,10 +137,10 @@ impl EventHandler for AuthenticationDisplay {
         Update::Consumed
     }
 
-    fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {
+    fn children(&mut self) -> Vec<Component<Child<'_>>> {
         match &mut self.state {
             State::Basic { selected_field, .. } => {
-                vec![selected_field.as_child()]
+                vec![selected_field.to_child_mut()]
             }
             State::Bearer { .. } => vec![],
         }

--- a/crates/slumber_tui/src/view/component/recipe_pane/body.rs
+++ b/crates/slumber_tui/src/view/component/recipe_pane/body.rs
@@ -5,7 +5,7 @@ use crate::view::{
     },
     component::recipe_pane::table::{RecipeFieldTable, RecipeFieldTableProps},
     draw::{Draw, DrawMetadata},
-    event::EventHandler,
+    event::{Child, EventHandler},
     Component,
 };
 use ratatui::Frame;
@@ -88,12 +88,12 @@ impl RecipeBodyDisplay {
 }
 
 impl EventHandler for RecipeBodyDisplay {
-    fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {
+    fn children(&mut self) -> Vec<Component<Child<'_>>> {
         match self {
             RecipeBodyDisplay::Raw { text_window, .. } => {
-                vec![text_window.as_child()]
+                vec![text_window.to_child_mut()]
             }
-            RecipeBodyDisplay::Form(form) => vec![form.as_child()],
+            RecipeBodyDisplay::Form(form) => vec![form.to_child_mut()],
         }
     }
 }

--- a/crates/slumber_tui/src/view/component/recipe_pane/recipe.rs
+++ b/crates/slumber_tui/src/view/component/recipe_pane/recipe.rs
@@ -9,7 +9,7 @@ use crate::{
         },
         context::PersistedLazy,
         draw::{Draw, DrawMetadata},
-        event::EventHandler,
+        event::{Child, EventHandler},
         Component,
     },
 };
@@ -125,13 +125,13 @@ impl RecipeDisplay {
 }
 
 impl EventHandler for RecipeDisplay {
-    fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {
+    fn children(&mut self) -> Vec<Component<Child<'_>>> {
         [
-            Some(self.tabs.as_child()),
-            self.body.as_mut().map(Component::as_child),
-            Some(self.query.as_child()),
-            Some(self.headers.as_child()),
-            self.authentication.as_mut().map(Component::as_child),
+            Some(self.tabs.to_child_mut()),
+            self.body.as_mut().map(Component::to_child_mut),
+            Some(self.query.to_child_mut()),
+            Some(self.headers.to_child_mut()),
+            self.authentication.as_mut().map(Component::to_child_mut),
         ]
         .into_iter()
         .flatten()

--- a/crates/slumber_tui/src/view/component/recipe_pane/table.rs
+++ b/crates/slumber_tui/src/view/component/recipe_pane/table.rs
@@ -10,7 +10,7 @@ use crate::{
         component::{misc::TextBoxModal, Component},
         context::{Persisted, PersistedKey, PersistedLazy},
         draw::{Draw, DrawMetadata, Generate},
-        event::{Event, EventHandler, Update},
+        event::{Child, Event, EventHandler, Update},
         state::select::SelectState,
         ViewContext,
     },
@@ -110,7 +110,7 @@ where
             // because it shouldn't be possible to change the selection while
             // the edit modal is open. It's safer to re-grab the modal by index
             // though, just to be sure we've got the right one.
-            self.select.data_mut().items_mut()[*row_index]
+            self.select.data_mut().get_mut().items_mut()[*row_index]
                 .value
                 .set_override(value);
         } else {
@@ -119,8 +119,8 @@ where
         Update::Consumed
     }
 
-    fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {
-        vec![self.select.as_child()]
+    fn children(&mut self) -> Vec<Component<Child<'_>>> {
+        vec![self.select.to_child_mut()]
     }
 }
 
@@ -212,7 +212,7 @@ impl<K: PersistedKey<Value = bool>> Generate for &RowState<K> {
 
 impl<K: PersistedKey<Value = bool>> RowState<K> {
     fn toggle(&mut self) {
-        *self.enabled.borrow_mut() ^= true;
+        *self.enabled.get_mut() ^= true;
     }
 
     /// Open a modal to create or edit the value's temporary override

--- a/crates/slumber_tui/src/view/component/request_view.rs
+++ b/crates/slumber_tui/src/view/component/request_view.rs
@@ -7,7 +7,7 @@ use crate::{
             text_window::{TextWindow, TextWindowProps},
         },
         draw::{Draw, DrawMetadata, Generate, ToStringGenerate},
-        event::{Event, EventHandler, Update},
+        event::{Child, Event, EventHandler, Update},
         state::StateCell,
         util::highlight,
         Component, ViewContext,
@@ -104,8 +104,8 @@ impl EventHandler for RequestView {
         Update::Consumed
     }
 
-    fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {
-        vec![self.body_text_window.as_child()]
+    fn children(&mut self) -> Vec<Component<Child<'_>>> {
+        vec![self.body_text_window.to_child_mut()]
     }
 }
 

--- a/crates/slumber_tui/src/view/component/response_view.rs
+++ b/crates/slumber_tui/src/view/component/response_view.rs
@@ -7,7 +7,7 @@ use crate::{
         component::queryable_body::{QueryableBody, QueryableBodyProps},
         context::PersistedLazy,
         draw::{Draw, DrawMetadata, Generate, ToStringGenerate},
-        event::{Event, EventHandler, Update},
+        event::{Child, Event, EventHandler, Update},
         state::StateCell,
         Component, ViewContext,
     },
@@ -127,9 +127,9 @@ impl EventHandler for ResponseBodyView {
         Update::Consumed
     }
 
-    fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {
+    fn children(&mut self) -> Vec<Component<Child<'_>>> {
         if let Some(state) = self.state.get_mut() {
-            vec![state.body.as_child()]
+            vec![state.body.to_child_mut()]
         } else {
             vec![]
         }

--- a/crates/slumber_tui/src/view/context.rs
+++ b/crates/slumber_tui/src/view/context.rs
@@ -146,6 +146,10 @@ pub type Persisted<K> = persisted::Persisted<ViewContext, K>;
 /// Wrapper for [persisted::PersistedLazy] bound to our store
 pub type PersistedLazy<K, C> = persisted::PersistedLazy<ViewContext, K, C>;
 
+/// Wrapper for [persisted::PersistedLazyRefMut] bound to our store
+pub type PersistedLazyRefMut<'a, K, C> =
+    persisted::PersistedLazyRefMut<'a, ViewContext, K, C>;
+
 /// Persist UI state via the database. We have to be able to serialize keys to
 /// insert and lookup. We have to serialize values to insert, and deserialize
 /// them to retrieve.

--- a/crates/slumber_tui/src/view/state/fixed_select.rs
+++ b/crates/slumber_tui/src/view/state/fixed_select.rs
@@ -201,11 +201,11 @@ where
 {
     type Value = Item;
 
-    fn get_persisted(&self) -> Self::Value {
+    fn get_to_persist(&self) -> Self::Value {
         self.selected()
     }
 
-    fn set_persisted(&mut self, value: Self::Value) {
+    fn restore_persisted(&mut self, value: Self::Value) {
         // This will call the on_select callback if the item is in the list
         self.select(&value);
     }

--- a/crates/slumber_tui/src/view/state/select.rs
+++ b/crates/slumber_tui/src/view/state/select.rs
@@ -374,11 +374,11 @@ where
 {
     type Value = Option<Item::Id>;
 
-    fn get_persisted(&self) -> Self::Value {
+    fn get_to_persist(&self) -> Self::Value {
         self.selected().map(Item::id).cloned()
     }
 
-    fn set_persisted(&mut self, value: Self::Value) {
+    fn restore_persisted(&mut self, value: Self::Value) {
         // If we persisted `None`, we *don't* want to update state here. That
         // means the list was empty before persisting and it may now have data,
         // and we don't want to overwrite whatever was pre-selected

--- a/crates/slumber_tui/src/view/test_util.rs
+++ b/crates/slumber_tui/src/view/test_util.rs
@@ -8,7 +8,7 @@ use crate::{
         component::Component,
         context::ViewContext,
         draw::{Draw, DrawMetadata},
-        event::{Event, EventHandler, Update},
+        event::{Child, Event, EventHandler, ToChild, Update},
     },
 };
 use crossterm::event::{
@@ -37,7 +37,7 @@ pub struct TestComponent<'term, T, Props> {
 impl<'term, Props, T> TestComponent<'term, T, Props>
 where
     Props: Clone,
-    T: Draw<Props> + EventHandler,
+    T: Draw<Props> + ToChild,
 {
     /// Create a new component, then draw it to the screen and drain the event
     /// queue. Components aren't useful until they've been drawn once, because
@@ -243,8 +243,8 @@ impl<T> WithModalQueue<T> {
 }
 
 impl<T: EventHandler> EventHandler for WithModalQueue<T> {
-    fn children(&mut self) -> Vec<Component<&mut dyn EventHandler>> {
-        vec![self.modal_queue.as_child(), self.inner.as_child()]
+    fn children(&mut self) -> Vec<Component<Child<'_>>> {
+        vec![self.modal_queue.to_child_mut(), self.inner.to_child_mut()]
     }
 }
 


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

- Upgrade `persisted` to 0.3.0
  - This required some refactoring to handle the new save-on-mutate behavior of PersistedLazy. This fixes some bugs around PersistedLazy with values getting out of sync, due to new values being created before old ones are dropped.
- Remove `Replaceable`
  - Not needed now that values are persisted immediately, rather than only on drop

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

- Adds more complexity to the event handling code
- Potential performance impact from persisting more often. Mitigated by an `==` check that makes sure we only persist when the value has actually changed

## QA

_How did you test this?_

Existing tests cover some persistence use cases. Also tested manually in TUI

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
