### PR TITLE
Move log file again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Here's the full list of changes:
   - The new equivalent would be `{_{`, which parses as `{{`
   - The goal of this change is to make escaping behavior simpler and more consistent
   - For more info on the new behavior, [see the docs](https://slumber.lucaspickering.me/book/api/request_collection/template.html#escape-sequences)
+- Remove `--log` CLI argument
+  - See note on log files in Changed section for why this is no longer necessary
 
 ### Added
 
@@ -31,6 +33,10 @@ Here's the full list of changes:
 
 - `!json` bodies are now prettified when sent to the server
 - Use `vim` as default editor if none is configured
+- Move logs back to a shared file
+  - They had been split into one file per session, which made them hard to find
+  - The file is now eventually deleted once it exceeds a certain size
+  - PID is now included in each log line to help disambiguate between parallel sessions
 
 ### Fixed
 

--- a/crates/slumber_cli/src/commands/show.rs
+++ b/crates/slumber_cli/src/commands/show.rs
@@ -3,9 +3,7 @@ use clap::Parser;
 use serde::Serialize;
 use slumber_config::Config;
 use slumber_core::{
-    collection::CollectionFile,
-    db::Database,
-    util::{DataDirectory, TempDirectory},
+    collection::CollectionFile, db::Database, util::DataDirectory,
 };
 use std::{borrow::Cow, path::Path, process::ExitCode};
 
@@ -32,8 +30,9 @@ impl Subcommand for ShowCommand {
             ShowTarget::Paths => {
                 let collection_path =
                     CollectionFile::try_path(None, global.file);
-                println!("Data directory: {}", DataDirectory::get());
-                println!("Temporary directory: {}", TempDirectory::get());
+                let data_dir = DataDirectory::get();
+                println!("Data directory: {}", data_dir);
+                println!("Log file: {}", data_dir.log_file().display());
                 println!("Config: {}", Config::path().display());
                 println!("Database: {}", Database::path().display());
                 println!(

--- a/crates/slumber_cli/src/lib.rs
+++ b/crates/slumber_cli/src/lib.rs
@@ -48,10 +48,6 @@ pub struct GlobalArgs {
     /// (in this order): slumber.yml, slumber.yaml, .slumber.yml, .slumber.yaml
     #[clap(long, short)]
     pub file: Option<PathBuf>,
-    /// Print the path to the log file for this session, before running the
-    /// given subcommand
-    #[clap(long)]
-    pub log: bool,
 }
 
 /// A CLI subcommand

--- a/crates/slumber_tui/src/view/common/list.rs
+++ b/crates/slumber_tui/src/view/common/list.rs
@@ -29,21 +29,6 @@ pub struct List<'a, Item> {
     phantom: PhantomData<&'a ()>,
 }
 
-impl<'a, Item> List<'a, Item> {
-    pub fn from_iter(items: impl 'a + IntoIterator<Item = Item>) -> Self {
-        Self {
-            items: items
-                .into_iter()
-                .map(|value| ListItem {
-                    value,
-                    disabled: false,
-                })
-                .collect(),
-            phantom: PhantomData,
-        }
-    }
-}
-
 impl<'a, Item> From<&'a SelectState<Item>> for List<'a, &'a Item> {
     fn from(select: &'a SelectState<Item>) -> Self {
         Self {

--- a/crates/slumber_tui/src/view/component/help.rs
+++ b/crates/slumber_tui/src/view/component/help.rs
@@ -14,7 +14,7 @@ use ratatui::{
     Frame,
 };
 use slumber_config::{Action, Config, InputBinding};
-use slumber_core::util::TempDirectory;
+use slumber_core::util::DataDirectory;
 
 const CRATE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -100,7 +100,11 @@ impl Draw for HelpModal {
                 ("Configuration", Config::path().display().to_string().into()),
                 (
                     "Log",
-                    TempDirectory::get().log().display().to_string().into(),
+                    DataDirectory::get()
+                        .log_file()
+                        .display()
+                        .to_string()
+                        .into(),
                 ),
                 (
                     "Collection",

--- a/docs/src/troubleshooting/logs.md
+++ b/docs/src/troubleshooting/logs.md
@@ -1,12 +1,10 @@
 # Logs
 
-Each Slumber session logs information and events to a log file. This can often be helpful in debugging bugs and other issues with the app. Each session of Slumber logs to its own file, and files are stored in a temporary directory so they are automatically cleaned up periodically by the operating system.
+Each Slumber session logs information and events to a log file. This can often be helpful in debugging bugs and other issues with the app. All sessions of Slumber log to the same file. Currently there is no easy to way disambiguate between logs from parallel sessions :(
 
 ## Finding the Log File
 
-To find the path to a particular TUI session's log file, hit the `?` to open the help dialog. It will be listed under the General section. To find logs for a CLI command, pass the `--log` argument and it will be printed at startup.
-
-> Note: Each Slumber session, including each invocation of the CLI, will log to its own file. That means there's no easy way to retroactively find the logs for a CLI command if you didn't pass `--log`. Instead, you can find the log directory with `slumber show paths`, then search each log file in that directory to find the one associated with the command in question. If the thing you're debugging is reproducible though, it's easier just to run it again with `--log`.
+To find the path to the log file, hit the `?` to open the help dialog. It will be listed under the General section. Alternatively, run the command `slumber show paths`.
 
 Once you have the path to a log file, you can watch the logs with `tail -f <log file>`, or get the entire log contents with `cat <log file>`.
 


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

- Move logs back into a single predictable file
- Rotate log files
    - If the size exceeds 1MB, it'll be moved to a backup, so we max at 2MB usage
- Don't crash if we can't log
- Remove --log flag since it's unnecessary now
- Update docs to reflect new reality

The --log removal is a breaking change, but in reality it's not going to break anyone's workflow.

I'd like to add the PID to the log message, but that requires https://github.com/tokio-rs/tracing/pull/2655 (or at least it makes it a lot easier)

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

- Bugs bad
- Logs are harder to disambiguate now. Will be mitigated in the future by including the PID

## QA

_How did you test this?_

Manual testing

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
