### PR TITLE
Fix garbage events from vim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Here's the full list of changes:
   - E.g. F5 will now refresh the collection while a text box is in focus
 - Redraw TUI when terminal is resized
 - Clamp text window scroll state when window is resized or text changes
+- Fix extraneous input events when exiting Vim [#351](https://github.com/LucasPickering/slumber/issues/351)
 
 ## [1.8.1] - 2024-08-11
 

--- a/crates/slumber_tui/src/util.rs
+++ b/crates/slumber_tui/src/util.rs
@@ -4,6 +4,7 @@ use crate::{
     view::Confirm,
 };
 use anyhow::Context;
+use crossterm::event;
 use editor_command::EditorBuilder;
 use futures::{future, FutureExt};
 use slumber_core::{
@@ -15,6 +16,7 @@ use std::{
     ops::Deref,
     path::{Path, PathBuf},
     process::Command,
+    time::Duration,
 };
 use tokio::{fs::OpenOptions, io::AsyncWriteExt, sync::oneshot};
 use tracing::{debug, error, info, warn};
@@ -42,6 +44,13 @@ where
                 None
             }
         }
+    }
+}
+
+/// Clear all input events in the terminal event buffer
+pub fn clear_event_buffer() {
+    while let Ok(true) = event::poll(Duration::from_millis(0)) {
+        let _ = event::read();
     }
 }
 


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Vim dumps out some garbage events on exit, which causes strange behavior in Slumber. I never figured out what this output really is, or why it's going back to Slumber, but a simple solution is to just drain the event buffer immediately after exiting Vim.

Closes #351

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

There's potential for lost events here. If the user passed other events _after_ opening the terminal, and they're in the queue, they'll get lost. In reality this will only happen if the app is pretty slowly. In general, lost events is probably better than extra events.

## QA

_How did you test this?_

Manually testing with vim

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
