### PR TITLE
Fix some issues with large request bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Here's the full list of changes:
 - Redraw TUI when terminal is resized
 - Clamp text window scroll state when window is resized or text changes
 - Fix extraneous input events when exiting Vim [#351](https://github.com/LucasPickering/slumber/issues/351)
+- Improve performance and fix crashes when handling large request/response bodies [#356](https://github.com/LucasPickering/slumber/issues/356)
 
 ## [1.8.1] - 2024-08-11
 

--- a/crates/slumber_cli/src/commands/request.rs
+++ b/crates/slumber_cli/src/commands/request.rs
@@ -153,7 +153,7 @@ impl BuildRequestCommand {
         let collection_file = CollectionFile::load(collection_path).await?;
         let collection = collection_file.collection;
         let config = Config::load()?;
-        let http_engine = HttpEngine::new(&config.ignore_certificate_hosts);
+        let http_engine = HttpEngine::new(&config.http);
 
         // Validate profile ID, so we can provide a good error if it's invalid
         if let Some(profile_id) = &self.profile {

--- a/crates/slumber_config/src/lib.rs
+++ b/crates/slumber_config/src/lib.rs
@@ -18,7 +18,10 @@ pub use theme::Theme;
 use anyhow::Context;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
-use slumber_core::util::{parse_yaml, DataDirectory, ResultTraced};
+use slumber_core::{
+    http::HttpEngineConfig,
+    util::{parse_yaml, DataDirectory, ResultTraced},
+};
 use std::{fs::File, path::PathBuf};
 use tracing::info;
 
@@ -34,8 +37,7 @@ pub struct Config {
     /// Command to use for in-app editing. If provided, overrides
     /// `VISUAL`/`EDITOR` environment variables
     pub editor: Option<String>,
-    /// TLS cert errors on these hostnames are ignored. Be careful!
-    pub ignore_certificate_hosts: Vec<String>,
+    pub http: HttpEngineConfig,
     /// Should templates be rendered inline in the UI, or should we show the
     /// raw text?
     pub preview_templates: bool,
@@ -86,7 +88,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             editor: None,
-            ignore_certificate_hosts: Default::default(),
+            http: HttpEngineConfig::default(),
             preview_templates: true,
             input_bindings: Default::default(),
             theme: Default::default(),

--- a/crates/slumber_core/src/db.rs
+++ b/crates/slumber_core/src/db.rs
@@ -355,7 +355,7 @@ impl CollectionDatabase {
                     ":method": exchange.request.method.as_str(),
                     ":url": exchange.request.url.as_str(),
                     ":request_headers": SqlWrap(&exchange.request.headers),
-                    ":request_body": exchange.request.body.as_deref(),
+                    ":request_body": exchange.request.body(),
 
                     ":status_code": exchange.response.status.as_u16(),
                     ":response_headers": SqlWrap(&exchange.response.headers),

--- a/crates/slumber_core/src/db/migrations.rs
+++ b/crates/slumber_core/src/db/migrations.rs
@@ -192,7 +192,7 @@ fn migrate_requests_v2_up(transaction: &Transaction) -> HookResult {
             ":method": exchange.request.method.as_str(),
             ":url": exchange.request.url.as_str(),
             ":request_headers": SqlWrap(&exchange.request.headers),
-            ":request_body": exchange.request.body.as_deref(),
+            ":request_body": exchange.request.body(),
 
             ":status_code": exchange.response.status.as_u16(),
             ":response_headers": SqlWrap(&exchange.response.headers),

--- a/crates/slumber_core/src/http.rs
+++ b/crates/slumber_core/src/http.rs
@@ -324,7 +324,7 @@ impl RequestTicket {
         let id = self.record.id;
 
         // Capture the rest of this method in a span
-        let _ = info_span!("HTTP request", request_id = %id, ?self).entered();
+        let _ = info_span!("HTTP request", request_id = %id).entered();
 
         // This start time will be accurate because the request doesn't launch
         // until this whole future is awaited

--- a/crates/slumber_core/src/test_util.rs
+++ b/crates/slumber_core/src/test_util.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     collection::{ChainSource, HasId},
-    http::HttpEngine,
+    http::{HttpEngine, HttpEngineConfig},
     template::{Prompt, Prompter},
     util::{get_repo_root, ResultTraced},
 };
@@ -61,7 +61,10 @@ pub fn temp_dir() -> TempDir {
 #[fixture]
 #[once]
 pub fn http_engine() -> HttpEngine {
-    HttpEngine::new(&["danger".to_owned()])
+    HttpEngine::new(&HttpEngineConfig {
+        ignore_certificate_hosts: vec!["danger".to_owned()],
+        ..Default::default()
+    })
 }
 
 /// Guard for a temporary directory. Create the directory on creation, delete

--- a/crates/slumber_tui/src/context.rs
+++ b/crates/slumber_tui/src/context.rs
@@ -45,7 +45,7 @@ impl TuiContext {
     fn new(config: Config) -> Self {
         let styles = Styles::new(&config.theme);
         let input_engine = InputEngine::new(config.input_bindings.clone());
-        let http_engine = HttpEngine::new(&config.ignore_certificate_hosts);
+        let http_engine = HttpEngine::new(&config.http);
         Self {
             config,
             styles,

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,9 @@ fn initialize_tracing(console_output: bool) {
     let targets: Targets = std::env::var("RUST_LOG")
         .ok()
         .and_then(|env| env.parse().ok())
-        .unwrap_or_default();
+        .unwrap_or_else(|| {
+            Targets::new().with_target("slumber", LevelFilter::WARN)
+        });
     let file_subscriber = log_file.map(|log_file| {
         // Include PID
         // https://github.com/tokio-rs/tracing/pull/2655


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

- Don't log request bodies
- Optimize `TemplatePreview` initialization to remove recursion. This fixes a stack overflow for large bodies
- Don't store request bodies >1MB in the DB
- Default to WARN log level

This is a first step toward #356 

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

- Losing request data
- There's still perf issues with large bodies

## QA

_How did you test this?_

Manual testing

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
