### PR TITLE
add-select: CHANGELOG, docs, and test enhancements for ChainSource::Select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Here's the full list of changes:
   - Press `e` on any value you want to edit (you can [customize the key](https://slumber.lucaspickering.me/book/api/configuration/input_bindings.html))
 - Add `editor` field to the config, allowing you to customize what editor Slumber opens for in-app editing
   - [See docs for more](https://slumber.lucaspickering.me/book/api/configuration/editor.html)
+- Add `!select` ChainSource type, allowing your collection to prompt the user to select a value from a static list
+  - [See docs for more](https://slumber.lucaspickering.me/book/api/request_collection/chain_source.html#select)
 
 ### Changed
 

--- a/crates/slumber_core/src/test_util.rs
+++ b/crates/slumber_core/src/test_util.rs
@@ -121,10 +121,38 @@ impl Prompter for TestPrompter {
         }
     }
 
-    fn select(&self, select: Select) {
+    fn select(&self, _select: Select) {
+        unimplemented!("TestPrompter does not support selects")
+    }
+}
+
+/// Response to selects with zero or more values in sequence
+#[derive(Debug, Default)]
+pub struct TestSelectPrompter {
+    /// Index within the contained select to grab response for
+    responses: Vec<usize>,
+    /// Track where in the sequence of responses we are
+    index: AtomicUsize,
+}
+
+impl TestSelectPrompter {
+    pub fn new<T: Into<usize>>(responses: impl IntoIterator<Item = T>) -> Self {
+        Self {
+            responses: responses.into_iter().map(T::into).collect(),
+            index: 0.into(),
+        }
+    }
+}
+
+impl Prompter for TestSelectPrompter {
+    fn prompt(&self, _prompt: Prompt) {
+        unimplemented!("TestSelectPrompter does not support prompts")
+    }
+
+    fn select(&self, mut select: Select) {
         let index = self.index.fetch_add(1, Ordering::Relaxed);
         if let Some(value) = self.responses.get(index) {
-            select.channel.respond(value.clone())
+            select.channel.respond(select.options.swap_remove(*value))
         }
     }
 }

--- a/docs/src/api/request_collection/chain.md
+++ b/docs/src/api/request_collection/chain.md
@@ -41,6 +41,15 @@ password:
     message: Enter Password
   sensitive: true
 ---
+# Prompt the user to select a value from a static list
+fruit:
+  souce: !select
+    message: Select Fruit
+    options:
+      - apple
+      - banana
+      - guava
+---
 # Use a value from another response
 # Assume the request recipe with ID `login` returns a body like `{"token": "foo"}`
 auth_token:

--- a/docs/src/api/request_collection/chain_source.md
+++ b/docs/src/api/request_collection/chain_source.md
@@ -33,6 +33,7 @@ message: Enter Password
 | `!env`     | [`ChainSource::Environment`](#environment-variable) | Value of an envionrment variable, or empty string if undefined  |
 | `!file`    | [`ChainSource::File`](#file)                        | Contents of the file                                            |
 | `!prompt`  | [`ChainSource::Prompt`](#prompt)                    | Value entered by the user                                       |
+| `!select`  | [`ChainSource::Select`](#select)                    | User selects a value from a list                                |
 
 ### Request
 
@@ -135,4 +136,13 @@ Prompt the user for input to use as the rendered value.
 | Field     | Type       | Description                                                                                                                                   | Default  |
 | --------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
 | `message` | `Template` | Descriptive prompt for the user                                                                                                               | Chain ID |
-| `default` | `Template` | Value to pre-populated the prompt textbox. **Note**: Dur to a library limitation, not supported on chains with `sensitive: true` _in the CLI_ | `null`   |
+| `default` | `Template` | Value to pre-populated the prompt textbox. **Note**: Due to a library limitation, not supported on chains with `sensitive: true` _in the CLI_ | `null`   |
+
+### Select
+
+Prompt the user to select a defined value from a list.
+
+| Field     | Type          | Description                             | Default  |
+| --------- | ------------- | --------------------------------------- | -------- |
+| `message` | `Template`    | Descriptive prompt for the user         | Chain ID |
+| `options` | `Template[]`  | List of options to present to the user  | Required |


### PR DESCRIPTION
## Description

Updates the CHANGELOG and documentation to detail the new ChainSource previously introduced.

Enhances tests associated with the select prompt functionality to prove out rendering and chain resolving.

## Known Risks

None

## QA

docs appear correct - 
<img width="794" alt="image" src="https://github.com/user-attachments/assets/bbf5fda9-8592-49c7-b5ae-087cd9cedadc">
<img width="821" alt="image" src="https://github.com/user-attachments/assets/a56da0c5-3c9a-413a-8fff-c47fdfddfb8c">
<img width="793" alt="image" src="https://github.com/user-attachments/assets/be1b7d11-e774-4234-97e2-8d4b57c2a611">

## Checklist

- [X] Have you read `CONTRIBUTING.md` already?
- [X] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [X] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
