### PR TITLE
Dynamic select changelog + docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 
 - Use `SLUMBER_CONFIG_PATH` to customize configuration (_not_ collection) file path [#370](https://github.com/LucasPickering/slumber/issues/370)
+- Add a dynamic variant to `!select` chain type, allowing your collection to present a list of values driven from the output of another chain. (thanks @anussel5559)
+  - [See docs for more](https://slumber.lucaspickering.me/book/api/request_collection/chain_source.html#select)
 
 ### Fixed
 

--- a/docs/src/api/request_collection/chain_source.md
+++ b/docs/src/api/request_collection/chain_source.md
@@ -173,10 +173,19 @@ password:
 
 Prompt the user to select a defined value from a list.
 
-| Field     | Type         | Description                            | Default  |
-| --------- | ------------ | -------------------------------------- | -------- |
-| `message` | `Template`   | Descriptive prompt for the user        | Chain ID |
-| `options` | `Template[]` | List of options to present to the user | Required |
+| Field     | Type                               | Description                            | Default  |
+| --------- | ---------------------------------- | -------------------------------------- | -------- |
+| `message` | `Template`                         | Descriptive prompt for the user        | Chain ID |
+| `options` | [`SelectOptions`](#Select-options) | List of options to present to the user | Required |
+
+#### Select Options
+
+The list of options to present to the user. This can be a static list of values or a dynamic configuration to generate the list of options.
+
+| Variant   | Type                                              | Description                                                  |
+| --------- | ------------------------------------------------- | ------------------------------------------------------------ |
+| `fixed`   | `Template[]`                                      | A fixed list of options                                      |
+| `dynamic` | [`DynamicSelectOptions`](#dynamic-select-options) | A dynamic configuration used to generate the list of options |
 
 #### Examples
 
@@ -188,4 +197,21 @@ fruit:
       - apple
       - banana
       - guava
+dynamic_fruit:
+  source: !select
+    message: Select Fruit
+    options:
+      # Assume this respones body looks like: {"fruits": ["apple", "guava", "pear"]}
+      source: "{{chains.request_fruit}}"
+      selector: $.fruits[*]
 ```
+
+### Dynamic Select Options
+
+This defines a dynamic configuration used to generate the list of options in a select chain. The `source` output could be any JSON value, in which case a `selector` must be used to filter to a JSON array.
+If the `source` output is already a JSON array, no selector is required.
+
+| Field      | Type                                                                                   | Description                                                                        | Default  |
+| ---------- | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | -------- |
+| `source`   | `Template`                                                                             | The source of the data to drive the list of options.                               | Required |
+| `selector` | [`JSONPath`](https://www.ietf.org/archive/id/draft-goessner-dispatch-jsonpath-00.html) | A JSONPath expression to filter down to a JSON array.                              | `null`   |


### PR DESCRIPTION
## Description

Updates the changelog and docs to detail new dynamic variant on `options` in the select chain type

## Known Risks

None

## QA

Docs render - 
![image](https://github.com/user-attachments/assets/d5537621-b8f3-423c-b148-24cfb542a782)

## Checklist

- [X] Have you read `CONTRIBUTING.md` already?
- [X] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [X] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
