### PR TITLE
[BREAKING] Use underscores for escaping keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Breaking
 
-- Backslashes are no longer deduplicated during template parsing, except when immediately preceding a key open
-  - For example, previously `\\text` would parse as `\text`. It now parses as `\\text`
-  - Previously you could also write `\text`, and it would parse as `\text`. That behavior remains the same
-  - The goal of this change is to make backslash behavior more transparent and consistent
+- Replace backslash escape sequence with a simpler scheme based on `_`
+  - For example, previously a key would be escaped as `\{{`. This introduced complexities around how to handle additional backslashes, and also required doubling up backslashes in YAML
+  - The new equivalent would be `{_{`, which parses as `{{`
+  - The goal of this change is to make escaping behavior simpler and more consistent
   - For more info on the new behavior, [see the docs](https://slumber.lucaspickering.me/book/api/request_collection/template.html#escape-sequences)
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,6 +178,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1053,6 +1068,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1241,6 +1262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1466,6 +1488,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.5.0",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "proptest-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ff7ff745a347b87471d859a377a9a404361e7efc2a971d73424a6d183c0fc77"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.65",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quinn"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1548,6 +1607,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -1865,6 +1933,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2166,6 +2246,8 @@ dependencies = [
  "mime",
  "openapiv3",
  "pretty_assertions",
+ "proptest",
+ "proptest-derive",
  "regex",
  "reqwest",
  "rmp-serde",
@@ -2551,6 +2633,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2659,6 +2747,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2232,7 +2232,6 @@ dependencies = [
 name = "slumber_core"
 version = "1.8.1"
 dependencies = [
- "aho-corasick",
  "anyhow",
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ slumber_config = {path = "./crates/slumber_config", version = "1.8.1" }
 slumber_core = {path = "./crates/slumber_core", version = "1.8.1" }
 slumber_tui = {path = "./crates/slumber_tui", version = "1.8.1" }
 strum = {version = "0.26.3", default-features = false}
-thiserror = "1.0.63"
 tokio = {version = "1.39.2", default-features = false}
 tracing = "0.1.40"
 uuid = {version = "1.10.0", default-features = false}

--- a/crates/slumber_core/Cargo.toml
+++ b/crates/slumber_core/Cargo.toml
@@ -11,7 +11,6 @@ version = "1.8.1"
 # Rely on parent for rust-version
 
 [dependencies]
-aho-corasick = "1.0.0"
 anyhow = "1.0.0"
 async-trait = "0.1.81"
 bytes = {workspace = true, features = ["serde"]}
@@ -23,6 +22,7 @@ indexmap = {workspace = true, features = ["serde"]}
 itertools = {workspace = true}
 mime = "0.3.17"
 openapiv3 = "2.0.0"
+regex = {version = "1.10.5", default-features = false}
 reqwest = {workspace = true, features = ["multipart", "rustls-tls", "rustls-tls-native-roots"]}
 rmp-serde = "1.1.2"
 rstest = {workspace = true, optional = true}
@@ -45,7 +45,6 @@ env-lock = "0.1.0"
 pretty_assertions = {workspace = true}
 proptest = "1.5.0"
 proptest-derive = "0.5.0"
-regex = {version = "1.10.5", default-features = false}
 rstest = {workspace = true}
 serde_test = {workspace = true}
 wiremock = {version = "0.6.1", default-features = false}

--- a/crates/slumber_core/Cargo.toml
+++ b/crates/slumber_core/Cargo.toml
@@ -43,6 +43,8 @@ winnow = "0.6.16"
 [dev-dependencies]
 env-lock = "0.1.0"
 pretty_assertions = {workspace = true}
+proptest = "1.5.0"
+proptest-derive = "0.5.0"
 regex = {version = "1.10.5", default-features = false}
 rstest = {workspace = true}
 serde_test = {workspace = true}

--- a/crates/slumber_core/proptest-regressions/template/parse.txt
+++ b/crates/slumber_core/proptest-regressions/template/parse.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 5da7cbd1d4c1191c7ecb571e3d1ac8b73e4bfda8b8f8024a5b0fe74636c049aa # shrinks to template = Template { chunks: [Raw("{"), Key(Field(Identifier("a")))] }
+cc 54c67ac2c41a41eae30d6b5d2527db9dcff8067404394b666a7c0ad0ae619cb4 # shrinks to template = Template { chunks: [Raw("\\{"), Key(Field(Identifier("_")))] }

--- a/crates/slumber_core/proptest-regressions/template/parse.txt
+++ b/crates/slumber_core/proptest-regressions/template/parse.txt
@@ -6,3 +6,4 @@
 # everyone who runs the test benefits from these saved cases.
 cc 5da7cbd1d4c1191c7ecb571e3d1ac8b73e4bfda8b8f8024a5b0fe74636c049aa # shrinks to template = Template { chunks: [Raw("{"), Key(Field(Identifier("a")))] }
 cc 54c67ac2c41a41eae30d6b5d2527db9dcff8067404394b666a7c0ad0ae619cb4 # shrinks to template = Template { chunks: [Raw("\\{"), Key(Field(Identifier("_")))] }
+cc 118b4b0567516b0ca07967894b8be053da5ed0cbe03ceca967ae411e12e305bc # shrinks to template = Template { chunks: [Raw("{{{")] }

--- a/crates/slumber_core/src/collection/models.rs
+++ b/crates/slumber_core/src/collection/models.rs
@@ -380,6 +380,7 @@ pub struct Chain {
     Serialize,
     Deserialize,
 )]
+#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct ChainId(#[deref(forward)] Identifier);
 
 impl<T: Into<Identifier>> From<T> for ChainId {

--- a/crates/slumber_core/src/template.rs
+++ b/crates/slumber_core/src/template.rs
@@ -1,5 +1,6 @@
 //! Generate strings (and bytes) from user-written templates with dynamic data
 
+mod cereal;
 mod error;
 mod parse;
 mod prompt;
@@ -1229,7 +1230,7 @@ mod tests {
     async fn test_render_escaped() {
         let context =
             profile_context(indexmap! { "user_id".into() => "user1".into() });
-        let template = r#"user: {{user_id}} escaped: \{{user_id}}"#;
+        let template = "user: {{user_id}} escaped: {_{user_id}}";
         assert_eq!(
             render!(template, context).unwrap(),
             "user: user1 escaped: {{user_id}}"

--- a/crates/slumber_core/src/template/cereal.rs
+++ b/crates/slumber_core/src/template/cereal.rs
@@ -1,0 +1,89 @@
+use crate::template::Template;
+use serde::{
+    de::{Error, Visitor},
+    Deserialize, Deserializer, Serialize,
+};
+
+impl Serialize for Template {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.display().serialize(serializer)
+    }
+}
+
+// Custom deserializer for `Template`. This is useful for deserializing values
+// that are not strings, but should be treated as strings such as numbers,
+// booleans, and nulls.
+impl<'de> Deserialize<'de> for Template {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct TemplateVisitor;
+
+        macro_rules! visit_primitive {
+            ($func:ident, $type:ty) => {
+                fn $func<E>(self, v: $type) -> Result<Self::Value, E>
+                where
+                    E: Error,
+                {
+                    self.visit_string(v.to_string())
+                }
+            };
+        }
+
+        impl<'de> Visitor<'de> for TemplateVisitor {
+            type Value = Template;
+
+            fn expecting(
+                &self,
+                formatter: &mut std::fmt::Formatter,
+            ) -> std::fmt::Result {
+                formatter.write_str("string, number, or boolean")
+            }
+
+            visit_primitive!(visit_bool, bool);
+            visit_primitive!(visit_u64, u64);
+            visit_primitive!(visit_i64, i64);
+            visit_primitive!(visit_f64, f64);
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                v.parse().map_err(E::custom)
+            }
+        }
+
+        deserializer.deserialize_any(TemplateVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+    use serde_test::{assert_de_tokens, Token};
+
+    /// Test deserialization, which has some additional logic on top of parsing
+    #[rstest]
+    // boolean
+    #[case::bool_true(Token::Bool(true), "true")]
+    #[case::bool_false(Token::Bool(false), "false")]
+    // numeric
+    #[case::u64(Token::U64(1000), "1000")]
+    #[case::i64_negative(Token::I64(-1000), "-1000")]
+    #[case::float_positive(Token::F64(10.1), "10.1")]
+    #[case::float_negative(Token::F64(-10.1), "-10.1")]
+    // string
+    #[case::str(Token::Str("hello"), "hello")]
+    #[case::str_null(Token::Str("null"), "null")]
+    #[case::str_true(Token::Str("true"), "true")]
+    #[case::str_false(Token::Str("false"), "false")]
+    #[case::str_with_keys(Token::Str("{{user_id}}"), "{{user_id}}")]
+    fn test_deserialize(#[case] token: Token, #[case] expected: &str) {
+        assert_de_tokens(&Template::from(expected), &[token]);
+    }
+}

--- a/docs/src/api/request_collection/template.md
+++ b/docs/src/api/request_collection/template.md
@@ -18,23 +18,14 @@ There are several ways of sourcing templating values:
 
 ## Escape Sequences
 
-In some scenarios you may want to use the `{{` sequence to represent those literal characters, rather than the start of a template key. To achieve this, you can escape the sequence with a backslash `\`.
+In some scenarios you may want to use the `{{` sequence to represent those literal characters, rather than the start of a template key. To achieve this, you can escape the sequence with an underscore inside it, e.g. `{_{`. If you want the literal string `{_{`, then add an extra underscore: `{__{`.
 
-```
-\{{this is raw text}}
-# Parses as ["\{{this is raw text}}"]
-```
-
-If you want to represent a literal backslash before a template key, you can escape the backslash:
-
-```
-\\{{field1}}
-# Parses as ["\", field("field1")]
-```
-
-> Note: YAML also uses `\` as its escape character, meaning you'll need to double all backslashes: the first to escape in YAML, the second to escape in Slumber.
-
-Any other backslash (i.e. any backslash not followed by another backslash or `{{`) is treated literally. **This is different from backslash behavior in most languages**. In most syntaxes, backslashes are _always_ part of an escape sequence, and literal backslashes need to be doubled up. In Slumber however, backslashes are just regular characters _except_ in these sequences `\{{` and `\\{{`. The reason for this is to eliminate the need to double all backslashes _in addition_ to the doubling already required by YAML. This allows you to write normal strings and have them parse as standard YAML, without having to think about the fact that Slumber is adding an additional layer of template parsing in the middle. In other words, this syntax is _intentionally_ esoteric, to prevent iterfering with nested syntax.
+| Template                | Parses as                  |
+| ----------------------- | -------------------------- |
+| `{_{this is raw text}}` | `["{{this is raw text}}"]` |
+| `{_{{field1}}`          | `["{", field("field1")]`   |
+| `{__{{field1}}`         | `["{__", field("field1")]` |
+| `{_`                    | `["{_"]` (no escaping)     |
 
 ## Examples
 
@@ -55,8 +46,5 @@ Any other backslash (i.e. any backslash not followed by another backslash or `{{
 "hello, world!"
 ---
 # Escaped template key
-"\\{{this is raw text}}"
----
-# Escaped backslash
-"\\\\{{location}}"
+"{_{this is raw text}}"
 ```


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

In the process of adding prop tests for parsing, I discovered a number of bugs in the `\`-based escape behavior. After fucking around with it for a while I decided to just go with an entirely simpler scheme, based on `_`. If you want a `{` in a raw string, and it's followed by another `{` (where the second is either also in the raw string, or the start of a key), just put a `_` in between them. If you want `{_{`, do `{__{`. Underscores all the way down.

This also includes prop tests for the parse-display round trip.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

This is a breaking change, as noted in the changelog. I plan to release 2.0 soon. It should impact a pretty small number of users (I can't imagine many people, if any, were using the escape behavior to begin with). After the release, risk should be pretty low since this is a much simpler scheme than the previous one, and is well tested with prop tests now.

## QA

_How did you test this?_

- Added more unit test cases
- Added prop tests

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
