### PR TITLE
Propagate unconsumed key events in TextBox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Fix response body filter not applying on new responses
 - Support quoted arguments in editor commands
 - Fix certain UI values not persisting correctly
+- Propgated unconsumed key events from text boxes
+  - E.g. F5 will now refresh the collection while a text box is in focus
 
 ## [1.8.1] - 2024-08-11
 

--- a/crates/slumber_tui/src/view/test_util.rs
+++ b/crates/slumber_tui/src/view/test_util.rs
@@ -220,6 +220,11 @@ impl PropagatedEvents {
             self.0
         )
     }
+
+    /// Get propgated events as a slice
+    pub fn events(&self) -> &[Event] {
+        &self.0
+    }
 }
 
 /// A wrapper component to pair a component with a modal queue. Useful when the


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

F5 in a text box now does F5 things

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

People may not want F5 to do F5 things

## QA

_How did you test this?_

F5

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
