### PR TITLE
Remove non-existent command from docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+- Updated the Configuration docs to remove the non-existent `slumber show dir` command
+
 ## [2.0.0] - 2024-09-06
 
 2.0 is headlined by a highly requested feature: one-off edits to recipes! If you need to tweak a query parameter or edit a body, but don't want to modify your collection file, you can now highlight the value in question and hit `e` to modify it. The override will be retained until you modify the collection file or exit Slumber, at which point it will revert to its original value.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
 - Updated the Configuration docs to remove the non-existent `slumber show dir` command
 
 ## [2.0.0] - 2024-09-06

--- a/docs/src/api/configuration/index.md
+++ b/docs/src/api/configuration/index.md
@@ -4,7 +4,7 @@ Configuration provides _application_-level settings, as opposed to collection-le
 
 ## Location & Creation
 
-Configuration is stored in the Slumber root directory, under the file `config.yml`. To find the root directory, you can run:
+Configuration is stored in the Slumber root directory, under the file `config.yml`. To find the config file, you can run:
 
 ```sh
 slumber show paths

--- a/docs/src/api/configuration/index.md
+++ b/docs/src/api/configuration/index.md
@@ -7,14 +7,7 @@ Configuration provides _application_-level settings, as opposed to collection-le
 Configuration is stored in the Slumber root directory, under the file `config.yml`. To find the root directory, you can run:
 
 ```sh
-slumber show dir
-```
-
-To quickly create and edit the file:
-
-```sh
-# Replace vim with your favorite text editor
-vim $(slumber show dir)/config.yml
+slumber show paths
 ```
 
 If the root directory doesn't exist yet, you can create it yourself or have Slumber create it by simply starting the TUI.


### PR DESCRIPTION
## Description

The docs reference the `slumber show dir` command which does not exist.
The similar `slumber show paths` command provides the required information.

## Known Risks

None, this is a documentation only change.

## QA

Ran `oranda dev` and observed the corrected docs.

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
