### PR TITLE
Remove message batching optimization

### DIFF
--- a/crates/slumber_tui/src/lib.rs
+++ b/crates/slumber_tui/src/lib.rs
@@ -27,9 +27,7 @@ use crate::{
 use anyhow::{anyhow, Context};
 use chrono::Utc;
 use crossterm::{
-    event::{
-        self, DisableMouseCapture, EnableMouseCapture, Event, EventStream,
-    },
+    event::{DisableMouseCapture, EnableMouseCapture, Event, EventStream},
     terminal::{EnterAlternateScreen, LeaveAlternateScreen},
 };
 use futures::StreamExt;
@@ -205,15 +203,7 @@ impl Tui {
             needs_draw |= self.view.handle_events();
 
             // ===== Draw Phase =====
-            // Only draw if something's changed. Skip draws if we have more
-            // messages to process. This prevents us from falling behind the
-            // message queue, which can happen if the UI gets slow. Interactions
-            // will start to look jittery, but it's better than locking the user
-            // out. We know the next loop iteration will also have a message to
-            // handle, so we don't have to worry about losing the draw entirely.
-            let has_more_messages = !self.messages_rx.is_empty()
-                || event::poll(Duration::from_millis(0)).unwrap_or(false);
-            if needs_draw && !has_more_messages {
+            if needs_draw {
                 self.draw()?;
             }
         }


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

The optimization was to skip draws while there are messages in the queue. The goal of it was to prevent the TUI from falling behind when draws get slow. The problem is this changes the semantics of the program. A draw updates the set of which components are visible, which affects event handling since only visible components are given events. This specifically caused a bug in the following chain of events:

1. User input triggers event (open a modal)
2. Event handling calls a component constructor (history modal)
3. Constructor queues a message (load history from DB)
4. Component is rendered immediately after construction, so it's marked as visible = true
5. Message contains a callback to queue a local event with the loaded data

With the optimization, step 4 is skipped because of the message queued in step 3. This means by the time the local event is handled in step 5, the new component was never rendered so it's still marked as visible=false and doesn't get to see its own event.

In general optimizations should not change the semantics of a program. In the future I think the best way to prevent the event loop from falling behind is to fix slow renders rather than skipping them. This may lead to some worse behavior for the user, but the tradeoff is less complexity in the main loop. This was a hard bug to find and I don't want to do it again.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Degraded performance when renders get slow

## QA

_How did you test this?_

Manually. There's no tests for the full TUI loop and I'm avoiding writing them cause it's hard.

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
