### PR TITLE
[BREAKING] Don't deduplicate backslashes during parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Breaking
+
+- Backslashes are no longer deduplicated during template parsing, except when immediately preceding a key open
+  - For example, previously `\\text` would parse as `\text`. It now parses as `\\text`
+  - Previously you could also write `\text`, and it would parse as `\text`. That behavior remains the same
+  - The goal of this change is to make backslash behavior more transparent and consistent
+  - For more info on the new behavior, [see the docs](https://slumber.lucaspickering.me/book/api/request_collection/template.html#escape-sequences)
+
 ### Added
 
 - Edit recipe values (query params, headers, etc.) in the TUI to provide one-off values

--- a/docs/src/api/request_collection/template.md
+++ b/docs/src/api/request_collection/template.md
@@ -22,17 +22,19 @@ In some scenarios you may want to use the `{{` sequence to represent those liter
 
 ```
 \{{this is raw text}}
+# Parses as ["\{{this is raw text}}"]
 ```
 
 If you want to represent a literal backslash before a template key, you can escape the backslash:
 
 ```
 \\{{field1}}
+# Parses as ["\", field("field1")]
 ```
 
-> Note: YAML also uses `\` as its escape character, meaning you'll need to double all backslashes: the firs to escape in YAML, the second to escape in Slumber.
+> Note: YAML also uses `\` as its escape character, meaning you'll need to double all backslashes: the first to escape in YAML, the second to escape in Slumber.
 
-Any other backslash (i.e. any backslash not followed by another backslash or `{{`) is treated literally.
+Any other backslash (i.e. any backslash not followed by another backslash or `{{`) is treated literally. **This is different from backslash behavior in most languages**. In most syntaxes, backslashes are _always_ part of an escape sequence, and literal backslashes need to be doubled up. In Slumber however, backslashes are just regular characters _except_ in these sequences `\{{` and `\\{{`. The reason for this is to eliminate the need to double all backslashes _in addition_ to the doubling already required by YAML. This allows you to write normal strings and have them parse as standard YAML, without having to think about the fact that Slumber is adding an additional layer of template parsing in the middle. In other words, this syntax is _intentionally_ esoteric, to prevent iterfering with nested syntax.
 
 ## Examples
 


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

The old backslash syntax meant raw:template syntax wasn't 1:1. It was possible to write two different strings that parsed to the same template. This means mapping back to strings wasn't necessarily an identical round trip. The new syntax is a breaking change, but will probably not affect most users, and should be an improvement for those who are impacted.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Breaking change obviously requires 2.0. This could break templates for some people, because they will start getting more backslashes in their recipes than previously. Mitigated by documenting the change in the changelog, and the new behavior in the docs.

## QA

_How did you test this?_

Added/updated unit tests

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
