### PR TITLE
Add ChainSource::Select chain option [core only]

### DIFF
--- a/crates/slumber_cli/src/commands/request.rs
+++ b/crates/slumber_cli/src/commands/request.rs
@@ -9,7 +9,7 @@ use slumber_core::{
     collection::{CollectionFile, ProfileId, RecipeId},
     db::{CollectionDatabase, Database},
     http::{BuildOptions, HttpEngine, RequestSeed, RequestTicket},
-    template::{Prompt, Prompter, TemplateContext, TemplateError},
+    template::{Prompt, Prompter, Select, TemplateContext, TemplateError},
     util::ResultTraced,
 };
 use std::{
@@ -225,6 +225,10 @@ impl Prompter for CliPrompter {
         {
             prompt.channel.respond(value);
         }
+    }
+
+    fn select(&self, _select: Select) {
+        unimplemented!("Select prompts not yet implemented");
     }
 }
 

--- a/crates/slumber_core/src/collection/models.rs
+++ b/crates/slumber_core/src/collection/models.rs
@@ -420,6 +420,13 @@ pub enum ChainSource {
         #[serde(default)]
         section: ChainRequestSection,
     },
+    /// Prompt the user to select a value from a list
+    Select {
+        /// Descriptor to show to the user
+        message: Option<Template>,
+        /// List of options to choose from
+        options: Vec<Template>,
+    },
 }
 
 /// Test-only helpers

--- a/crates/slumber_core/src/template/error.rs
+++ b/crates/slumber_core/src/template/error.rs
@@ -175,7 +175,7 @@ pub enum ChainError {
 
     /// Never got a response from the prompt channel. Do *not* store the
     /// `RecvError` here, because it provides useless extra output to the user.
-    #[error("No response from prompt")]
+    #[error("No response from prompt/select")]
     PromptNoResponse,
 
     /// A bubbled-error from rendering a nested template in the chain arguments

--- a/crates/slumber_core/src/template/prompt.rs
+++ b/crates/slumber_core/src/template/prompt.rs
@@ -19,6 +19,9 @@ pub trait Prompter: Debug + Send + Sync {
     /// If an error occurs while prompting the user, just drop the returner.
     /// The implementor is responsible for logging the error as appropriate.
     fn prompt(&self, prompt: Prompt);
+
+    /// Ask the user to pick an item for a list of choices
+    fn select(&self, select: Select);
 }
 
 /// Data defining a prompt which should be presented to the user
@@ -30,6 +33,17 @@ pub struct Prompt {
     pub default: Option<String>,
     /// Should the value the user is typing be masked? E.g. password input
     pub sensitive: bool,
+    /// How the prompter will pass the answer back
+    pub channel: PromptChannel<String>,
+}
+
+/// A list of options to present to the user
+#[derive(Debug)]
+pub struct Select {
+    /// Tell the user what we're asking for
+    pub message: String,
+    /// List of choices the user can pick from
+    pub options: Vec<String>,
     /// How the prompter will pass the answer back
     pub channel: PromptChannel<String>,
 }

--- a/crates/slumber_core/src/test_util.rs
+++ b/crates/slumber_core/src/test_util.rs
@@ -3,7 +3,7 @@
 use crate::{
     collection::{ChainSource, HasId},
     http::{HttpEngine, HttpEngineConfig},
-    template::{Prompt, Prompter},
+    template::{Prompt, Prompter, Select},
     util::{get_repo_root, ResultTraced},
 };
 use anyhow::Context;
@@ -118,6 +118,13 @@ impl Prompter for TestPrompter {
             prompt.channel.respond(value.clone())
         } else if let Some(default) = prompt.default {
             prompt.channel.respond(default);
+        }
+    }
+
+    fn select(&self, select: Select) {
+        let index = self.index.fetch_add(1, Ordering::Relaxed);
+        if let Some(value) = self.responses.get(index) {
+            select.channel.respond(value.clone())
         }
     }
 }

--- a/crates/slumber_tui/src/message.rs
+++ b/crates/slumber_tui/src/message.rs
@@ -10,7 +10,7 @@ use slumber_core::{
     http::{
         BuildOptions, Exchange, RequestBuildError, RequestError, RequestRecord,
     },
-    template::{Prompt, Prompter, Template, TemplateChunk},
+    template::{Prompt, Prompter, Select, Template, TemplateChunk},
     util::ResultTraced,
 };
 use std::{path::PathBuf, sync::Arc};
@@ -44,6 +44,10 @@ impl MessageSender {
 impl Prompter for MessageSender {
     fn prompt(&self, prompt: Prompt) {
         self.send(Message::PromptStart(prompt));
+    }
+
+    fn select(&self, _select: Select) {
+        unimplemented!("Select prompts not yet implemented");
     }
 }
 

--- a/crates/slumber_tui/src/view/util.rs
+++ b/crates/slumber_tui/src/view/util.rs
@@ -4,7 +4,7 @@ pub mod highlight;
 pub mod persistence;
 
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
-use slumber_core::template::{Prompt, PromptChannel, Prompter};
+use slumber_core::template::{Prompt, PromptChannel, Prompter, Select};
 
 /// A data structure for representation a yes/no confirmation. This is similar
 /// to [Prompt], but it only asks a yes/no question.
@@ -24,6 +24,10 @@ pub struct PreviewPrompter;
 impl Prompter for PreviewPrompter {
     fn prompt(&self, prompt: Prompt) {
         prompt.channel.respond("<prompt>".into())
+    }
+
+    fn select(&self, select: Select) {
+        select.channel.respond("<select>".into())
     }
 }
 


### PR DESCRIPTION
## Description

Implements core-only aspects of ChainSource::Select feature described [here](https://github.com/LucasPickering/slumber/issues/352)

Future PRs will implement appropriate user input gathering for TUI & CLI, using a chain which returns an array to drive the `options` (dynamic options), and documentation

## Known Risks

Core only change, actually prompting the user is not yet implemented (in TUI or CLI) and will panic if a request leveraging a ChainSource::Select is executed

## QA

WIP

## Checklist

- [X] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [X] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
