### PR TITLE
add-select: Support dynamic options in ChainSource::Select

### DIFF
--- a/crates/slumber_core/src/collection/models.rs
+++ b/crates/slumber_core/src/collection/models.rs
@@ -425,7 +425,22 @@ pub enum ChainSource {
         /// Descriptor to show to the user
         message: Option<Template>,
         /// List of options to choose from
-        options: Vec<Template>,
+        options: SelectOptions,
+    },
+}
+
+/// Static or dynamic list of options for a select chain
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(PartialEq))]
+#[serde(rename_all = "snake_case", deny_unknown_fields, untagged)]
+pub enum SelectOptions {
+    Fixed(Vec<Template>),
+    /// Dynamic requires a source (often a chain) that either returns a JSON
+    /// array OR a JSON object, in which case we'll use selector to query
+    /// and find the array to parse in to the list of options
+    Dynamic {
+        source: Template,
+        selector: Option<Query>,
     },
 }
 

--- a/crates/slumber_core/src/http/query.rs
+++ b/crates/slumber_core/src/http/query.rs
@@ -3,7 +3,7 @@
 use crate::http::content_type::ResponseContent;
 use derive_more::{Display, FromStr};
 use serde::{Deserialize, Serialize};
-use serde_json_path::{ExactlyOneError, JsonPath};
+use serde_json_path::{ExactlyOneError, JsonPath, NodeList};
 use std::borrow::Cow;
 use thiserror::Error;
 
@@ -17,7 +17,7 @@ impl Query {
     /// Apply a query to some content, returning the result in the original
     /// format. This will convert to a common format, apply the query, then
     /// convert back.
-    pub fn query(
+    pub fn query_content(
         &self,
         value: &dyn ResponseContent,
     ) -> Box<dyn ResponseContent> {
@@ -28,6 +28,11 @@ impl Query {
             self.0.query(&json_value).into_iter().cloned().collect(),
         );
         content_type.parse_json(Cow::Owned(queried))
+    }
+
+    /// Apply a query to some content, returning a list of results.
+    pub fn query_list<'a>(&self, value: &'a serde_json::Value) -> NodeList<'a> {
+        self.0.query(value)
     }
 
     /// Apply a query to some content, returning a string. The query should

--- a/crates/slumber_core/src/template/error.rs
+++ b/crates/slumber_core/src/template/error.rs
@@ -178,6 +178,20 @@ pub enum ChainError {
     #[error("No response from prompt/select")]
     PromptNoResponse,
 
+    /// We hit some sort of deserialization error while trying to build dynamic
+    /// options
+    #[error("Dynamic option list failed to deserialize as JSON")]
+    DynamicSelectOptions {
+        #[source]
+        error: Arc<serde_json::Error>,
+    },
+
+    #[error(
+        "Dynamic select options are invalid. Source must be an array or a \
+        selector must be provided."
+    )]
+    DynamicOptionsInvalid,
+
     /// A bubbled-error from rendering a nested template in the chain arguments
     #[error("Rendering nested template for field `{field}`")]
     Nested {

--- a/crates/slumber_core/src/test_util.rs
+++ b/crates/slumber_core/src/test_util.rs
@@ -136,9 +136,9 @@ pub struct TestSelectPrompter {
 }
 
 impl TestSelectPrompter {
-    pub fn new<T: Into<usize>>(responses: impl IntoIterator<Item = T>) -> Self {
+    pub fn new(responses: impl IntoIterator<Item = usize>) -> Self {
         Self {
-            responses: responses.into_iter().map(T::into).collect(),
+            responses: responses.into_iter().collect(),
             index: 0.into(),
         }
     }

--- a/crates/slumber_tui/src/view/component/queryable_body.rs
+++ b/crates/slumber_tui/src/view/component/queryable_body.rs
@@ -232,7 +232,7 @@ fn init_text(
             // Body is a known content type so we parsed it - apply a query if
             // necessary and prettify the output
             query
-                .map(|query| query.query(parsed_body).prettify())
+                .map(|query| query.query_content(parsed_body).prettify())
                 .unwrap_or_else(|| parsed_body.prettify())
         })
         // Content couldn't be parsed, fall back to the raw text

--- a/slumber.yml
+++ b/slumber.yml
@@ -37,6 +37,12 @@ chains:
         - baz
         - a really really really really long option
         - "{{chains.username}}"
+  select_dynamic:
+    source: !select
+      message: Select a value
+      options:
+        source: "{{chains.auth_token}}"
+        selector: $[*]
   auth_token:
     source: !request
       recipe: login
@@ -83,7 +89,7 @@ requests:
         url: "{{host}}/get"
         query:
           - foo=bar
-          - select={{chains.select_value}}
+          - select={{chains.select_dynamic}}
 
       get_user: !request
         <<: *base


### PR DESCRIPTION
## Description

Modifies the expected type of a Chainsource::Select to support a dynamic options list.

Updates rendering code to support the potential enum, parsing the result from a dynamic options list from a stringified JSON array to expected vector.

Phase 3 of [issue#352](https://github.com/LucasPickering/slumber/issues/352)

## Known Risks

None

## QA

selectValue uses a dynamic list (based on a request - see `slumber.yml` diff) - and it renders ok in preview:
![image](https://github.com/user-attachments/assets/249334af-a46a-40d3-b39f-d79369e841bf)

the list is generated via the chain, parsed to an array, and correctly presented to the user:
![image](https://github.com/user-attachments/assets/db53c593-da53-4324-9e0e-d40222f48f7c)

![image](https://github.com/user-attachments/assets/de7958ed-3891-4751-b829-0ae035935ecd)

## Checklist

- [X] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [X] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
