### PR TITLE
Add persistence for authentication overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1395,9 +1395,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "persisted"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc99f0d02a8bf234e45d51304c97edfdbc5d49cffde9380da5bc41e3ca93bbf7"
+checksum = "82e5edc4d6dc44801ef97a92f9ffb9c41109283dd2417863cdacba396aaeea82"
 dependencies = [
  "derive_more",
  "persisted_derive",
@@ -1406,9 +1406,9 @@ dependencies = [
 
 [[package]]
 name = "persisted_derive"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef115d443975f882ec890bc76199ebe6ba04f53f4830e061bbc562c56b7579b8"
+checksum = "c7471b53f84a721aeb9a70b422262543332c3433350b8dd76c0fe0b3df5767ca"
 dependencies = [
  "quote",
  "syn 2.0.65",

--- a/crates/slumber_tui/Cargo.toml
+++ b/crates/slumber_tui/Cargo.toml
@@ -21,7 +21,7 @@ futures = {workspace = true}
 indexmap = {workspace = true}
 itertools = {workspace = true}
 notify = {version = "6.1.1", default-features = false, features = ["macos_fsevent"]}
-persisted = {version = "0.3.0", features = ["serde"]}
+persisted = {version = "0.3.1", features = ["serde"]}
 ratatui = {workspace = true, features = ["crossterm", "underline-color", "unstable-widget-ref"]}
 reqwest = {workspace = true}
 serde = {workspace = true}

--- a/crates/slumber_tui/src/lib.rs
+++ b/crates/slumber_tui/src/lib.rs
@@ -373,8 +373,7 @@ impl Tui {
     fn reload_collection(&mut self, collection: Collection) {
         self.collection_file.collection = collection.into();
 
-        // Rebuild the whole view, because tons of things can change. Drop the
-        // old one *first* to make sure UI state is saved before being restored
+        // Rebuild the whole view, because tons of things can change
         let database = self.database.clone();
         let messages_tx = self.messages_tx();
         let collection_file = &self.collection_file;

--- a/crates/slumber_tui/src/view/component.rs
+++ b/crates/slumber_tui/src/view/component.rs
@@ -14,3 +14,5 @@ mod root;
 
 pub use internal::Component;
 pub use root::Root;
+// Exported for the view context
+pub use recipe_pane::RecipeOverrideStore;

--- a/crates/slumber_tui/src/view/component/primary.rs
+++ b/crates/slumber_tui/src/view/component/primary.rs
@@ -425,7 +425,9 @@ mod tests {
     use crate::{
         message::{Message, RequestConfig},
         test_util::{harness, terminal, TestHarness, TestTerminal},
-        view::test_util::TestComponent,
+        view::{
+            test_util::TestComponent, util::persistence::DatabasePersistedStore,
+        },
     };
     use persisted::PersistedStore;
     use rstest::rstest;
@@ -452,11 +454,11 @@ mod tests {
     /// Test selected pane and fullscreen mode loading from persistence
     #[rstest]
     fn test_pane_persistence(mut harness: TestHarness, terminal: TestTerminal) {
-        ViewContext::store_persisted(
+        DatabasePersistedStore::store_persisted(
             &SingletonKey::<PrimaryPane>::default(),
             &PrimaryPane::Exchange,
         );
-        ViewContext::store_persisted(
+        DatabasePersistedStore::store_persisted(
             &FullscreenModeKey,
             &Some(FullscreenMode::Exchange),
         );

--- a/crates/slumber_tui/src/view/component/profile_select.rs
+++ b/crates/slumber_tui/src/view/component/profile_select.rs
@@ -324,7 +324,10 @@ impl<'a> Draw<ProfileDetailProps<'a>> for ProfileDetail {
 
 #[cfg(test)]
 mod tests {
-    use crate::test_util::{harness, TestHarness};
+    use crate::{
+        test_util::{harness, TestHarness},
+        view::util::persistence::DatabasePersistedStore,
+    };
     use persisted::PersistedStore;
     use rstest::rstest;
     use slumber_core::test_util::{by_id, Factory};
@@ -350,7 +353,7 @@ mod tests {
             ..Profile::factory(())
         }));
         if let Some(persisted_id) = persisted_id {
-            ViewContext::store_persisted(
+            DatabasePersistedStore::store_persisted(
                 &SelectedProfileKey,
                 &Some(persisted_id.into()),
             );

--- a/crates/slumber_tui/src/view/component/queryable_body.rs
+++ b/crates/slumber_tui/src/view/component/queryable_body.rs
@@ -248,7 +248,10 @@ mod tests {
     use crate::{
         context::TuiContext,
         test_util::{harness, terminal, TestHarness, TestTerminal},
-        view::{test_util::TestComponent, util::persistence::PersistedLazy},
+        view::{
+            test_util::TestComponent,
+            util::persistence::{DatabasePersistedStore, PersistedLazy},
+        },
     };
     use crossterm::event::KeyCode;
     use persisted::{PersistedKey, PersistedStore};
@@ -390,7 +393,7 @@ mod tests {
         struct Key;
 
         // Add initial query to the DB
-        ViewContext::store_persisted(&Key, &"$.greeting".to_owned());
+        DatabasePersistedStore::store_persisted(&Key, &"$.greeting".to_owned());
 
         // We already have another test to check that querying works via typing
         // in the box, so we just need to make sure state is initialized

--- a/crates/slumber_tui/src/view/component/recipe_pane.rs
+++ b/crates/slumber_tui/src/view/component/recipe_pane.rs
@@ -1,7 +1,10 @@
 mod authentication;
 mod body;
+mod persistence;
 mod recipe;
 mod table;
+
+pub use persistence::RecipeOverrideStore;
 
 use crate::{
     context::TuiContext,

--- a/crates/slumber_tui/src/view/component/recipe_pane/persistence.rs
+++ b/crates/slumber_tui/src/view/component/recipe_pane/persistence.rs
@@ -1,7 +1,7 @@
 //! Single-session persistence for recipe overrides
 
 use crate::view::{common::template_preview::TemplatePreview, ViewContext};
-use persisted::{PersistedContainer, PersistedStore};
+use persisted::{PersistedContainer, PersistedLazy, PersistedStore};
 use slumber_core::{
     collection::RecipeId, http::content_type::ContentType, template::Template,
 };
@@ -53,65 +53,82 @@ pub enum RecipeOverrideValue {
     Override(Template),
 }
 
-/// Helper for some piece of the recipe UI that supports overriding and persists
-/// its overrides to [RecipeOverrideStore]
-pub type RecipeOverrideContainer = persisted::PersistedLazy<
-    RecipeOverrideStore,
-    RecipeOverrideKey,
-    RecipeTemplate,
->;
+/// A template that can be previewed, overridden, and persisted. Parent is
+/// responsible for implementing the override behavior, and calling
+/// [set_override](Self::set_override) when needed.
+#[derive(Debug)]
+pub struct RecipeTemplate(
+    persisted::PersistedLazy<
+        RecipeOverrideStore,
+        RecipeOverrideKey,
+        RecipeTemplateInner,
+    >,
+);
+
+impl RecipeTemplate {
+    pub fn new(
+        persisted_key: RecipeOverrideKey,
+        template: Template,
+        content_type: Option<ContentType>,
+    ) -> Self {
+        Self(PersistedLazy::new(
+            persisted_key,
+            RecipeTemplateInner {
+                template: template.clone(),
+                preview: TemplatePreview::new(template, content_type),
+                content_type,
+                is_overridden: false,
+            },
+        ))
+    }
+
+    /// Override the recipe with a new template
+    pub fn set_override(&mut self, template: Template) {
+        self.0.get_mut().set_override(template);
+    }
+
+    pub fn template(&self) -> &Template {
+        &self.0.template
+    }
+
+    pub fn preview(&self) -> &TemplatePreview {
+        &self.0.preview
+    }
+
+    pub fn content_type(&self) -> Option<ContentType> {
+        self.0.content_type
+    }
+
+    pub fn is_overridden(&self) -> bool {
+        self.0.is_overridden
+    }
+}
 
 /// A template that can be previewed and overridden. Parent is responsible for
 /// implementing the override behavior, and calling
 /// [set_override](Self::set_override) when needed.
 #[derive(Debug)]
-pub struct RecipeTemplate {
+struct RecipeTemplateInner {
     template: Template,
     preview: TemplatePreview,
     /// Retain this so we can rebuild the preview with it
     content_type: Option<ContentType>,
-    overridden: bool,
+    is_overridden: bool,
 }
 
-impl RecipeTemplate {
-    pub fn new(template: Template, content_type: Option<ContentType>) -> Self {
-        Self {
-            template: template.clone(),
-            preview: TemplatePreview::new(template, content_type),
-            content_type,
-            overridden: false,
-        }
-    }
-
-    /// Override the recipe with a new template
-    pub fn set_override(&mut self, template: Template) {
+impl RecipeTemplateInner {
+    fn set_override(&mut self, template: Template) {
         self.template = template.clone();
-        self.overridden = true;
+        self.is_overridden = true;
         self.preview = TemplatePreview::new(template, self.content_type);
     }
-
-    pub fn template(&self) -> &Template {
-        &self.template
-    }
-
-    pub fn preview(&self) -> &TemplatePreview {
-        &self.preview
-    }
-
-    pub fn content_type(&self) -> Option<ContentType> {
-        self.content_type
-    }
-
-    pub fn overridden(&self) -> bool {
-        self.overridden
-    }
 }
 
-impl PersistedContainer for RecipeTemplate {
+impl PersistedContainer for RecipeTemplateInner {
     type Value = RecipeOverrideValue;
 
     fn get_to_persist(&self) -> Self::Value {
-        if self.overridden {
+        if self.is_overridden {
             RecipeOverrideValue::Override(self.template.clone())
         } else {
             RecipeOverrideValue::Default
@@ -129,7 +146,47 @@ impl PersistedContainer for RecipeTemplate {
 /// identifies any piece of a recipe that can be overridden.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, persisted::PersistedKey)]
 #[persisted(RecipeOverrideValue)]
-pub enum RecipeOverrideKey {
-    /// Overridden body for a particular recipe
-    Body { recipe_id: RecipeId },
+pub struct RecipeOverrideKey {
+    kind: RecipeOverrideKeyKind,
+    recipe_id: RecipeId,
+}
+
+impl RecipeOverrideKey {
+    pub fn body(recipe_id: RecipeId) -> Self {
+        Self {
+            kind: RecipeOverrideKeyKind::Body,
+            recipe_id,
+        }
+    }
+
+    pub fn auth_basic_username(recipe_id: RecipeId) -> Self {
+        Self {
+            kind: RecipeOverrideKeyKind::AuthenticationBasicUsername,
+            recipe_id,
+        }
+    }
+
+    pub fn auth_basic_password(recipe_id: RecipeId) -> Self {
+        Self {
+            kind: RecipeOverrideKeyKind::AuthenticationBasicPassword,
+            recipe_id,
+        }
+    }
+
+    pub fn auth_bearer_token(recipe_id: RecipeId) -> Self {
+        Self {
+            kind: RecipeOverrideKeyKind::AuthenticationBearerToken,
+            recipe_id,
+        }
+    }
+}
+
+/// Different kinds of recipe fields that can be persisted. This is exposed only
+/// through methods on [RecipeOverrideKey] to make usage a bit terser.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+enum RecipeOverrideKeyKind {
+    Body,
+    AuthenticationBasicUsername,
+    AuthenticationBasicPassword,
+    AuthenticationBearerToken,
 }

--- a/crates/slumber_tui/src/view/component/recipe_pane/persistence.rs
+++ b/crates/slumber_tui/src/view/component/recipe_pane/persistence.rs
@@ -1,0 +1,135 @@
+//! Single-session persistence for recipe overrides
+
+use crate::view::{common::template_preview::TemplatePreview, ViewContext};
+use persisted::{PersistedContainer, PersistedStore};
+use slumber_core::{
+    collection::RecipeId, http::content_type::ContentType, template::Template,
+};
+use std::{collections::HashMap, fmt::Debug};
+use tracing::debug;
+
+/// Special single-session [PersistedStore] just for edited recipe templates.
+/// We don't want to store recipe overrides across sessions, because they could
+/// be very large and conflict with changes in the recipe. Using a dedicated
+/// type for this makes the generic bounds stricter which is nice.
+///
+/// To persist something in this store, you probably want to use
+/// [RecipeTemplate] for your component/state field.
+#[derive(Debug, Default)]
+pub struct RecipeOverrideStore(HashMap<RecipeOverrideKey, Template>);
+
+impl PersistedStore<RecipeOverrideKey> for RecipeOverrideStore {
+    fn load_persisted(key: &RecipeOverrideKey) -> Option<RecipeOverrideValue> {
+        if let Some(template) =
+            ViewContext::with_override_store(|store| store.0.get(key).cloned())
+        {
+            // Only overridden values are persisted
+            debug!(?key, ?template, "Loaded persisted recipe override");
+            Some(RecipeOverrideValue::Override(template))
+        } else {
+            None
+        }
+    }
+
+    fn store_persisted(key: &RecipeOverrideKey, value: &RecipeOverrideValue) {
+        // The value will be None if the template isn't overridden, in which
+        // case we don't want to store it
+        if let RecipeOverrideValue::Override(template) = value {
+            debug!(?key, ?template, "Persisting recipe override");
+            ViewContext::with_override_store_mut(|store| {
+                store.0.insert(key.clone(), template.clone());
+            })
+        }
+    }
+}
+
+/// An override value that may be persisted in the store
+#[derive(Debug, PartialEq)]
+pub enum RecipeOverrideValue {
+    /// Default recipe value is in use, i.e. no override is present. Nothing
+    /// will be persisted
+    Default,
+    /// User has provided an override for this field, persist it
+    Override(Template),
+}
+
+/// Helper for some piece of the recipe UI that supports overriding and persists
+/// its overrides to [RecipeOverrideStore]
+pub type RecipeOverrideContainer = persisted::PersistedLazy<
+    RecipeOverrideStore,
+    RecipeOverrideKey,
+    RecipeTemplate,
+>;
+
+/// A template that can be previewed and overridden. Parent is responsible for
+/// implementing the override behavior, and calling
+/// [set_override](Self::set_override) when needed.
+#[derive(Debug)]
+pub struct RecipeTemplate {
+    template: Template,
+    preview: TemplatePreview,
+    /// Retain this so we can rebuild the preview with it
+    content_type: Option<ContentType>,
+    overridden: bool,
+}
+
+impl RecipeTemplate {
+    pub fn new(template: Template, content_type: Option<ContentType>) -> Self {
+        Self {
+            template: template.clone(),
+            preview: TemplatePreview::new(template, content_type),
+            content_type,
+            overridden: false,
+        }
+    }
+
+    /// Override the recipe with a new template
+    pub fn set_override(&mut self, template: Template) {
+        self.template = template.clone();
+        self.overridden = true;
+        self.preview = TemplatePreview::new(template, self.content_type);
+    }
+
+    pub fn template(&self) -> &Template {
+        &self.template
+    }
+
+    pub fn preview(&self) -> &TemplatePreview {
+        &self.preview
+    }
+
+    pub fn content_type(&self) -> Option<ContentType> {
+        self.content_type
+    }
+
+    pub fn overridden(&self) -> bool {
+        self.overridden
+    }
+}
+
+impl PersistedContainer for RecipeTemplate {
+    type Value = RecipeOverrideValue;
+
+    fn get_to_persist(&self) -> Self::Value {
+        if self.overridden {
+            RecipeOverrideValue::Override(self.template.clone())
+        } else {
+            RecipeOverrideValue::Default
+        }
+    }
+
+    fn restore_persisted(&mut self, value: Self::Value) {
+        if let RecipeOverrideValue::Override(template) = value {
+            self.set_override(template);
+        }
+    }
+}
+
+/// Persisted key for anything that goes in [RecipeOverrideStore]. This uniquely
+/// identifies any piece of a recipe that can be overridden.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, persisted::PersistedKey)]
+#[persisted(RecipeOverrideValue)]
+pub enum RecipeOverrideKey {
+    /// Overridden body for a particular recipe
+    Body { recipe_id: RecipeId },
+}

--- a/crates/slumber_tui/src/view/component/recipe_pane/recipe.rs
+++ b/crates/slumber_tui/src/view/component/recipe_pane/recipe.rs
@@ -86,7 +86,11 @@ impl RecipeDisplay {
             // Map authentication type
             authentication: recipe.authentication.as_ref().map(
                 |authentication| {
-                    AuthenticationDisplay::new(authentication.clone()).into()
+                    AuthenticationDisplay::new(
+                        recipe.id.clone(),
+                        authentication.clone(),
+                    )
+                    .into()
                 },
             ),
         }

--- a/crates/slumber_tui/src/view/component/root.rs
+++ b/crates/slumber_tui/src/view/component/root.rs
@@ -251,7 +251,9 @@ mod tests {
     use super::*;
     use crate::{
         test_util::{harness, terminal, TestHarness, TestTerminal},
-        view::test_util::TestComponent,
+        view::{
+            test_util::TestComponent, util::persistence::DatabasePersistedStore,
+        },
     };
     use crossterm::event::KeyCode;
     use persisted::PersistedStore;
@@ -303,7 +305,7 @@ mod tests {
             Exchange::factory((Some(profile_id.clone()), recipe_id.clone()));
         harness.database.insert_exchange(&old_exchange).unwrap();
         harness.database.insert_exchange(&new_exchange).unwrap();
-        ViewContext::store_persisted(
+        DatabasePersistedStore::store_persisted(
             &SelectedRequestKey,
             &Some(old_exchange.id),
         );

--- a/crates/slumber_tui/src/view/context.rs
+++ b/crates/slumber_tui/src/view/context.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 use slumber_core::{collection::Collection, db::CollectionDatabase};
 use std::{cell::RefCell, sync::Arc};
+use tracing::debug;
 
 /// Thread-local context container, which stores mutable state needed in the
 /// view thread. Until [TuiContext](crate::TuiContext), which stores
@@ -60,6 +61,7 @@ impl ViewContext {
         database: CollectionDatabase,
         messages_tx: MessageSender,
     ) {
+        debug!("Initializing view context");
         Self::INSTANCE.with_borrow_mut(|context| {
             *context = Some(Self {
                 collection,

--- a/crates/slumber_tui/src/view/context.rs
+++ b/crates/slumber_tui/src/view/context.rs
@@ -2,8 +2,8 @@ use crate::{
     message::{Message, MessageSender},
     view::{
         common::modal::Modal,
+        component::RecipeOverrideStore,
         event::{Event, EventQueue},
-        util::persistence::RecipeOverrideStore,
     },
 };
 use slumber_core::{collection::Collection, db::CollectionDatabase};

--- a/crates/slumber_tui/src/view/state/select.rs
+++ b/crates/slumber_tui/src/view/state/select.rs
@@ -444,8 +444,8 @@ mod tests {
     use crate::{
         test_util::{harness, terminal, TestHarness, TestTerminal},
         view::{
-            test_util::TestComponent, util::persistence::PersistedLazy,
-            ViewContext,
+            test_util::TestComponent,
+            util::persistence::{DatabasePersistedStore, PersistedLazy},
         },
     };
     use crossterm::event::KeyCode;
@@ -555,7 +555,10 @@ mod tests {
         let profile_id = ProfileId::factory(());
         let profile = ProfileItem(profile_id.clone());
 
-        ViewContext::store_persisted(&Key, &Some(profile_id.clone()));
+        DatabasePersistedStore::store_persisted(
+            &Key,
+            &Some(profile_id.clone()),
+        );
 
         let pid = profile_id.clone();
         let select = PersistedLazy::new(

--- a/crates/slumber_tui/src/view/util/persistence.rs
+++ b/crates/slumber_tui/src/view/util/persistence.rs
@@ -3,9 +3,11 @@
 use crate::view::ViewContext;
 use persisted::PersistedStore;
 use serde::{de::DeserializeOwned, Serialize};
-use slumber_core::{collection::RecipeId, template::Template};
-use std::{collections::HashMap, fmt::Debug};
-use tracing::debug;
+use std::fmt::Debug;
+
+/// This struct exists solely to hold an impl of [PersistedStore], which
+/// persists UI state into the database.
+pub struct DatabasePersistedStore;
 
 /// Wrapper for [persisted::PersistedKey] that applies additional bounds
 /// necessary for our store
@@ -13,91 +15,34 @@ pub trait PersistedKey: Debug + Serialize + persisted::PersistedKey {}
 impl<T: Debug + Serialize + persisted::PersistedKey> PersistedKey for T {}
 
 /// Wrapper for [persisted::Persisted] bound to our store
-pub type Persisted<K> = persisted::Persisted<ViewContext, K>;
+pub type Persisted<K> = persisted::Persisted<DatabasePersistedStore, K>;
 
 /// Wrapper for [persisted::PersistedLazy] bound to our store
-pub type PersistedLazy<K, C> = persisted::PersistedLazy<ViewContext, K, C>;
+pub type PersistedLazy<K, C> =
+    persisted::PersistedLazy<DatabasePersistedStore, K, C>;
 
 /// Persist UI state via the database. We have to be able to serialize keys to
 /// insert and lookup. We have to serialize values to insert, and deserialize
 /// them to retrieve.
-impl<K> PersistedStore<K> for ViewContext
+impl<K> PersistedStore<K> for DatabasePersistedStore
 where
     K: PersistedKey,
     K::Value: Debug + Serialize + DeserializeOwned,
 {
     fn load_persisted(key: &K) -> Option<K::Value> {
-        Self::with_database(|database| database.get_ui(K::type_name(), key))
-            // Error is already traced in the DB, nothing to do with it here
-            .ok()
-            .flatten()
+        ViewContext::with_database(|database| {
+            database.get_ui(K::type_name(), key)
+        })
+        // Error is already traced in the DB, nothing to do with it here
+        .ok()
+        .flatten()
     }
 
     fn store_persisted(key: &K, value: &K::Value) {
-        Self::with_database(|database| {
+        ViewContext::with_database(|database| {
             database.set_ui(K::type_name(), key, value)
         })
         // Error is already traced in the DB, nothing to do with it here
         .ok();
     }
-}
-
-/// Special single-session [PersistedStore] just for edited recipe templates.
-/// We don't want to store recipe overrides across sessions, because they could
-/// be very large and conflict with changes in the recipe. Using a dedicated
-/// type for this makes the generic bounds stricter which is nice.
-///
-/// To persist something in this store, you probably want to implement
-/// [PersistedContainer](persisted::PersistedContainer) for your component/state
-/// field.
-#[derive(Debug, Default)]
-pub struct RecipeOverrideStore(HashMap<RecipeOverrideKey, Template>);
-
-impl PersistedStore<RecipeOverrideKey> for RecipeOverrideStore {
-    fn load_persisted(key: &RecipeOverrideKey) -> Option<RecipeOverrideValue> {
-        if let Some(template) =
-            ViewContext::with_override_store(|store| store.0.get(key).cloned())
-        {
-            // Only overridden values are persisted
-            debug!(?key, ?template, "Loaded persisted recipe override");
-            Some(RecipeOverrideValue::Override(template))
-        } else {
-            None
-        }
-    }
-
-    fn store_persisted(key: &RecipeOverrideKey, value: &RecipeOverrideValue) {
-        // The value will be None if the template isn't overridden, in which
-        // case we don't want to store it
-        if let RecipeOverrideValue::Override(template) = value {
-            debug!(?key, ?template, "Persisting recipe override");
-            ViewContext::with_override_store_mut(|store| {
-                store.0.insert(key.clone(), template.clone());
-            })
-        }
-    }
-}
-
-/// An override value that may be persisted in the store
-#[derive(Debug, PartialEq)]
-pub enum RecipeOverrideValue {
-    /// Default recipe value is in use, i.e. no override is present. Nothing
-    /// will be persisted
-    Default,
-    /// User has provided an override for this field, persist it
-    Override(Template),
-}
-
-/// Helper for some piece of the recipe UI that supports overriding and persists
-/// its overrides to [RecipeOverrideStore]
-pub type RecipeOverrideContainer<T> =
-    persisted::PersistedLazy<RecipeOverrideStore, RecipeOverrideKey, T>;
-
-/// Persisted key for anything that goes in [RecipeOverrideStore]. This uniquely
-/// identifies any piece of a recipe that can be overridden.
-#[derive(Clone, Debug, Eq, Hash, PartialEq, persisted::PersistedKey)]
-#[persisted(RecipeOverrideValue)]
-pub enum RecipeOverrideKey {
-    /// Overridden body for a particular recipe
-    Body { recipe_id: RecipeId },
 }


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

- Clean up some recipe override persistence code
- Add persistence to authentication field overrides
- Fix a bug with override persisting after a collection reload. We don't want this because the underlying recipe field could've changed during the reload

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

- Values may not be persisted
- Overrides may not be getting used

Mitigated with testing

## QA

_How did you test this?_

Added a couple tests

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
