### PR TITLE
Persist recipe body edits

### DIFF
--- a/crates/slumber_tui/src/view/common/text_window.rs
+++ b/crates/slumber_tui/src/view/common/text_window.rs
@@ -21,7 +21,7 @@ use unicode_width::UnicodeWidthStr;
 
 /// A scrollable (but not editable) block of text. Internal state will be
 /// updated on each render, to adjust to the text's width/height. Generally the
-/// parent should be storing an instant of [Text] and passing the same value to
+/// parent should be storing an instance of [Text] and passing the same value to
 /// this on each render. Generating the `Text` could potentially be expensive
 /// (especially if it includes syntax highlighting).
 #[derive(derive_more::Debug, Default)]

--- a/crates/slumber_tui/src/view/component/exchange_pane.rs
+++ b/crates/slumber_tui/src/view/component/exchange_pane.rs
@@ -11,9 +11,9 @@ use crate::{
             },
             Component,
         },
-        context::PersistedLazy,
         draw::{Draw, DrawMetadata, Generate},
         event::{Child, Event, EventHandler, Update},
+        util::persistence::PersistedLazy,
         RequestState, ViewContext,
     },
 };

--- a/crates/slumber_tui/src/view/component/primary.rs
+++ b/crates/slumber_tui/src/view/component/primary.rs
@@ -12,10 +12,10 @@ use crate::{
             recipe_list::RecipeListPane,
             recipe_pane::{RecipeMenuAction, RecipePane, RecipePaneProps},
         },
-        context::{Persisted, PersistedLazy},
         draw::{Draw, DrawMetadata, ToStringGenerate},
         event::{Child, Event, EventHandler, Update},
         state::{fixed_select::FixedSelectState, RequestState},
+        util::persistence::{Persisted, PersistedLazy},
         Component, ViewContext,
     },
 };

--- a/crates/slumber_tui/src/view/component/profile_select.rs
+++ b/crates/slumber_tui/src/view/component/profile_select.rs
@@ -8,10 +8,10 @@ use crate::{
             list::List, modal::Modal, table::Table,
             template_preview::TemplatePreview, Pane,
         },
-        context::Persisted,
         draw::{Draw, DrawMetadata, Generate},
         event::{Child, Event, EventHandler, Update},
         state::{select::SelectState, StateCell},
+        util::persistence::Persisted,
         Component, ViewContext,
     },
 };

--- a/crates/slumber_tui/src/view/component/queryable_body.rs
+++ b/crates/slumber_tui/src/view/component/queryable_body.rs
@@ -248,7 +248,7 @@ mod tests {
     use crate::{
         context::TuiContext,
         test_util::{harness, terminal, TestHarness, TestTerminal},
-        view::{context::PersistedLazy, test_util::TestComponent},
+        view::{test_util::TestComponent, util::persistence::PersistedLazy},
     };
     use crossterm::event::KeyCode;
     use persisted::{PersistedKey, PersistedStore};

--- a/crates/slumber_tui/src/view/component/recipe_list.rs
+++ b/crates/slumber_tui/src/view/component/recipe_list.rs
@@ -3,10 +3,10 @@ use crate::{
     view::{
         common::{actions::ActionsModal, list::List, Pane},
         component::{primary::PrimaryPane, recipe_pane::RecipeMenuAction},
-        context::{Persisted, PersistedLazy},
         draw::{Draw, DrawMetadata, Generate},
         event::{Child, Event, EventHandler, Update},
         state::select::SelectState,
+        util::persistence::{Persisted, PersistedLazy},
         Component, ViewContext,
     },
 };

--- a/crates/slumber_tui/src/view/component/recipe_pane/recipe.rs
+++ b/crates/slumber_tui/src/view/component/recipe_pane/recipe.rs
@@ -7,9 +7,9 @@ use crate::{
             body::RecipeBodyDisplay,
             table::{RecipeFieldTable, RecipeFieldTableProps},
         },
-        context::PersistedLazy,
         draw::{Draw, DrawMetadata},
         event::{Child, EventHandler},
+        util::persistence::PersistedLazy,
         Component,
     },
 };
@@ -80,10 +80,9 @@ impl RecipeDisplay {
                 }),
             )
             .into(),
-            body: recipe
-                .body
-                .as_ref()
-                .map(|body| RecipeBodyDisplay::new(body, &recipe.id).into()),
+            body: recipe.body.as_ref().map(|body| {
+                RecipeBodyDisplay::new(body, recipe.id.clone()).into()
+            }),
             // Map authentication type
             authentication: recipe.authentication.as_ref().map(
                 |authentication| {

--- a/crates/slumber_tui/src/view/component/recipe_pane/table.rs
+++ b/crates/slumber_tui/src/view/component/recipe_pane/table.rs
@@ -8,10 +8,10 @@ use crate::{
             text_box::TextBox,
         },
         component::{misc::TextBoxModal, Component},
-        context::{Persisted, PersistedKey, PersistedLazy},
         draw::{Draw, DrawMetadata, Generate},
         event::{Child, Event, EventHandler, Update},
         state::select::SelectState,
+        util::persistence::{Persisted, PersistedKey, PersistedLazy},
         ViewContext,
     },
 };

--- a/crates/slumber_tui/src/view/component/response_view.rs
+++ b/crates/slumber_tui/src/view/component/response_view.rs
@@ -5,10 +5,10 @@ use crate::{
     view::{
         common::{actions::ActionsModal, header_table::HeaderTable},
         component::queryable_body::{QueryableBody, QueryableBodyProps},
-        context::PersistedLazy,
         draw::{Draw, DrawMetadata, Generate, ToStringGenerate},
         event::{Child, Event, EventHandler, Update},
         state::StateCell,
+        util::persistence::PersistedLazy,
         Component, ViewContext,
     },
 };

--- a/crates/slumber_tui/src/view/component/root.rs
+++ b/crates/slumber_tui/src/view/component/root.rs
@@ -9,12 +9,12 @@ use crate::{
             misc::NotificationText,
             primary::{PrimaryView, PrimaryViewProps},
         },
-        context::PersistedLazy,
         draw::{Draw, DrawMetadata, Generate},
         event::{Child, Event, EventHandler, Update},
         state::{
             request_store::RequestStore, RequestState, RequestStateSummary,
         },
+        util::persistence::PersistedLazy,
         Component, ViewContext,
     },
 };

--- a/crates/slumber_tui/src/view/state/select.rs
+++ b/crates/slumber_tui/src/view/state/select.rs
@@ -443,7 +443,10 @@ mod tests {
     use super::*;
     use crate::{
         test_util::{harness, terminal, TestHarness, TestTerminal},
-        view::{context::PersistedLazy, test_util::TestComponent, ViewContext},
+        view::{
+            test_util::TestComponent, util::persistence::PersistedLazy,
+            ViewContext,
+        },
     };
     use crossterm::event::KeyCode;
     use persisted::{PersistedKey, PersistedStore};

--- a/crates/slumber_tui/src/view/test_util.rs
+++ b/crates/slumber_tui/src/view/test_util.rs
@@ -92,7 +92,7 @@ where
     /// Drain events from the event queue, and handle them one-by-one. Return
     /// the events that were propagated (i.e. not consumed by the component or
     /// its children), in the order they were queued/handled.
-    pub fn drain_events(&mut self) -> PropagatedEvents {
+    fn drain_events(&mut self) -> PropagatedEvents {
         // Safety check, prevent annoying bugs
         assert!(
             self.component.is_visible(),
@@ -107,6 +107,18 @@ where
             }
         }
         PropagatedEvents(propagated)
+    }
+
+    /// Drain all events in the queue, then draw the component to the terminal.
+    ///
+    /// This similar to [update_draw](Self::update_draw), but doesn't require
+    /// you to queue a new event first. This is helpful in the rare occasions
+    /// where the UI needs to respond to some asyncronous event, such as a
+    /// callback that would normally be called by the main loop.
+    pub fn drain_draw(&mut self) -> PropagatedEvents {
+        let propagated = self.drain_events();
+        self.draw(None);
+        propagated
     }
 
     /// Put an event on the event queue, handle **all** events in the queue,
@@ -134,9 +146,7 @@ where
             )
         });
         ViewContext::push_event(event);
-        let propagated = self.drain_events();
-        self.draw(None);
-        propagated
+        self.drain_draw()
     }
 
     /// Push a terminal input event onto the event queue, then drain events and

--- a/crates/slumber_tui/src/view/util.rs
+++ b/crates/slumber_tui/src/view/util.rs
@@ -1,6 +1,7 @@
 //! Helper structs and functions for building components
 
 pub mod highlight;
+pub mod persistence;
 
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use slumber_core::template::{Prompt, PromptChannel, Prompter};

--- a/crates/slumber_tui/src/view/util/persistence.rs
+++ b/crates/slumber_tui/src/view/util/persistence.rs
@@ -1,0 +1,103 @@
+//! Implementation of the [persisted] crate for UI data
+
+use crate::view::ViewContext;
+use persisted::PersistedStore;
+use serde::{de::DeserializeOwned, Serialize};
+use slumber_core::{collection::RecipeId, template::Template};
+use std::{collections::HashMap, fmt::Debug};
+use tracing::debug;
+
+/// Wrapper for [persisted::PersistedKey] that applies additional bounds
+/// necessary for our store
+pub trait PersistedKey: Debug + Serialize + persisted::PersistedKey {}
+impl<T: Debug + Serialize + persisted::PersistedKey> PersistedKey for T {}
+
+/// Wrapper for [persisted::Persisted] bound to our store
+pub type Persisted<K> = persisted::Persisted<ViewContext, K>;
+
+/// Wrapper for [persisted::PersistedLazy] bound to our store
+pub type PersistedLazy<K, C> = persisted::PersistedLazy<ViewContext, K, C>;
+
+/// Persist UI state via the database. We have to be able to serialize keys to
+/// insert and lookup. We have to serialize values to insert, and deserialize
+/// them to retrieve.
+impl<K> PersistedStore<K> for ViewContext
+where
+    K: PersistedKey,
+    K::Value: Debug + Serialize + DeserializeOwned,
+{
+    fn load_persisted(key: &K) -> Option<K::Value> {
+        Self::with_database(|database| database.get_ui(K::type_name(), key))
+            // Error is already traced in the DB, nothing to do with it here
+            .ok()
+            .flatten()
+    }
+
+    fn store_persisted(key: &K, value: &K::Value) {
+        Self::with_database(|database| {
+            database.set_ui(K::type_name(), key, value)
+        })
+        // Error is already traced in the DB, nothing to do with it here
+        .ok();
+    }
+}
+
+/// Special single-session [PersistedStore] just for edited recipe templates.
+/// We don't want to store recipe overrides across sessions, because they could
+/// be very large and conflict with changes in the recipe. Using a dedicated
+/// type for this makes the generic bounds stricter which is nice.
+///
+/// To persist something in this store, you probably want to implement
+/// [PersistedContainer](persisted::PersistedContainer) for your component/state
+/// field.
+#[derive(Debug, Default)]
+pub struct RecipeOverrideStore(HashMap<RecipeOverrideKey, Template>);
+
+impl PersistedStore<RecipeOverrideKey> for RecipeOverrideStore {
+    fn load_persisted(key: &RecipeOverrideKey) -> Option<RecipeOverrideValue> {
+        if let Some(template) =
+            ViewContext::with_override_store(|store| store.0.get(key).cloned())
+        {
+            // Only overridden values are persisted
+            debug!(?key, ?template, "Loaded persisted recipe override");
+            Some(RecipeOverrideValue::Override(template))
+        } else {
+            None
+        }
+    }
+
+    fn store_persisted(key: &RecipeOverrideKey, value: &RecipeOverrideValue) {
+        // The value will be None if the template isn't overridden, in which
+        // case we don't want to store it
+        if let RecipeOverrideValue::Override(template) = value {
+            debug!(?key, ?template, "Persisting recipe override");
+            ViewContext::with_override_store_mut(|store| {
+                store.0.insert(key.clone(), template.clone());
+            })
+        }
+    }
+}
+
+/// An override value that may be persisted in the store
+#[derive(Debug, PartialEq)]
+pub enum RecipeOverrideValue {
+    /// Default recipe value is in use, i.e. no override is present. Nothing
+    /// will be persisted
+    Default,
+    /// User has provided an override for this field, persist it
+    Override(Template),
+}
+
+/// Helper for some piece of the recipe UI that supports overriding and persists
+/// its overrides to [RecipeOverrideStore]
+pub type RecipeOverrideContainer<T> =
+    persisted::PersistedLazy<RecipeOverrideStore, RecipeOverrideKey, T>;
+
+/// Persisted key for anything that goes in [RecipeOverrideStore]. This uniquely
+/// identifies any piece of a recipe that can be overridden.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, persisted::PersistedKey)]
+#[persisted(RecipeOverrideValue)]
+pub enum RecipeOverrideKey {
+    /// Overridden body for a particular recipe
+    Body { recipe_id: RecipeId },
+}


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Persist recipe bodies in a single-session store. The store is just in memory, which means the data never has to be serialized or deserialized. There's a lot of clones going on here, but since `Template` uses `Arc` for its raw strings, it shouldn't be too expensive.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

- Large memory usage
- Persistence setup is kinda complicated

## QA

_How did you test this?_

- Added a unit test
- Manual TUI testing

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
