### PR TITLE
Remove complicated JSON body logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   - [See docs for more](https://slumber.lucaspickering.me/book/api/configuration/editor.html)
 - Use `vim` as default editor if none is configured
 
+### Changed
+
+- `!json` bodies are now prettified when sent to the server
+
 ### Fixed
 
 - Fix Basic auth being label as Bearer auth in Recipe Authentication pane

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,17 +128,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-recursion"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.65",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2165,7 +2154,6 @@ version = "1.8.1"
 dependencies = [
  "aho-corasick",
  "anyhow",
- "async-recursion",
  "async-trait",
  "bytes",
  "chrono",

--- a/crates/slumber_core/Cargo.toml
+++ b/crates/slumber_core/Cargo.toml
@@ -13,7 +13,6 @@ version = "1.8.1"
 [dependencies]
 aho-corasick = "1.0.0"
 anyhow = "1.0.0"
-async-recursion = "1.1.1"
 async-trait = "0.1.81"
 bytes = {workspace = true, features = ["serde"]}
 chrono = {workspace = true, features = ["clock", "serde", "std"]}

--- a/crates/slumber_core/src/collection.rs
+++ b/crates/slumber_core/src/collection.rs
@@ -462,11 +462,12 @@ mod tests {
                     method: Method::Post,
                     url: "{{host}}/anything/login".into(),
 
-                    body: Some(RecipeBody::Raw(
-                        "{\"username\": \"{{username}}\", \
+                    body: Some(RecipeBody::Raw {
+                        body: "{\"username\": \"{{username}}\", \
                         \"password\": \"{{chains.password}}\"}"
                             .into(),
-                    )),
+                        content_type: None,
+                    }),
                     authentication: None,
                     query: vec![
                         ("sudo".into(), "yes_please".into()),
@@ -498,12 +499,11 @@ mod tests {
                             name: Some("Modify User".into()),
                             method: Method::Put,
                             url: "{{host}}/anything/{{user_guid}}".into(),
-                            body: Some(RecipeBody::Json(
-                                json!({
-                                    "username": "new username"
-                                })
-                                .into(),
-                            )),
+                            body: Some(RecipeBody::Raw {
+                                body: json!({"username": "new username"})
+                                    .into(),
+                                content_type: Some(ContentType::Json),
+                            }),
                             authentication: Some(Authentication::Bearer(
                                 "{{chains.auth_token}}".into(),
                             )),
@@ -518,9 +518,11 @@ mod tests {
                             method: Method::Put,
                             url: "{{host}}/anything/{{user_guid}}".into(),
 
-                            body: Some(RecipeBody::Json(
-                                json!(r#"{"warning": "NOT an object"}"#).into(),
-                            )),
+                            body: Some(RecipeBody::Raw {
+                                body: json!(r#"{"warning": "NOT an object"}"#)
+                                    .into(),
+                                content_type: Some(ContentType::Json),
+                            }),
                             authentication: Some(Authentication::Basic {
                                 username: "{{username}}".into(),
                                 password: Some("{{password}}".into()),

--- a/crates/slumber_core/src/http/content_type.rs
+++ b/crates/slumber_core/src/http/content_type.rs
@@ -53,6 +53,13 @@ impl ContentType {
         }
     }
 
+    /// Get the MIME for this content type
+    pub fn to_mime(&self) -> Mime {
+        match self {
+            ContentType::Json => mime::APPLICATION_JSON,
+        }
+    }
+
     /// Guess content type from a file path based on its extension
     pub fn from_path(path: &Path) -> anyhow::Result<Self> {
         let extension = path

--- a/crates/slumber_core/src/template.rs
+++ b/crates/slumber_core/src/template.rs
@@ -103,6 +103,13 @@ impl From<String> for Template {
     }
 }
 
+#[cfg(any(test, feature = "test"))]
+impl From<serde_json::Value> for Template {
+    fn from(value: serde_json::Value) -> Self {
+        format!("{value:#}").into()
+    }
+}
+
 /// An identifier that can be used in a template key. A valid identifier is
 /// any non-empty string that contains only alphanumeric characters, `-`, or
 /// `_`.

--- a/crates/slumber_tui/src/view/component/primary.rs
+++ b/crates/slumber_tui/src/view/component/primary.rs
@@ -438,7 +438,7 @@ mod tests {
     ) -> TestComponent<'term, PrimaryView, PrimaryViewProps<'static>> {
         let view = PrimaryView::new(&harness.collection);
         let component = TestComponent::new(
-            &terminal,
+            terminal,
             view,
             PrimaryViewProps {
                 selected_request: None,

--- a/crates/slumber_tui/src/view/component/profile_select.rs
+++ b/crates/slumber_tui/src/view/component/profile_select.rs
@@ -345,7 +345,7 @@ mod tests {
         #[case] persisted_id: Option<&str>,
         #[case] expected: Option<&str>,
     ) {
-        let profiles = by_id(profile_ids.into_iter().map(|&id| Profile {
+        let profiles = by_id(profile_ids.iter().map(|&id| Profile {
             id: id.into(),
             ..Profile::factory(())
         }));

--- a/test_data/insomnia.json
+++ b/test_data/insomnia.json
@@ -124,7 +124,7 @@
       "method": "POST",
       "body": {
         "mimeType": "application/json",
-        "text": "{\n\t\"message\": \"hello!\"\n}"
+        "text": "{\n  \"message\": \"hello!\"\n}"
       },
       "preRequestScript": "",
       "parameters": [],


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Stringifying JSON bodies during deserialization instead during the draw/request build phases eliminates a ton of grungy logic. It'll also make it easier to make bodies editable.

The only user-facing change here is that we now prettify JSON bodies during deserialization instead of just during the draw, meaning we'll now start sending pretty bodies in requests. This should make the behavior more predictable, because what's send matches what's shown in the Recipe pane. This is reflected in several test changes.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

- Sending larger bodies over the wire. In the future we could add a flag to disable this prettification

## QA

_How did you test this?_

Updated unit tests

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
