### PR TITLE
Persist query/header/form overrides

### DIFF
--- a/crates/slumber_tui/src/view/component/recipe_pane/body.rs
+++ b/crates/slumber_tui/src/view/component/recipe_pane/body.rs
@@ -49,10 +49,11 @@ impl RecipeBodyDisplay {
             | RecipeBody::FormMultipart(fields) => {
                 let inner = RecipeFieldTable::new(
                     FormRowKey(recipe_id.clone()),
-                    fields.iter().map(|(field, value)| {
+                    fields.iter().enumerate().map(|(i, (field, value))| {
                         (
                             field.clone(),
                             value.clone(),
+                            RecipeOverrideKey::form_field(recipe_id.clone(), i),
                             FormRowToggleKey {
                                 recipe_id: recipe_id.clone(),
                                 field: field.clone(),
@@ -328,9 +329,9 @@ mod tests {
         );
     }
 
-    /// Template should be loaded from the persistence store on init
+    /// Override template should be loaded from the persistence store on init
     #[rstest]
-    fn test_persisted_load(
+    fn test_persisted_override(
         _harness: TestHarness,
         #[with(10, 1)] terminal: TestTerminal,
     ) {

--- a/crates/slumber_tui/src/view/component/recipe_pane/persistence.rs
+++ b/crates/slumber_tui/src/view/component/recipe_pane/persistence.rs
@@ -179,6 +179,36 @@ impl RecipeOverrideKey {
             recipe_id,
         }
     }
+
+    /// Get a unique key for a query parameter. This can use index instead of
+    /// param name because it's only used within one session, and params can't
+    /// be added/reordered/removed without reloading the collection.
+    pub fn query_param(recipe_id: RecipeId, index: usize) -> Self {
+        Self {
+            kind: RecipeOverrideKeyKind::QueryParam(index),
+            recipe_id,
+        }
+    }
+
+    /// Get a unique key for a header. This can use index instead of
+    /// param name because it's only used within one session, and params can't
+    /// be added/reordered/removed without reloading the collection.
+    pub fn header(recipe_id: RecipeId, index: usize) -> Self {
+        Self {
+            kind: RecipeOverrideKeyKind::Header(index),
+            recipe_id,
+        }
+    }
+
+    /// Get a unique key for a form field. This can use index instead of
+    /// param name because it's only used within one session, and params can't
+    /// be added/reordered/removed without reloading the collection.
+    pub fn form_field(recipe_id: RecipeId, index: usize) -> Self {
+        Self {
+            kind: RecipeOverrideKeyKind::FormField(index),
+            recipe_id,
+        }
+    }
 }
 
 /// Different kinds of recipe fields that can be persisted. This is exposed only
@@ -189,4 +219,7 @@ enum RecipeOverrideKeyKind {
     AuthenticationBasicUsername,
     AuthenticationBasicPassword,
     AuthenticationBearerToken,
+    QueryParam(usize),
+    Header(usize),
+    FormField(usize),
 }

--- a/crates/slumber_tui/src/view/component/recipe_pane/recipe.rs
+++ b/crates/slumber_tui/src/view/component/recipe_pane/recipe.rs
@@ -5,6 +5,7 @@ use crate::{
         component::recipe_pane::{
             authentication::AuthenticationDisplay,
             body::RecipeBodyDisplay,
+            persistence::RecipeOverrideKey,
             table::{RecipeFieldTable, RecipeFieldTableProps},
         },
         draw::{Draw, DrawMetadata},
@@ -54,10 +55,11 @@ impl RecipeDisplay {
             url: TemplatePreview::new(recipe.url.clone(), None),
             query: RecipeFieldTable::new(
                 QueryRowKey(recipe.id.clone()),
-                recipe.query.iter().map(|(param, value)| {
+                recipe.query.iter().enumerate().map(|(i, (param, value))| {
                     (
                         param.clone(),
                         value.clone(),
+                        RecipeOverrideKey::query_param(recipe.id.clone(), i),
                         QueryRowToggleKey {
                             recipe_id: recipe.id.clone(),
                             param: param.clone(),
@@ -68,16 +70,19 @@ impl RecipeDisplay {
             .into(),
             headers: RecipeFieldTable::new(
                 HeaderRowKey(recipe.id.clone()),
-                recipe.headers.iter().map(|(header, value)| {
-                    (
-                        header.clone(),
-                        value.clone(),
-                        HeaderRowToggleKey {
-                            recipe_id: recipe.id.clone(),
-                            header: header.clone(),
-                        },
-                    )
-                }),
+                recipe.headers.iter().enumerate().map(
+                    |(i, (header, value))| {
+                        (
+                            header.clone(),
+                            value.clone(),
+                            RecipeOverrideKey::header(recipe.id.clone(), i),
+                            HeaderRowToggleKey {
+                                recipe_id: recipe.id.clone(),
+                                header: header.clone(),
+                            },
+                        )
+                    },
+                ),
             )
             .into(),
             body: recipe.body.as_ref().map(|body| {


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Persist override values for table-based recipe sections (query params/headers/form fields).

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

The type signature for the persistence keys here is the same for all 3 kinds, so it's possible to get the function wrong. Mitigated by reading carefully.

## QA

_How did you test this?_

Manual testing, added some unit tests

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
