### PR TITLE
Modal cleanup, improve component tracing

### DIFF
--- a/crates/slumber_tui/src/view.rs
+++ b/crates/slumber_tui/src/view.rs
@@ -34,7 +34,7 @@ use slumber_core::{
     db::CollectionDatabase,
 };
 use std::{fmt::Debug, sync::Arc};
-use tracing::{error, trace, trace_span};
+use tracing::{debug, trace_span, warn};
 
 /// Primary entrypoint for the view. This contains the main draw functions, as
 /// well as bindings for externally modifying the view state. We use a component
@@ -155,11 +155,11 @@ impl View {
             trace_span!("View event", ?event).in_scope(|| {
                 match self.root.update_all(event) {
                     Update::Consumed => {
-                        trace!("View event consumed")
+                        debug!("View event consumed")
                     }
                     // Consumer didn't eat the event - huh?
                     Update::Propagate(_) => {
-                        error!("View event was unhandled");
+                        warn!("View event was unhandled");
                     }
                 }
             });

--- a/crates/slumber_tui/src/view/common/actions.rs
+++ b/crates/slumber_tui/src/view/common/actions.rs
@@ -28,7 +28,7 @@ impl<T: FixedSelect> ActionsModal<T> {
         let on_submit = move |action: &mut T| {
             // Close the modal *first*, so the parent can handle the
             // callback event. Jank but it works
-            ViewContext::push_event(Event::CloseModal);
+            ViewContext::push_event(Event::CloseModal { submitted: true });
             ViewContext::push_event(Event::new_local(*action));
         };
 

--- a/crates/slumber_tui/src/view/component/internal.rs
+++ b/crates/slumber_tui/src/view/component/internal.rs
@@ -46,7 +46,7 @@ thread_local! {
 /// in the past where the inner component is drawn without this pass through
 /// layer, which means the component area isn't tracked. That means cursor
 /// events aren't handled.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct Component<T> {
     /// Unique random identifier for this component, to reference it in global
     /// state
@@ -218,6 +218,13 @@ impl<T> Component<T> {
 
         self.inner.draw(frame, props, metadata);
         drop(guard); // Make sure guard stays alive until here
+    }
+}
+
+// Derive impl doesn't work because the constructor gets the correct name
+impl<T: Default> Default for Component<T> {
+    fn default() -> Self {
+        Self::new(T::default())
     }
 }
 

--- a/crates/slumber_tui/src/view/component/profile_select.rs
+++ b/crates/slumber_tui/src/view/component/profile_select.rs
@@ -146,7 +146,7 @@ impl ProfileListModal {
         fn on_submit(profile: &mut ProfileListItem) {
             // Close the modal *first*, so the parent can handle the
             // callback event. Jank but it works
-            ViewContext::push_event(Event::CloseModal);
+            ViewContext::push_event(Event::CloseModal { submitted: true });
             ViewContext::push_event(Event::new_local(SelectProfile(
                 profile.id.clone(),
             )));

--- a/crates/slumber_tui/src/view/context.rs
+++ b/crates/slumber_tui/src/view/context.rs
@@ -167,14 +167,17 @@ mod tests {
         assert_events!(); // Start empty
 
         ViewContext::push_event(Event::new_local(3u32));
-        ViewContext::push_event(Event::CloseModal);
+        ViewContext::push_event(Event::CloseModal { submitted: false });
         assert_events!(
             Event::Local(event) if event.downcast_ref::<u32>() == Some(&3),
-            Event::CloseModal,
+            Event::CloseModal{ submitted: false },
         );
 
         assert_matches!(ViewContext::pop_event(), Some(Event::Local(_)));
-        assert_matches!(ViewContext::pop_event(), Some(Event::CloseModal));
+        assert_matches!(
+            ViewContext::pop_event(),
+            Some(Event::CloseModal { submitted: false })
+        );
         assert_events!(); // Empty again
     }
 

--- a/crates/slumber_tui/src/view/event.rs
+++ b/crates/slumber_tui/src/view/event.rs
@@ -195,8 +195,14 @@ pub enum Event {
     /// Show a modal to the user
     OpenModal(Box<dyn Modal>),
     /// Close the current modal. This is useful for the contents of the modal
-    /// to implement custom close triggers.
-    CloseModal,
+    /// to implement custom close triggers
+    CloseModal {
+        /// Some modals have a concept of submission, and want to execute
+        /// certain one-time code during close, conditional on whether the
+        /// modal was submitted or cancelled. For modals without submissions,
+        /// this is `false`.
+        submitted: bool,
+    },
 
     /// Tell the user something informational
     Notify(Notification),


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

- Add `submitted` flag to `ModalClose` event
  - This prevents the need to track submission state with `Rc<Cell<bool>>` nonsense
- Fix empty name for components created with `Component::default()`
- Improve tracing messages during component event handling

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

- Overtracing
  - Mitigated by hiding everything behind the tracing tier
- Bugs in modal handling
  - Mitigated with various test cases

## QA

_How did you test this?_

Manually and existing test cases. No new functionality to test.

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
