### PR TITLE
Add `slumber new` subcommand to generate a new collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Add a dynamic variant to `!select` chain type, allowing your collection to present a list of values driven from the output of another chain. (thanks @anussel5559)
   - [See docs for more](https://slumber.lucaspickering.me/book/api/request_collection/chain_source.html#select)
 - Cancel in-flight requests with the `cancel` action (bound to escape by default)
+- Add `slumber new` subcommand to generate new collection files [#376](https://github.com/LucasPickering/slumber/issues/376)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2201,13 +2201,18 @@ dependencies = [
  "anyhow",
  "clap",
  "dialoguer",
+ "env-lock",
  "indexmap",
  "itertools 0.13.0",
+ "pretty_assertions",
  "reqwest",
+ "rstest",
  "serde",
+ "serde_json",
  "serde_yaml",
  "slumber_config",
  "slumber_core",
+ "tokio",
  "tracing",
 ]
 

--- a/crates/slumber_cli/Cargo.toml
+++ b/crates/slumber_cli/Cargo.toml
@@ -23,5 +23,13 @@ slumber_config = {workspace = true}
 slumber_core = {workspace = true}
 tracing = {workspace = true}
 
+[dev-dependencies]
+env-lock = {workspace = true}
+pretty_assertions = {workspace = true}
+rstest = {workspace = true}
+serde_json = {workspace = true}
+slumber_core = {workspace = true, features = ["test"]}
+tokio = {workspace = true, features = ["rt", "macros"]}
+
 [package.metadata.release]
 tag = false

--- a/crates/slumber_cli/src/commands.rs
+++ b/crates/slumber_cli/src/commands.rs
@@ -2,5 +2,6 @@ pub mod collections;
 pub mod generate;
 pub mod history;
 pub mod import;
+pub mod new;
 pub mod request;
 pub mod show;

--- a/crates/slumber_cli/src/commands/new.rs
+++ b/crates/slumber_cli/src/commands/new.rs
@@ -1,0 +1,152 @@
+use crate::{GlobalArgs, Subcommand};
+use anyhow::Context;
+use clap::Parser;
+use std::{fs::OpenOptions, io::Write, path::PathBuf, process::ExitCode};
+
+/// We use a static source file, to get control of whitespace/comments.
+/// Generating a collection and serializing it would be like driving from the
+/// back seat with a broom stick.
+const SOURCE: &[u8] = include_bytes!("new.yml");
+const DEFAULT_PATH: &str = "slumber.yml";
+
+/// Generate a new Slumber collection file
+#[derive(Clone, Debug, Parser)]
+pub struct NewCommand {
+    /// Path to write the new file to. If omitted, fall back to the global
+    /// `--file` argument, or default to `slumber.yml`
+    file: Option<PathBuf>,
+    /// If a file already exists at the path, overwrite it instead of failing
+    #[clap(long)]
+    overwrite: bool,
+}
+
+impl Subcommand for NewCommand {
+    async fn execute(self, global: GlobalArgs) -> anyhow::Result<ExitCode> {
+        let path = self
+            .file
+            .or(global.file)
+            .unwrap_or_else(|| DEFAULT_PATH.into());
+
+        let mut file = OpenOptions::new()
+            .create_new(!self.overwrite)
+            .create(self.overwrite)
+            .write(true)
+            .truncate(self.overwrite)
+            .open(&path)
+            .with_context(|| format!("Error opening file {path:?}"))?;
+        file.write_all(SOURCE)
+            .with_context(|| format!("Error writing to file {path:?}"))?;
+
+        eprintln!("New collection created at `{}`", path.display());
+
+        Ok(ExitCode::SUCCESS)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indexmap::indexmap;
+    use pretty_assertions::assert_eq;
+    use rstest::rstest;
+    use serde_json::json;
+    use slumber_core::{
+        collection::{
+            Chain, ChainSource, Collection, Folder, Method, Profile, Recipe,
+            RecipeBody, RecipeNode,
+        },
+        http::content_type::ContentType,
+        test_util::{by_id, temp_dir, Factory, TempDir},
+    };
+    use std::{env, fs};
+
+    /// Test creating a new collection file, specifying the path in various ways
+    #[rstest]
+    #[case::default_path(None, None, "slumber.yml")]
+    #[case::global_path_arg(None, Some("global.yml"), "global.yml")]
+    #[case::local_path_arg(Some("local.yml"), Some("global.yml"), "local.yml")]
+    #[tokio::test]
+    async fn test_new(
+        temp_dir: TempDir,
+        #[case] file_arg: Option<&str>,
+        #[case] global_file_arg: Option<&str>,
+        #[case] expected_created_path: PathBuf,
+    ) {
+        // Lock an empty env as a proxy for the cwd. We can't just construct
+        // full paths because the default value will always be relative to cwd
+        let _guard = env_lock::lock_env([] as [(&str, Option<&str>); 0]);
+        env::set_current_dir(&*temp_dir).unwrap();
+
+        let command = NewCommand {
+            file: file_arg.map(PathBuf::from),
+            overwrite: false,
+        };
+        let global_args = GlobalArgs {
+            file: global_file_arg.map(PathBuf::from),
+        };
+
+        command.execute(global_args).await.unwrap();
+        let contents = fs::read(&expected_created_path)
+            .with_context(|| {
+                format!(
+                    "Error reading results from expected output path \
+                    {expected_created_path:?}"
+                )
+            })
+            .unwrap();
+        assert_eq!(contents, SOURCE);
+    }
+
+    /// Test that the initial collection is a valid collection with some
+    /// specific contents
+    #[test]
+    fn test_deserialize() {
+        let collection: Collection = serde_yaml::from_slice(SOURCE).unwrap();
+        let expected = Collection {
+            profiles: by_id([Profile {
+                id: "example".into(),
+                name: Some("Example Profile".into()),
+                data: indexmap! {
+                    "host".into() => "https://httpbin.org".into()
+                },
+            }]),
+            chains: by_id([Chain {
+                id: "example".into(),
+                source: ChainSource::Request {
+                    recipe: "example1".into(),
+                    trigger: Default::default(),
+                    section: Default::default(),
+                },
+                selector: Some("$.data".parse().unwrap()),
+                ..Chain::factory(())
+            }]),
+            recipes: by_id([
+                RecipeNode::Recipe(Recipe {
+                    id: "example1".into(),
+                    name: Some("Example Request 1".into()),
+                    method: Method::Get,
+                    url: "{{host}}/anything".into(),
+                    ..Recipe::factory(())
+                }),
+                RecipeNode::Folder(Folder {
+                    id: "example_folder".into(),
+                    name: Some("Example Folder".into()),
+                    children: by_id([RecipeNode::Recipe(Recipe {
+                        id: "example2".into(),
+                        name: Some("Example Request 2".into()),
+                        method: Method::Post,
+                        url: "{{host}}/anything".into(),
+                        body: Some(RecipeBody::Raw {
+                            body: json!({"data": "{{chains.example}}"}).into(),
+                            content_type: Some(ContentType::Json),
+                        }),
+                        ..Recipe::factory(())
+                    })]),
+                }),
+            ])
+            .into(),
+            _ignore: serde::de::IgnoredAny,
+        };
+        assert_eq!(collection, expected);
+    }
+}

--- a/crates/slumber_cli/src/commands/new.yml
+++ b/crates/slumber_cli/src/commands/new.yml
@@ -1,0 +1,34 @@
+# For basic usage info, see:
+# https://slumber.lucaspickering.me/book/getting_started.html
+# For all collection options, see:
+# https://slumber.lucaspickering.me/book/api/request_collection/index.html
+
+# Profiles are groups of data you can easily switch between. A common usage is
+# to define profiles for various environments of a REST service
+profiles:
+  example:
+    name: Example Profile
+    data:
+      host: https://httpbin.org
+
+# Chains allow you to use dynamic data in your request templates
+chains:
+  example:
+    source: !request
+      recipe: example1
+    selector: $.data
+
+requests:
+  example1: !request
+    name: Example Request 1
+    method: GET
+    url: "{{host}}/anything"
+
+  example_folder: !folder
+    name: Example Folder
+    requests:
+      example2: !request
+        name: Example Request 2
+        method: POST
+        url: "{{host}}/anything"
+        body: !json { "data": "{{chains.example}}" }

--- a/crates/slumber_cli/src/lib.rs
+++ b/crates/slumber_cli/src/lib.rs
@@ -12,8 +12,8 @@ mod util;
 
 use crate::commands::{
     collections::CollectionsCommand, generate::GenerateCommand,
-    history::HistoryCommand, import::ImportCommand, request::RequestCommand,
-    show::ShowCommand,
+    history::HistoryCommand, import::ImportCommand, new::NewCommand,
+    request::RequestCommand, show::ShowCommand,
 };
 use clap::Parser;
 use std::{path::PathBuf, process::ExitCode};
@@ -53,11 +53,12 @@ pub struct GlobalArgs {
 /// A CLI subcommand
 #[derive(Clone, Debug, clap::Subcommand)]
 pub enum CliCommand {
-    Request(RequestCommand),
-    Generate(GenerateCommand),
-    Import(ImportCommand),
     Collections(CollectionsCommand),
+    Generate(GenerateCommand),
     History(HistoryCommand),
+    Import(ImportCommand),
+    New(NewCommand),
+    Request(RequestCommand),
     Show(ShowCommand),
 }
 
@@ -65,11 +66,12 @@ impl CliCommand {
     /// Execute this CLI subcommand
     pub async fn execute(self, global: GlobalArgs) -> anyhow::Result<ExitCode> {
         match self {
-            Self::Generate(command) => command.execute(global).await,
-            Self::Request(command) => command.execute(global).await,
-            Self::Import(command) => command.execute(global).await,
             Self::Collections(command) => command.execute(global).await,
+            Self::Generate(command) => command.execute(global).await,
             Self::History(command) => command.execute(global).await,
+            Self::Import(command) => command.execute(global).await,
+            Self::New(command) => command.execute(global).await,
+            Self::Request(command) => command.execute(global).await,
             Self::Show(command) => command.execute(global).await,
         }
     }

--- a/crates/slumber_core/src/collection/models.rs
+++ b/crates/slumber_core/src/collection/models.rs
@@ -22,7 +22,7 @@ use strum::{EnumIter, IntoEnumIterator};
 /// This deliberately does not implement `Clone`, because it could potentially
 /// be very large. Instead, it's hidden behind an `Arc` by `CollectionFile`.
 #[derive(Debug, Default, Serialize, Deserialize)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(any(test, feature = "test"), derive(PartialEq))]
 #[serde(deny_unknown_fields)]
 pub struct Collection {
     #[serde(default, deserialize_with = "cereal::deserialize_id_map")]
@@ -43,7 +43,7 @@ pub struct Collection {
 
 /// Mutually exclusive hot-swappable config group
 #[derive(Debug, Serialize, Deserialize)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(any(test, feature = "test"), derive(PartialEq))]
 #[serde(deny_unknown_fields)]
 pub struct Profile {
     #[serde(skip)] // This will be auto-populated from the map key
@@ -101,7 +101,7 @@ impl crate::test_util::Factory for ProfileId {
 
 /// A gathering of like-minded recipes and/or folders
 #[derive(Debug, Serialize, Deserialize)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(any(test, feature = "test"), derive(PartialEq))]
 #[serde(deny_unknown_fields)]
 pub struct Folder {
     #[serde(skip)] // This will be auto-populated from the map key
@@ -173,7 +173,7 @@ impl crate::test_util::Factory<&str> for Recipe {
 /// not called `RequestTemplate` because the word "template" has a specific
 /// meaning related to string interpolation.
 #[derive(Debug, Serialize, Deserialize)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(any(test, feature = "test"), derive(PartialEq))]
 #[serde(deny_unknown_fields)]
 pub struct Recipe {
     #[serde(skip)] // This will be auto-populated from the map key
@@ -232,7 +232,7 @@ impl crate::test_util::Factory for RecipeId {
 #[derive(
     Copy, Clone, Debug, Display, EnumIter, FromStr, Serialize, Deserialize,
 )]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(any(test, feature = "test"), derive(PartialEq))]
 #[serde(into = "String", try_from = "String")]
 pub enum Method {
     #[display("CONNECT")]
@@ -343,7 +343,7 @@ impl From<&str> for RecipeBody {
 /// is the middleman: it defines where and how to pull the value, then recipes
 /// can use it in a template via `{{chains.<chain_id>}}`.
 #[derive(Debug, Serialize, Deserialize)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(any(test, feature = "test"), derive(PartialEq))]
 #[serde(deny_unknown_fields)]
 pub struct Chain {
     #[serde(skip)] // This will be auto-populated from the map key
@@ -391,7 +391,7 @@ impl<T: Into<Identifier>> From<T> for ChainId {
 
 /// The source of data for a chain
 #[derive(Debug, Serialize, Deserialize)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(any(test, feature = "test"), derive(PartialEq))]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub enum ChainSource {
     /// Run an external command to get a result
@@ -431,7 +431,7 @@ pub enum ChainSource {
 
 /// Static or dynamic list of options for a select chain
 #[derive(Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(any(test, feature = "test"), derive(PartialEq))]
 pub enum SelectOptions {
     Fixed(Vec<Template>),
     /// Dynamic requires a source (often a chain) that either returns a JSON
@@ -457,7 +457,7 @@ impl ChainSource {
 
 /// The component of the response to use as the chain source
 #[derive(Debug, Default, Serialize, Deserialize)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(any(test, feature = "test"), derive(PartialEq))]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub enum ChainRequestSection {
     #[default]
@@ -470,7 +470,7 @@ pub enum ChainRequestSection {
 /// Define when a recipe with a chained request should auto-execute the
 /// dependency request.
 #[derive(Copy, Clone, Debug, Default, Serialize, Deserialize)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(any(test, feature = "test"), derive(PartialEq))]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub enum ChainRequestTrigger {
     /// Never trigger the request. This is the default because upstream
@@ -489,7 +489,7 @@ pub enum ChainRequestTrigger {
 
 /// Trim whitespace from rendered output
 #[derive(Copy, Clone, Debug, Default, Serialize, Deserialize)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(any(test, feature = "test"), derive(PartialEq))]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub enum ChainOutputTrim {
     /// Do not trim the output

--- a/crates/slumber_core/src/collection/recipe_tree.rs
+++ b/crates/slumber_core/src/collection/recipe_tree.rs
@@ -17,7 +17,7 @@ use thiserror::Error;
 /// lot simpler. In reality it's unlikely they would want to give two things
 /// the same ID anyway.
 #[derive(derive_more::Debug, Default)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(any(test, feature = "test"), derive(PartialEq))]
 pub struct RecipeTree {
     /// Tree structure storing all the folder/recipe data
     tree: IndexMap<RecipeId, RecipeNode>,
@@ -32,12 +32,12 @@ pub struct RecipeTree {
 /// A path into the recipe tree. Every constructed path is assumed to be valid,
 /// which must be enforced by the creator.
 #[derive(Clone, Debug, From)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(any(test, feature = "test"), derive(PartialEq))]
 pub struct RecipeLookupKey(Vec<RecipeId>);
 
 /// A node in the recipe tree, either a folder or recipe
 #[derive(Debug, From, Serialize, Deserialize, EnumDiscriminants)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(any(test, feature = "test"), derive(PartialEq))]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 #[allow(clippy::large_enum_variant)]
 pub enum RecipeNode {

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -17,10 +17,11 @@
 
 # CLI Commands
 
-- [slumber request](./cli/request.md)
-- [slumber import](./cli/import.md)
-- [slumber generate](./cli/generate.md)
 - [slumber collections](./cli/collections.md)
+- [slumber generate](./cli/generate.md)
+- [slumber import](./cli/import.md)
+- [slumber new](./cli/new.md)
+- [slumber request](./cli/request.md)
 - [slumber show](./cli/show.md)
 
 # API Reference

--- a/docs/src/cli/new.md
+++ b/docs/src/cli/new.md
@@ -1,0 +1,15 @@
+# `slumber new`
+
+Generate a new Slumber collection file. The new collection will have some example data predefined.
+
+## Examples
+
+```sh
+# Generate and use a new collection at the default path of slumber.yml
+slumber new
+slumber
+
+# Generate and use a new collection at a custom path
+slumber new my-collection.yml
+slumber -f my-collection.yml
+```

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -6,18 +6,13 @@ Once you've [installed Slumber](/artifacts), setup is easy.
 
 ### 1. Create a Slumber collection file
 
-Slumber's core feature is that it's **source-based**. That means you write down your configuration in a file first, then run Slumber and it reads the file. This differs from other popular clients such as Postman and Insomnia. The goal of being source-based is to make it easy to save and share your configurations.
+Slumber's core feature is that it's **source-based**. That means you write down your configuration in a file first, then run Slumber and it reads the file. This differs from other popular clients such as Postman and Insomnia, where you define your configuration in the app, and it saves it to a file for you. The goal of being source-based is to make it easy to save and share your configurations.
 
-To get started, create a file called `slumber.yml` and add the following contents:
+The easiest way to get started is to generate a new collection with the `new` subcommand:
 
-```yaml
-requests:
-  get: !request
-    method: GET
-    url: https://httpbin.org/get
+```sh
+slumber new
 ```
-
-> Note: the `!request` tag, which tells Slumber that this is a request recipe, not a folder. This is [YAML's tag syntax](https://yaml.org/spec/1.2.2/#24-tags), which is used commonly throughout Slumber to provide explicit configuration.
 
 ### 2. Run Slumber
 
@@ -25,9 +20,11 @@ requests:
 slumber
 ```
 
+This will start the TUI, and you'll see the example requests available. Use tab/shift+tab (or the shortcut keys shown in the pane headers) to navigate around. Select a recipe in the left pane, then hit Enter to send a request.
+
 ## Going Further
 
-Here's a more complete example:
+Now that you have a collection, you'll want to customize it. Here's another example of a simple collection, showcasing multiple profiles:
 
 ```yaml
 # slumber.yml
@@ -52,4 +49,8 @@ requests:
       - big=true
 ```
 
-This request collection uses [templates](./user_guide//templates.md) and [profiles](./api/request_collection/profile.md) allow you to dynamically change the target host.
+> Note: the `!request` tag, which tells Slumber that this is a request recipe, not a folder. This is [YAML's tag syntax](https://yaml.org/spec/1.2.2/#24-tags), which is used commonly throughout Slumber to provide explicit configuration.
+
+This request collection uses [templates](./user_guide//templates.md) and [profiles](./api/request_collection/profile.md), allowing you to dynamically change the target host.
+
+To learn more about the powerful features of Slumber you can use in your collections, keep reading with [Key Concepts](./user_guide/key_concepts.md).


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Added a `slumber new` subcommand that generates a new collection file, similar to `cargo new`. Updated Getting Started docs to include the new command as well.

Closes #376

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

I wasn't sure exactly how much/little to include in the file. I wanted to make it enough to get started and demonstrate some intermediate features (chains/templates) without it being overwhelm. So the risk here is that it's too much info for a complete beginning to grasp, or too little to be maximally helpful.

## QA

_How did you test this?_

- Added some unit tests
- Tested manually

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
