### PR TITLE
Replace Option<Component<T>> with Component<Option<T>>

### DIFF
--- a/crates/tui/src/view/component/internal.rs
+++ b/crates/tui/src/view/component/internal.rs
@@ -215,14 +215,42 @@ impl<T> Component<T> {
     ) where
         T: Draw<Props>,
     {
+        self.draw_inner(frame, props, area, has_focus, &self.inner);
+    }
+
+    fn draw_inner<D: Draw<Props>, Props>(
+        &self,
+        frame: &mut Frame,
+        props: Props,
+        area: Rect,
+        has_focus: bool,
+        inner: &D,
+    ) {
         let guard = DrawGuard::new(self.id);
 
         // Update internal state for event handling
         let metadata = DrawMetadata::new_dangerous(area, has_focus);
         self.metadata.set(metadata);
 
-        self.inner.draw(frame, props, metadata);
+        inner.draw(frame, props, metadata);
         drop(guard); // Make sure guard stays alive until here
+    }
+}
+
+impl<T> Component<Option<T>> {
+    /// For components with optional data, draw the contents if present
+    pub fn draw_opt<Props>(
+        &self,
+        frame: &mut Frame,
+        props: Props,
+        area: Rect,
+        has_focus: bool,
+    ) where
+        T: Draw<Props>,
+    {
+        if let Some(inner) = &self.inner {
+            self.draw_inner(frame, props, area, has_focus, inner);
+        }
     }
 }
 

--- a/crates/tui/src/view/component/root.rs
+++ b/crates/tui/src/view/component/root.rs
@@ -37,7 +37,7 @@ pub struct Root {
     // ==== Children =====
     primary_view: Component<PrimaryView>,
     modal_queue: Component<ModalQueue>,
-    notification_text: Option<Component<NotificationText>>,
+    notification_text: Component<Option<NotificationText>>,
 }
 
 impl Root {
@@ -54,7 +54,7 @@ impl Root {
             // Children
             primary_view: primary_view.into(),
             modal_queue: Component::default(),
-            notification_text: None,
+            notification_text: Component::default(),
         }
     }
 
@@ -138,7 +138,7 @@ impl EventHandler for Root {
 
             Event::Notify(notification) => {
                 self.notification_text =
-                    Some(NotificationText::new(notification).into())
+                    Some(NotificationText::new(notification)).into()
             }
 
             Event::Input {
@@ -218,9 +218,8 @@ impl<'a> Draw<RootProps<'a>> for Root {
             Constraint::Length(footer.width() as u16),
         ])
         .areas(footer_area);
-        if let Some(notification_text) = &self.notification_text {
-            notification_text.draw(frame, (), notification_area, false);
-        }
+        self.notification_text
+            .draw_opt(frame, (), notification_area, false);
         frame.render_widget(footer, help_area);
 
         // Render modals last so they go on top

--- a/crates/tui/src/view/event.rs
+++ b/crates/tui/src/view/event.rs
@@ -49,6 +49,17 @@ pub trait EventHandler {
     }
 }
 
+/// Enable `Component<Option<T>>` with an empty event handler
+impl<T: EventHandler> EventHandler for Option<T> {
+    fn update(&mut self, _: &mut UpdateContext, event: Event) -> Update {
+        Update::Propagate(event)
+    }
+
+    fn children(&mut self) -> Vec<Component<Child<'_>>> {
+        Vec::new()
+    }
+}
+
 // We can't do a blanket impl of EventHandler based on DerefMut because of the
 // PersistedLazy's custom ToChild impl, which interferes with the blanket
 // ToChild impl


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

This makes code with optional data fields less clunky (hopefully). Specifically it eliminates the need for weird iter/option flattening in `children` impls, and `if let` guards for drawing optional data.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Code could potentially be harder to follow/more magical

## QA

_How did you test this?_

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
