### PR TITLE
Add default field to profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   - [See docs for more](https://slumber.lucaspickering.me/book/api/request_collection/chain_source.html#select)
 - Cancel in-flight requests with the `cancel` action (bound to escape by default)
 - Add `slumber new` subcommand to generate new collection files [#376](https://github.com/LucasPickering/slumber/issues/376)
+- Add `default` field to profiles
+  - When using the CLI, the `--profile` argument can be omitted to use the default profile
 
 ### Fixed
 

--- a/crates/cli/src/commands/new.rs
+++ b/crates/cli/src/commands/new.rs
@@ -106,6 +106,7 @@ mod tests {
             profiles: by_id([Profile {
                 id: "example".into(),
                 name: Some("Example Profile".into()),
+                default: false,
                 data: indexmap! {
                     "host".into() => "https://httpbin.org".into()
                 },

--- a/crates/core/src/collection.rs
+++ b/crates/core/src/collection.rs
@@ -256,6 +256,7 @@ mod tests {
                 Profile {
                     id: "profile1".into(),
                     name: Some("Profile 1".into()),
+                    default: false,
                     data: indexmap! {
                         "user_guid".into() => "abc123".into(),
                         "username".into() => "xX{{chains.username}}Xx".into(),
@@ -266,6 +267,7 @@ mod tests {
                 Profile {
                     id: "profile2".into(),
                     name: Some("Profile 2".into()),
+                    default: true,
                     data: indexmap! {
                         "host".into() => "https://httpbin.org".into(),
 

--- a/crates/core/src/collection/insomnia.rs
+++ b/crates/core/src/collection/insomnia.rs
@@ -284,20 +284,6 @@ impl Resource {
     }
 }
 
-impl From<Environment> for Profile {
-    fn from(environment: Environment) -> Self {
-        Profile {
-            id: environment.id.into(),
-            name: Some(environment.name),
-            data: environment
-                .data
-                .into_iter()
-                .map(|(k, v)| (k, Template::raw(v)))
-                .collect(),
-        }
-    }
-}
-
 impl From<RequestGroup> for RecipeNode {
     fn from(folder: RequestGroup) -> Self {
         RecipeNode::Folder(Folder {
@@ -484,6 +470,7 @@ fn build_profiles(
                 Profile {
                     id,
                     name: Some(environment.name),
+                    default: false,
                     data,
                 },
             )

--- a/crates/core/src/collection/openapi.rs
+++ b/crates/core/src/collection/openapi.rs
@@ -106,6 +106,7 @@ fn build_profiles(servers: Vec<Server>) -> IndexMap<ProfileId, Profile> {
                     // will be the same value, but we provide it for
                     // discoverability; the user may want to rename it
                     name: Some(url),
+                    default: false,
                     data,
                 },
             )

--- a/crates/tui/src/view/component/primary.rs
+++ b/crates/tui/src/view/component/primary.rs
@@ -108,7 +108,7 @@ impl ToStringGenerate for MenuAction {}
 
 impl PrimaryView {
     pub fn new(collection: &Collection) -> Self {
-        let profile_pane = ProfilePane::new(&collection.profiles).into();
+        let profile_pane = ProfilePane::new(collection).into();
         let recipe_list_pane = RecipeListPane::new(&collection.recipes).into();
         let selected_pane = FixedSelectState::builder()
             // Changing panes kicks us out of fullscreen

--- a/docs/src/api/request_collection/profile.md
+++ b/docs/src/api/request_collection/profile.md
@@ -4,10 +4,11 @@ A profile is a collection of static template values. It's useful for configuring
 
 ## Fields
 
-| Field  | Type                                         | Description                       | Default                |
-| ------ | -------------------------------------------- | --------------------------------- | ---------------------- |
-| `name` | `string`                                     | Descriptive name to use in the UI | Value of key in parent |
-| `data` | [`mapping[string, Template]`](./template.md) | Fields, mapped to their values    | `{}`                   |
+| Field     | Type                                         | Description                                                 | Default                |
+| --------- | -------------------------------------------- | ----------------------------------------------------------- | ---------------------- |
+| `name`    | `string`                                     | Descriptive name to use in the UI                           | Value of key in parent |
+| `default` | `boolean`                                    | Use this profile in the CLI when `--profile` isn't provided | `null`                 |
+| `data`    | [`mapping[string, Template]`](./template.md) | Fields, mapped to their values                              | `{}`                   |
 
 ## Examples
 

--- a/slumber.yml
+++ b/slumber.yml
@@ -5,6 +5,7 @@
 profiles:
   works:
     name: This Works
+    default: true
     data:
       host: https://httpbin.org
       username: xX{{chains.username}}Xx

--- a/test_data/regression.yml
+++ b/test_data/regression.yml
@@ -18,6 +18,7 @@ profiles:
       user_guid: abc123
   profile2:
     name: Profile 2
+    default: true
     data:
       <<: *base_profile_data
 


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

For the CLI, the default profile will be used when --profile isn't passed. For the TUI, we'll just preselect this field on first startup. Only one profile can be marked as default, and that's enforced during deserialization.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Default enforcement could be broken. Mitigated with a test. CLI is untested. 

## QA

_How did you test this?_

Unit tests, tested CLI manually

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
