### PR TITLE
add-select: [tui/cli] prompting support for select chainsource

### DIFF
--- a/crates/slumber_cli/src/commands/request.rs
+++ b/crates/slumber_cli/src/commands/request.rs
@@ -1,7 +1,7 @@
 use crate::{util::HeaderDisplay, GlobalArgs, Subcommand};
 use anyhow::{anyhow, Context};
 use clap::Parser;
-use dialoguer::{Input, Password};
+use dialoguer::{Input, Password, Select as DialoguerSelect};
 use indexmap::IndexMap;
 use itertools::Itertools;
 use slumber_config::Config;
@@ -227,8 +227,18 @@ impl Prompter for CliPrompter {
         }
     }
 
-    fn select(&self, _select: Select) {
-        unimplemented!("Select prompts not yet implemented");
+    fn select(&self, select: Select) {
+        let result = DialoguerSelect::new()
+            .with_prompt(select.message)
+            .items(&select.options)
+            .interact();
+
+        // If we failed to read the value, print an error and report nothing
+        if let Ok(value) =
+            result.context("Error reading value from select").traced()
+        {
+            select.channel.respond(select.options[value].clone());
+        }
     }
 }
 

--- a/crates/slumber_cli/src/commands/request.rs
+++ b/crates/slumber_cli/src/commands/request.rs
@@ -227,7 +227,7 @@ impl Prompter for CliPrompter {
         }
     }
 
-    fn select(&self, select: Select) {
+    fn select(&self, mut select: Select) {
         let result = DialoguerSelect::new()
             .with_prompt(select.message)
             .items(&select.options)
@@ -237,7 +237,7 @@ impl Prompter for CliPrompter {
         if let Ok(value) =
             result.context("Error reading value from select").traced()
         {
-            select.channel.respond(select.options[value].clone());
+            select.channel.respond(select.options.swap_remove(value));
         }
     }
 }

--- a/crates/slumber_tui/src/lib.rs
+++ b/crates/slumber_tui/src/lib.rs
@@ -302,6 +302,9 @@ impl Tui {
             Message::PromptStart(prompt) => {
                 self.view.open_modal(prompt);
             }
+            Message::SelectStart(select) => {
+                self.view.open_modal(select);
+            }
             Message::ConfirmStart(confirm) => {
                 self.view.open_modal(confirm);
             }

--- a/crates/slumber_tui/src/message.rs
+++ b/crates/slumber_tui/src/message.rs
@@ -46,8 +46,8 @@ impl Prompter for MessageSender {
         self.send(Message::PromptStart(prompt));
     }
 
-    fn select(&self, _select: Select) {
-        unimplemented!("Select prompts not yet implemented");
+    fn select(&self, select: Select) {
+        self.send(Message::SelectStart(select));
     }
 }
 
@@ -113,6 +113,10 @@ pub enum Message {
     /// Show a prompt to the user, asking for some input. Use the included
     /// channel to return the value.
     PromptStart(Prompt),
+
+    /// Show a select list to the user, asking them to choose an item
+    /// Use the included channel to return the selection.
+    SelectStart(Select),
 
     /// Exit the program
     Quit,

--- a/crates/slumber_tui/src/view/component/misc.rs
+++ b/crates/slumber_tui/src/view/component/misc.rs
@@ -4,23 +4,24 @@
 use crate::view::{
     common::{
         button::ButtonGroup,
+        list::List,
         modal::{IntoModal, Modal},
         text_box::TextBox,
     },
     component::Component,
     draw::{Draw, DrawMetadata, Generate},
     event::{Child, Event, EventHandler, Update},
-    state::Notification,
+    state::{select::SelectState, Notification},
     Confirm, ModalPriority, ViewContext,
 };
 use derive_more::Display;
 use ratatui::{
     prelude::Constraint,
-    text::Line,
+    text::{Line, Text},
     widgets::{Paragraph, Wrap},
     Frame,
 };
-use slumber_core::template::{Prompt, PromptChannel};
+use slumber_core::template::{Prompt, PromptChannel, Select};
 use std::{cell::Cell, fmt::Debug, rc::Rc};
 use strum::{EnumCount, EnumIter};
 
@@ -149,6 +150,111 @@ impl IntoModal for Prompt {
                 .default_value(self.default.unwrap_or_default()),
             |response| self.channel.respond(response),
         )
+    }
+}
+
+/// A modal that presents a list of simple string options to the user.
+/// The user will select one of the options and submit it, or cancel.
+#[derive(derive_more::Debug)]
+pub struct SelectListModal {
+    /// Modal title, from the select message
+    title: String,
+    /// List of options to present to the user
+    options: Component<SelectState<String>>,
+    /// Flag set before closing to indicate if we should submit in our own
+    /// `on_close`. This is set from the text box's `on_submit`.
+    submit: Rc<Cell<bool>>,
+    #[debug(skip)]
+    on_submit: Box<dyn 'static + FnOnce(String)>,
+}
+
+impl SelectListModal {
+    /// Create a modal that contains a list of options.
+    pub fn new(
+        title: String,
+        options: Vec<String>,
+        on_submit: impl 'static + FnOnce(String),
+    ) -> Self {
+        // The underlying SelectState may close the modal
+        // either because the user selected a value or left the modal
+        // We use `submit` to inform our modal that the user selected a value
+        let submit = Rc::new(Cell::new(false));
+        let submit_cell = Rc::clone(&submit);
+        Self {
+            title,
+            options: SelectState::builder(options)
+                .on_submit(move |_selection| {
+                    submit_cell.set(true);
+                    ViewContext::push_event(Event::CloseModal);
+                })
+                .build()
+                .into(),
+            submit,
+            on_submit: Box::new(on_submit),
+        }
+    }
+}
+
+impl Modal for SelectListModal {
+    fn title(&self) -> Line<'_> {
+        self.title.clone().into()
+    }
+
+    fn dimensions(&self) -> (Constraint, Constraint) {
+        // Do some simple math to size the select modal correctly to our
+        // underlying data
+        let options = self.options.data();
+        let longest_option =
+            options.items().map(|s| s.len()).max().unwrap_or(10);
+        // find our widest string to appropriately set width
+        let width = std::cmp::max(self.title.len(), longest_option);
+        (
+            Constraint::Length(width as u16),
+            Constraint::Length(options.len() as u16),
+        )
+    }
+
+    fn on_close(self: Box<Self>) {
+        // The modal is closed, but only submit the value if it was closed
+        // because the user selected a value (submitted).
+        if self.submit.get() {
+            // Return the user's value and close the prompt
+            (self.on_submit)(self.options.data().selected().unwrap().clone());
+        }
+    }
+}
+
+impl EventHandler for SelectListModal {
+    fn children(&mut self) -> Vec<Component<Child<'_>>> {
+        vec![self.options.to_child_mut()]
+    }
+}
+
+impl Draw for SelectListModal {
+    fn draw(&self, frame: &mut Frame, _: (), metadata: DrawMetadata) {
+        // Empty state
+        let options = self.options.data();
+        if options.is_empty() {
+            frame.render_widget(
+                Text::from(vec!["No options defined!".into()]),
+                metadata.area(),
+            );
+            return;
+        }
+
+        self.options
+            .draw(frame, List::from(options), metadata.area(), true);
+    }
+}
+
+/// Present a select list as a modal to the user
+impl IntoModal for Select {
+    type Target = SelectListModal;
+
+    fn into_modal(self) -> Self::Target {
+        SelectListModal::new(self.message, self.options, |response| {
+            self.channel.respond(response)
+        })
     }
 }
 

--- a/crates/slumber_tui/src/view/component/misc.rs
+++ b/crates/slumber_tui/src/view/component/misc.rs
@@ -197,7 +197,7 @@ impl SelectListModal {
 
 impl Modal for SelectListModal {
     fn title(&self) -> Line<'_> {
-        self.title.clone().into()
+        self.title.as_str().into()
     }
 
     fn dimensions(&self) -> (Constraint, Constraint) {
@@ -210,7 +210,7 @@ impl Modal for SelectListModal {
         let width = std::cmp::max(self.title.len(), longest_option);
         (
             Constraint::Length(width as u16),
-            Constraint::Length(options.len() as u16),
+            Constraint::Length(options.len().min(20) as u16),
         )
     }
 

--- a/slumber.yml
+++ b/slumber.yml
@@ -28,6 +28,15 @@ chains:
     source: !prompt
       message: Password
     sensitive: true
+  select_value:
+    source: !select
+      message: Select a value
+      options:
+        - foo
+        - bar
+        - baz
+        - a really really really really long option
+        - "{{chains.username}}"
   auth_token:
     source: !request
       recipe: login
@@ -63,6 +72,7 @@ requests:
     body: !form_urlencoded
       username: "{{username}}"
       password: "{{chains.password}}"
+      selectedValue: "{{chains.select_value}}"
 
   users: !folder
     name: Users


### PR DESCRIPTION
## Description

Implements full prompting support for `select` chainsource in the TUI and CLI

Second phase of implementation for [issue#352](https://github.com/LucasPickering/slumber/issues/352)

## Known Risks

None

## QA

TUI behaves as expected:

https://github.com/user-attachments/assets/0f8e6f0d-0161-4e2b-b3b5-554abc51724c

CLI behaves as expected:

https://github.com/user-attachments/assets/31103a0d-0e40-4e97-9671-e3e2700a3564

## Checklist

- [X] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [X] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
