### PR TITLE
Redraw entire screen after resize

### DIFF
--- a/crates/slumber_tui/src/lib.rs
+++ b/crates/slumber_tui/src/lib.rs
@@ -281,7 +281,10 @@ impl Tui {
                 event: Event::Resize(_, _),
                 ..
             } => {
-                // Immediately redraw the screen
+                // Redraw the entire screen. There are certain scenarios where
+                // the terminal gets cleared but ratatui's (e.g. waking from
+                // sleep) buffer doesn't, so the two get out of sync
+                self.terminal.clear()?;
                 self.draw()?;
             }
             Message::Input { event, action } => {


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

I've seen some issues when starting after a sleep, or connecting an external monitor, where the app doesn't entirely redraw. Clearing the screen after a resize should fix it.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

## QA

_How did you test this?_

Still need to validate 

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
