### PR TITLE
Clamp scroll state on text window changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Here's the full list of changes:
 - Propgated unconsumed key events from text boxes
   - E.g. F5 will now refresh the collection while a text box is in focus
 - Redraw TUI when terminal is resized
+- Clamp text window scroll state when window is resized or text changes
 
 ## [1.8.1] - 2024-08-11
 

--- a/crates/slumber_tui/src/test_util.rs
+++ b/crates/slumber_tui/src/test_util.rs
@@ -5,7 +5,12 @@ use crate::{
     message::{Message, MessageSender},
     view::ViewContext,
 };
-use ratatui::{backend::TestBackend, text::Line, Frame, Terminal};
+use ratatui::{
+    backend::TestBackend,
+    layout::{Position, Rect},
+    text::Line,
+    Frame, Terminal,
+};
 use rstest::fixture;
 use slumber_core::{
     collection::Collection, db::CollectionDatabase, test_util::Factory,
@@ -97,6 +102,14 @@ impl TestTerminal {
         let backend = TestBackend::new(width, height);
         let terminal = Terminal::new(backend).unwrap();
         Self(terminal.into())
+    }
+
+    pub fn area(&self) -> Rect {
+        self.0
+            .borrow()
+            .size()
+            .map(|size| (Position::default(), size).into())
+            .unwrap_or_default()
     }
 
     /// Alias for


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

On each draw, we'll enforce the text window scroll state is valid. If the text shrinks or window grows such that the previous scroll state is too far down/right to be valid, we'll snap back to the bottom/right of the content.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

- Edge cases still broken
- Duplicated scrolling code is a bit hard to read. De-dupe it seems like an overabstraction though

## QA

_How did you test this?_

- Manual testing
- Added a couple unit tests

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
