### PR TITLE
Fix query param serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Updated the Configuration docs to remove the non-existent `slumber show dir` command (thanks @SVendittelli)
 - Retain all request history when collection file is reloaded
   - Previously, pending and failed requests were lost on reload within a single session. These will still be lost when a session is exited.
+- Fix serialization of query parameter lists
 
 ## [2.0.0] - 2024-09-06
 

--- a/crates/slumber_core/src/collection/models.rs
+++ b/crates/slumber_core/src/collection/models.rs
@@ -186,10 +186,7 @@ pub struct Recipe {
     pub url: Template,
     pub body: Option<RecipeBody>,
     pub authentication: Option<Authentication>,
-    #[serde(
-        default,
-        deserialize_with = "cereal::deserialize_query_parameters"
-    )]
+    #[serde(default, with = "cereal::serde_query_parameters")]
     pub query: Vec<(String, Template)>,
     #[serde(default)]
     pub headers: IndexMap<String, Template>,


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Fix serialization of query params. Previously it spit out:

```
query:
  - - foo
    - bar
```

Now it spits out:

```
query:
  - foo=bar
```

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

It's possible someone is relying on this broken serialization.

## QA

_How did you test this?_

Added unit tests

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
