### PR TITLE
De-deprecate {{env.VARIABLE}} source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   - Database file remains in [data dir](https://docs.rs/dirs/latest/dirs/fn.data_dir.html) on all platforms
 - Create config file on startup if it doesn't exist
 - If config file fails to load during TUI startup, display an error and fall back to the default, rather than crashing
+- De-deprecate `{{env.VARIABLE}}` template sources
+  - They'll remain as a simpler alternative to `!env` chains
 
 ### Fixed
 

--- a/crates/core/src/template.rs
+++ b/crates/core/src/template.rs
@@ -208,7 +208,6 @@ pub enum TemplateKey {
     #[display("{CHAIN_PREFIX}{_0}")]
     Chain(ChainId),
     /// A value pulled from the process environment
-    /// DEPRECATED: To be removed in 2.0, replaced by !env chain source
     #[display("{ENV_PREFIX}{_0}")]
     Environment(Identifier),
 }

--- a/docs/src/api/request_collection/template.md
+++ b/docs/src/api/request_collection/template.md
@@ -10,11 +10,11 @@ For more detail on usage and examples, see the [user guide page on templates](..
 
 There are several ways of sourcing templating values:
 
-| Source                        | Syntax                | Description                                                                                                              | Default          |
-| ----------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------- |
-| [Profile](./profile.md) Field | `{{field_name}}`      | Static value from a profile                                                                                              | Error if unknown |
-| Environment Variable          | `{{env.VARIABLE}}`    | Environment variable from parent shell/process. **Deprecated in favor of the [`!env` chain source](./chain_source.md).** | `""`             |
-| [Chain](./chain.md)           | `{{chains.chain_id}}` | Complex chained value                                                                                                    | Error if unknown |
+| Source                        | Syntax                | Description                                    | Default          |
+| ----------------------------- | --------------------- | ---------------------------------------------- | ---------------- |
+| [Profile](./profile.md) Field | `{{field_name}}`      | Static value from a profile                    | Error if unknown |
+| Environment Variable          | `{{env.VARIABLE}}`    | Environment variable from parent shell/process | `""`             |
+| [Chain](./chain.md)           | `{{chains.chain_id}}` | Complex chained value                          | Error if unknown |
 
 ## Escape Sequences
 


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

I originally deprecated this when I added the `!env` chain source, but if all you're doing is reading a static variable, this is a simple alternative. It costs very little to continue to support this so I think it's worth keeping around.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Higher complexity with more features supported.

## QA

_How did you test this?_

Doc change only

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
