### PR TITLE
Fix release by tweaking changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ Here's the full list of changes:
 
 ### Fixed
 
-- Fix Basic auth being label as Bearer auth in Recipe Authentication pane
+- Fix basic auth being label as bearer auth in Recipe Authentication pane
 - Use correct binding for `search` action in the placeholder of the response filter textbox
   - Previously it was hardcoded to display the default of `/`
 - Fix response body filter not applying on new responses


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

That's an interesting commit message, isn't it. Apparently having the words "Basic" and "Bearer" in the changelog causes the CI to identify the release plan as containing "secrets", and therefore doesn't share it from the plan step to the execution steps. This error messages around this from Github are incredibly poor so I had to find the offending words with some binary search-type thing.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

## QA

_How did you test this?_

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
