### PR TITLE
Redraw screen on resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Here's the full list of changes:
 - Fix certain UI values not persisting correctly
 - Propgated unconsumed key events from text boxes
   - E.g. F5 will now refresh the collection while a text box is in focus
+- Redraw TUI when terminal is resized
 
 ## [1.8.1] - 2024-08-11
 

--- a/crates/slumber_config/Cargo.toml
+++ b/crates/slumber_config/Cargo.toml
@@ -24,6 +24,7 @@ tracing = {workspace = true}
 [dev-dependencies]
 rstest = {workspace = true}
 serde_test = {workspace = true}
+slumber_core = {workspace = true, features = ["test"]}
 
 [package.metadata.release]
 tag = false

--- a/crates/slumber_tui/src/input.rs
+++ b/crates/slumber_tui/src/input.rs
@@ -114,7 +114,6 @@ impl InputEngine {
             event,
             Event::FocusGained
                 | Event::FocusLost
-                | Event::Resize(_, _)
                 // Windows sends a release event that causes double triggers
                 // https://github.com/LucasPickering/slumber/issues/226
                 | Event::Key(KeyEvent {
@@ -313,7 +312,6 @@ mod tests {
     #[rstest]
     #[case::focus_gained(Event::FocusGained)]
     #[case::focus_lost(Event::FocusLost)]
-    #[case::resize(Event::Resize(10, 10))]
     #[case::key_release(key_event(
         KeyEventKind::Release,
         KeyCode::Enter,

--- a/crates/slumber_tui/src/lib.rs
+++ b/crates/slumber_tui/src/lib.rs
@@ -24,7 +24,9 @@ use crate::{
 use anyhow::{anyhow, Context};
 use chrono::Utc;
 use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, EventStream},
+    event::{
+        self, DisableMouseCapture, EnableMouseCapture, Event, EventStream,
+    },
     terminal::{EnterAlternateScreen, LeaveAlternateScreen},
 };
 use futures::{Future, StreamExt};
@@ -281,6 +283,13 @@ impl Tui {
                 action: Some(Action::ForceQuit),
                 ..
             } => self.quit(),
+            Message::Input {
+                event: Event::Resize(_, _),
+                ..
+            } => {
+                // Immediately redraw the screen
+                self.draw()?;
+            }
             Message::Input { event, action } => {
                 self.view.handle_input(event, action);
             }


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

TUI will automatically redraw when the terminal is resized, so it doesn't get into a weird state

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Maybe it doesn't work so well

## QA

_How did you test this?_

Manually

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
