### PR TITLE
Make raw recipe bodies editable

### DIFF
--- a/crates/slumber_core/src/collection/models.rs
+++ b/crates/slumber_core/src/collection/models.rs
@@ -302,7 +302,7 @@ pub enum Authentication<T = Template> {
 /// uses the variant to determine not only how to serialize the body, but also
 /// other parameters of the request (e.g. the `Content-Type` header).
 #[derive(Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(any(test, feature = "test"), derive(PartialEq))]
 pub enum RecipeBody {
     /// Plain string/bytes body
     Raw {
@@ -329,7 +329,7 @@ impl RecipeBody {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test"))]
 impl From<&str> for RecipeBody {
     fn from(template: &str) -> Self {
         Self::Raw {

--- a/crates/slumber_core/src/http/models.rs
+++ b/crates/slumber_core/src/http/models.rs
@@ -4,7 +4,7 @@
 //! exchange is incomplete or failed.
 
 use crate::{
-    collection::{Authentication, ProfileId, RecipeId},
+    collection::{Authentication, ProfileId, RecipeBody, RecipeId},
     http::{
         cereal,
         content_type::{ContentType, ResponseContent},
@@ -93,7 +93,7 @@ impl RequestSeed {
 /// These store *indexes* rather than keys because keys may not be necessarily
 /// unique (e.g. in the case of query params). Technically some could use keys
 /// and some could use indexes, but I chose consistency.
-#[derive(Clone, Debug, Default)]
+#[derive(Debug, Default)]
 #[cfg_attr(any(test, feature = "test"), derive(PartialEq))]
 pub struct BuildOptions {
     /// Authentication can be overridden, but not disabled. For simplicity,
@@ -102,11 +102,14 @@ pub struct BuildOptions {
     pub headers: BuildFieldOverrides,
     pub query_parameters: BuildFieldOverrides,
     pub form_fields: BuildFieldOverrides,
+    /// Override body. This should *not* be used for form bodies, since those
+    /// can be override on a field-by-field basis.
+    pub body: Option<RecipeBody>,
 }
 
 /// A collection of modifications made to a particular section of a recipe
 /// (query params, headers, etc.). See [BuildFieldOverride]
-#[derive(Clone, Debug, Default)]
+#[derive(Debug, Default)]
 #[cfg_attr(any(test, feature = "test"), derive(PartialEq))]
 pub struct BuildFieldOverrides {
     overrides: HashMap<usize, BuildFieldOverride>,
@@ -141,7 +144,7 @@ impl FromIterator<(usize, BuildFieldOverride)> for BuildFieldOverrides {
 
 /// Modifications made to a single field (query param, header, etc.) in a
 /// recipe
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 #[cfg_attr(any(test, feature = "test"), derive(PartialEq))]
 pub enum BuildFieldOverride {
     /// Do not include this field in the recipe

--- a/crates/slumber_core/src/template.rs
+++ b/crates/slumber_core/src/template.rs
@@ -130,7 +130,7 @@ impl From<serde_json::Value> for Template {
 pub struct Identifier(String);
 
 /// A shortcut for creating identifiers from static strings. Since the string
-/// is static we know it must be valid; panic if not.
+/// is defined in code we're assuming it's valid.
 impl From<&'static str> for Identifier {
     fn from(value: &'static str) -> Self {
         Self(value.parse().unwrap())

--- a/crates/slumber_tui/src/view/common/template_preview.rs
+++ b/crates/slumber_tui/src/view/common/template_preview.rs
@@ -96,6 +96,12 @@ impl TemplatePreview {
     }
 }
 
+impl From<Template> for TemplatePreview {
+    fn from(template: Template) -> Self {
+        Self::new(template, None)
+    }
+}
+
 /// Clone internal text. Only call this for small pieces of text
 impl Generate for &TemplatePreview {
     type Output<'this> =  Text<'this>

--- a/crates/slumber_tui/src/view/common/text_window.rs
+++ b/crates/slumber_tui/src/view/common/text_window.rs
@@ -43,6 +43,8 @@ pub struct TextWindowProps<'a> {
     /// Text to render. We take a reference because this component tends to
     /// contain a lot of text, and we don't want to force a clone on render
     pub text: &'a Text<'a>,
+    /// Extra text to render below the text window
+    pub footer: Option<Text<'a>>,
     pub margins: ScrollbarMargins,
 }
 
@@ -216,6 +218,25 @@ impl<'a> Draw<TextWindowProps<'a>> for TextWindow {
         // Draw the text content
         self.render_chars(props.text, frame.buffer_mut(), text_area);
 
+        // Render the footer just below the text. If the text has maxed out the
+        // possible area, this will render beyond that. A bit hacky but in
+        // practice it works
+        if let Some(footer) = props.footer {
+            frame.render_widget(
+                footer,
+                Rect {
+                    x: text_area.x,
+                    y: text_area.y
+                        + (cmp::min(
+                            self.text_height.get(),
+                            self.window_height.get(),
+                        )) as u16,
+                    width: text_area.width,
+                    height: 1,
+                },
+            );
+        }
+
         // Scrollbars
         if has_vertical_scroll {
             frame.render_widget(
@@ -273,6 +294,7 @@ mod tests {
                     right: 0,
                     bottom: 0,
                 },
+                footer: None,
             },
         );
         terminal.assert_buffer_lines([
@@ -355,6 +377,7 @@ mod tests {
                     right: 0,
                     bottom: 0,
                 },
+                footer: None,
             },
         );
         terminal.assert_buffer_lines([
@@ -380,6 +403,7 @@ mod tests {
                     right: 0,
                     bottom: 0,
                 },
+                footer: None,
             },
         );
         terminal.assert_buffer_lines([

--- a/crates/slumber_tui/src/view/component/queryable_body.rs
+++ b/crates/slumber_tui/src/view/component/queryable_body.rs
@@ -183,6 +183,7 @@ impl<'a> Draw<QueryableBodyProps<'a>> for QueryableBody {
                     bottom: 2, // Extra margin to jump over the search box
                     ..Default::default()
                 },
+                footer: None,
             },
             body_area,
             true,

--- a/crates/slumber_tui/src/view/component/recipe_pane/authentication.rs
+++ b/crates/slumber_tui/src/view/component/recipe_pane/authentication.rs
@@ -76,7 +76,9 @@ impl AuthenticationDisplay {
                 .validator(|value| value.parse::<Template>().is_ok()),
             |value| {
                 // Defer the state update into an event, so it can get &mut
-                ViewContext::push_event(Event::new_local(SaveOverride(value)))
+                ViewContext::push_event(Event::new_local(
+                    SaveAuthenticationOverride(value),
+                ))
             },
         ))
     }
@@ -129,7 +131,7 @@ impl EventHandler for AuthenticationDisplay {
     fn update(&mut self, event: Event) -> Update {
         if let Some(Action::Edit) = event.action() {
             self.open_edit_modal();
-        } else if let Some(SaveOverride(value)) = event.local() {
+        } else if let Some(SaveAuthenticationOverride(value)) = event.local() {
             self.set_override(value);
         } else {
             return Update::Propagate(event);
@@ -276,7 +278,7 @@ enum BasicFields {
 /// modal. These will be raw string values, consumer has to parse them to
 /// templates.
 #[derive(Debug)]
-struct SaveOverride(String);
+struct SaveAuthenticationOverride(String);
 
 #[cfg(test)]
 mod tests {

--- a/crates/slumber_tui/src/view/component/recipe_pane/recipe.rs
+++ b/crates/slumber_tui/src/view/component/recipe_pane/recipe.rs
@@ -103,18 +103,23 @@ impl RecipeDisplay {
             .body
             .as_ref()
             .and_then(|body| match body.data() {
-                RecipeBodyDisplay::Raw { .. } => None,
+                RecipeBodyDisplay::Raw(_) => None,
                 RecipeBodyDisplay::Form(form) => {
                     Some(form.data().to_build_overrides())
                 }
             })
             .unwrap_or_default();
+        let body = self
+            .body
+            .as_ref()
+            .and_then(|body| body.data().override_value());
 
         BuildOptions {
             authentication,
             headers: self.headers.data().to_build_overrides(),
             query_parameters: self.query.data().to_build_overrides(),
             form_fields,
+            body,
         }
     }
 

--- a/crates/slumber_tui/src/view/component/recipe_pane/table.rs
+++ b/crates/slumber_tui/src/view/component/recipe_pane/table.rs
@@ -105,7 +105,9 @@ where
                 selected_row.open_edit_modal();
             }
             // Consume the event even if we have no rows, for consistency
-        } else if let Some(SaveOverride { row_index, value }) = event.local() {
+        } else if let Some(SaveRecipeTableOverride { row_index, value }) =
+            event.local()
+        {
             // The row we're modifying *should* still be the selected row,
             // because it shouldn't be possible to change the selection while
             // the edit modal is open. It's safer to re-grab the modal by index
@@ -226,10 +228,12 @@ impl<K: PersistedKey<Value = bool>> RowState<K> {
                 .validator(|value| value.parse::<Template>().is_ok()),
             move |value| {
                 // Defer the state update into an event, so it can get &mut
-                ViewContext::push_event(Event::new_local(SaveOverride {
-                    row_index: index,
-                    value,
-                }))
+                ViewContext::push_event(Event::new_local(
+                    SaveRecipeTableOverride {
+                        row_index: index,
+                        value,
+                    },
+                ))
             },
         ));
     }
@@ -286,7 +290,7 @@ where
 /// Local event to modify a row's override template. Triggered from the edit
 /// modal
 #[derive(Debug)]
-struct SaveOverride {
+struct SaveRecipeTableOverride {
     row_index: usize,
     value: String,
 }

--- a/crates/slumber_tui/src/view/component/request_view.rs
+++ b/crates/slumber_tui/src/view/component/request_view.rs
@@ -144,6 +144,7 @@ impl Draw<RequestViewProps> for RequestView {
                 TextWindowProps {
                     text: body,
                     margins: Default::default(),
+                    footer: None,
                 },
                 body_area,
                 true,

--- a/crates/slumber_tui/src/view/test_util.rs
+++ b/crates/slumber_tui/src/view/test_util.rs
@@ -92,7 +92,7 @@ where
     /// Drain events from the event queue, and handle them one-by-one. Return
     /// the events that were propagated (i.e. not consumed by the component or
     /// its children), in the order they were queued/handled.
-    fn drain_events(&mut self) -> PropagatedEvents {
+    pub fn drain_events(&mut self) -> PropagatedEvents {
         // Safety check, prevent annoying bugs
         assert!(
             self.component.is_visible(),


### PR DESCRIPTION

## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Since bodies can be large, we provide editability through the external editor instead of the inline text box. 

![editable](https://github.com/user-attachments/assets/1cc39872-e7f8-4544-9a1f-93b2dd7190cc)


## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Currently the entire body is read back from the file and stored in memory. It'd be possible to store the override as a text diff from the original, but probably not worth it. We'd still have to (1) read the entire new body from the file and (2) parse it as a template. Once those two things are done, keeping the new template around in memory isn't that expensive.

Performance of cloning bodies multiple times.

## QA

_How did you test this?_

Unit tests, manual testing in TUI

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
