### PR TITLE
Reset edited values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Add `slumber new` subcommand to generate new collection files [#376](https://github.com/LucasPickering/slumber/issues/376)
 - Add `default` field to profiles
   - When using the CLI, the `--profile` argument can be omitted to use the default profile
+- Reset edited recipe values to their default using `r`
+  - You can [customize the key](https://slumber.lucaspickering.me/book/api/configuration/input_bindings.html) to whatever you want
 
 ### Changed
 

--- a/crates/config/src/input.rs
+++ b/crates/config/src/input.rs
@@ -144,6 +144,8 @@ pub enum Action {
     /// Trigger the workflow to provide a temporary override for a recipe value
     /// (body/param/etc.)
     Edit,
+    /// Reset temporary recipe override to its default value
+    Reset,
     /// Browse request history
     History,
     /// Start a search/filter operation

--- a/crates/tui/src/input.rs
+++ b/crates/tui/src/input.rs
@@ -173,6 +173,7 @@ impl Default for InputEngine {
                 Action::Toggle => KeyCode::Char(' ').into(),
                 Action::Cancel => KeyCode::Esc.into(),
                 Action::Edit => KeyCode::Char('e').into(),
+                Action::Reset => KeyCode::Char('r').into(),
                 Action::SelectProfileList => KeyCode::Char('p').into(),
                 Action::SelectRecipeList => KeyCode::Char('l').into(),
                 Action::SelectRecipe => KeyCode::Char('c').into(),

--- a/crates/tui/src/view/component/recipe_pane/body.rs
+++ b/crates/tui/src/view/component/recipe_pane/body.rs
@@ -201,8 +201,11 @@ impl RawBody {
 
 impl EventHandler for RawBody {
     fn update(&mut self, _: &mut UpdateContext, event: Event) -> Update {
-        if let Some(Action::Edit) = event.action() {
+        let action = event.action();
+        if let Some(Action::Edit) = action {
             self.open_editor();
+        } else if let Some(Action::Reset) = action {
+            self.body.reset_override();
         } else if let Some(SaveBodyOverride(path)) = event.local() {
             self.load_override(path);
         } else {
@@ -329,6 +332,10 @@ mod tests {
             persisted,
             Some(RecipeOverrideValue::Override("goodbye!".into()))
         );
+
+        // Reset edited state
+        component.send_key(KeyCode::Char('r')).assert_empty();
+        assert_eq!(component.data().override_value(), None);
     }
 
     /// Override template should be loaded from the persistence store on init

--- a/crates/tui/src/view/component/recipe_pane/recipe.rs
+++ b/crates/tui/src/view/component/recipe_pane/recipe.rs
@@ -188,8 +188,9 @@ impl Draw for RecipeDisplay {
         frame.render_widget(
             Paragraph::new(Span::styled(
                 format!(
-                    "Press {} to edit value",
-                    tui_context.input_engine.binding_display(Action::Edit)
+                    "Press {} to edit value, {} to reset",
+                    tui_context.input_engine.binding_display(Action::Edit),
+                    tui_context.input_engine.binding_display(Action::Reset),
                 ),
                 tui_context.styles.text.hint,
             ))

--- a/crates/tui/src/view/component/recipe_pane/table.rs
+++ b/crates/tui/src/view/component/recipe_pane/table.rs
@@ -107,11 +107,18 @@ where
     RowToggleKey: PersistedKey<Value = bool>,
 {
     fn update(&mut self, _: &mut UpdateContext, event: Event) -> Update {
-        if let Some(Action::Edit) = event.action() {
+        let action = event.action();
+        if let Some(Action::Edit) = action {
             if let Some(selected_row) = self.select.data().selected() {
                 selected_row.open_edit_modal();
             }
             // Consume the event even if we have no rows, for consistency
+        } else if let Some(Action::Reset) = action {
+            if let Some(selected_row) =
+                self.select.data_mut().get_mut().selected_mut()
+            {
+                selected_row.value.reset_override();
+            }
         } else if let Some(SaveRecipeTableOverride { row_index, value }) =
             event.local()
         {
@@ -449,6 +456,12 @@ mod tests {
                 .into_iter()
                 .collect(),
         );
+
+        // Reset edited state
+        component.send_key(KeyCode::Char('r')).assert_empty();
+        let selected_row =
+            component.data().inner().select.data().selected().unwrap();
+        assert!(!selected_row.value.is_overridden());
     }
 
     /// Override templates should be loaded from the store on init

--- a/crates/tui/src/view/state/select.rs
+++ b/crates/tui/src/view/state/select.rs
@@ -217,8 +217,14 @@ impl<Item, State: SelectStateData> SelectState<Item, State> {
     /// Get the currently selected item (if any)
     pub fn selected(&self) -> Option<&Item> {
         self.items
-            .get(self.state.borrow().selected()?)
+            .get(self.selected_index()?)
             .map(|item| &item.value)
+    }
+
+    /// Mutable reference to the currently selected item (if any)
+    pub fn selected_mut(&mut self) -> Option<&mut Item> {
+        let index = self.selected_index()?;
+        self.items.get_mut(index).map(|item| &mut item.value)
     }
 
     /// Select an item by value. Context is required for callbacks. Generally

--- a/docs/src/api/configuration/input_bindings.md
+++ b/docs/src/api/configuration/input_bindings.md
@@ -31,41 +31,42 @@ input_bindings:
 
 ## Actions
 
-| Action                | Default Binding             |
-| --------------------- | --------------------------- |
-| `left_click`          | None                        |
-| `right_click`         | None                        |
-| `scroll_up`           | None                        |
-| `scroll_down`         | None                        |
-| `scroll_left`         | `shift left`                |
-| `scroll_right`        | `shift right`               |
-| `quit`                | `q`                         |
-| `force_quit`          | `ctrl c`                    |
-| `previous_pane`       | `backtab` (AKA `shift tab`) |
-| `next_pane`           | `tab`                       |
-| `up`                  | `up`                        |
-| `down`                | `down`                      |
-| `left`                | `left`                      |
-| `right`               | `right`                     |
-| `page_up`             | `pgup`                      |
-| `page_down`           | `pgdn`                      |
-| `home`                | `home`                      |
-| `end`                 | `end`                       |
-| `submit`              | `enter`                     |
-| `toggle`              | `space`                     |
-| `cancel`              | `esc`                       |
-| `edit`                | `e`                         |
-| `history`             | `h`                         |
-| `search`              | `/`                         |
-| `reload_collection`   | `f5`                        |
-| `fullscreen`          | `f`                         |
-| `open_actions`        | `x`                         |
-| `open_help`           | `?`                         |
-| `select_profile_list` | `p`                         |
-| `select_recipe_list`  | `l`                         |
-| `select_recipe`       | `c`                         |
-| `select_request`      | `r`                         |
-| `select_response`     | `s`                         |
+| Action                | Default Binding             | Description                                           |
+| --------------------- | --------------------------- | ----------------------------------------------------- |
+| `left_click`          | None                        |                                                       |
+| `right_click`         | None                        |                                                       |
+| `scroll_up`           | None                        |                                                       |
+| `scroll_down`         | None                        |                                                       |
+| `scroll_left`         | `shift left`                |                                                       |
+| `scroll_right`        | `shift right`               |                                                       |
+| `quit`                | `q`                         | Exit current dialog, or the entire app                |
+| `force_quit`          | `ctrl c`                    | Exit the app, regardless                              |
+| `previous_pane`       | `backtab` (AKA `shift tab`) | Select previous pane in the cycle                     |
+| `next_pane`           | `tab`                       |                                                       |
+| `up`                  | `up`                        |                                                       |
+| `down`                | `down`                      |                                                       |
+| `left`                | `left`                      |                                                       |
+| `right`               | `right`                     |                                                       |
+| `page_up`             | `pgup`                      |                                                       |
+| `page_down`           | `pgdn`                      |                                                       |
+| `home`                | `home`                      |                                                       |
+| `end`                 | `end`                       |                                                       |
+| `submit`              | `enter`                     | Send a request, submit a text box, etc.               |
+| `toggle`              | `space`                     | Toggle a checkbox on/off                              |
+| `cancel`              | `esc`                       | Cancel current dialog or request                      |
+| `edit`                | `e`                         | Apply a temporary override to a recipe value          |
+| `reset`               | `r`                         | Reset temporary recipe override to its default        |
+| `history`             | `h`                         | Open request history for a recipe                     |
+| `search`              | `/`                         | Open/select search for current pane                   |
+| `reload_collection`   | `f5`                        | Force reload collection file                          |
+| `fullscreen`          | `f`                         | Fullscreen current pane                               |
+| `open_actions`        | `x`                         | Open actions menu                                     |
+| `open_help`           | `?`                         | Open help dialog                                      |
+| `select_profile_list` | `p`                         | Open Profile List dialog                              |
+| `select_recipe_list`  | `l`                         | Select Recipe List pane                               |
+| `select_recipe`       | `c`                         | Select Recipe pane                                    |
+| `select_response`     | `s`                         | Select Request/Response pane                          |
+| `select_request`      | `r`                         | Select Request/Response pane (backward compatibility) |
 
 > Note: mouse bindings are not configurable; mouse actions such as `left_click` _can_ be bound to a key combination, which cannot be unbound from the default mouse action.
 


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Reset edited recipe values with `r`

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

It's easy to accidentally reset a value, because there's no confirmation. This could be mitigated with a confirmation dialog, but I don't think it's worth it because the overrides are meant to be temporary anyway, so losing it shouldn't be catastrophic.

## QA

_How did you test this?_

Added unit tests, tested manually in TUI

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
