### PR TITLE
Change default keybind for reset action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Add `slumber new` subcommand to generate new collection files [#376](https://github.com/LucasPickering/slumber/issues/376)
 - Add `default` field to profiles
   - When using the CLI, the `--profile` argument can be omitted to use the default profile
-- Reset edited recipe values to their default using `r`
+- Reset edited recipe values to their default using `z`
   - You can [customize the key](https://slumber.lucaspickering.me/book/api/configuration/input_bindings.html) to whatever you want
 - Add `selector_mode` field to chains, to control how single vs multiple results from a JSONPath selector are handled
   - Previously, if a selector returned multiple results, an error was returned. Now, the result list will be rendered as a JSON array. To return to the previous behavior, set `selector_mode: single` in your chain.

--- a/crates/tui/src/input.rs
+++ b/crates/tui/src/input.rs
@@ -173,7 +173,7 @@ impl Default for InputEngine {
                 Action::Toggle => KeyCode::Char(' ').into(),
                 Action::Cancel => KeyCode::Esc.into(),
                 Action::Edit => KeyCode::Char('e').into(),
-                Action::Reset => KeyCode::Char('r').into(),
+                Action::Reset => KeyCode::Char('z').into(),
                 Action::SelectProfileList => KeyCode::Char('p').into(),
                 Action::SelectRecipeList => KeyCode::Char('l').into(),
                 Action::SelectRecipe => KeyCode::Char('c').into(),

--- a/crates/tui/src/view/component/recipe_pane/authentication.rs
+++ b/crates/tui/src/view/component/recipe_pane/authentication.rs
@@ -342,7 +342,7 @@ mod tests {
         );
 
         // Reset username
-        component.send_key(KeyCode::Char('r')).assert_empty();
+        component.send_key(KeyCode::Char('z')).assert_empty();
         assert_eq!(component.data().inner().override_value(), None);
 
         // Edit password
@@ -359,7 +359,7 @@ mod tests {
         );
 
         // Reset password
-        component.send_key(KeyCode::Char('r')).assert_empty();
+        component.send_key(KeyCode::Char('z')).assert_empty();
         assert_eq!(component.data().inner().override_value(), None);
     }
 
@@ -423,7 +423,7 @@ mod tests {
         );
 
         // Reset token
-        component.send_key(KeyCode::Char('r')).assert_empty();
+        component.send_key(KeyCode::Char('z')).assert_empty();
         assert_eq!(component.data().inner().override_value(), None);
     }
 

--- a/crates/tui/src/view/component/recipe_pane/body.rs
+++ b/crates/tui/src/view/component/recipe_pane/body.rs
@@ -334,7 +334,7 @@ mod tests {
         );
 
         // Reset edited state
-        component.send_key(KeyCode::Char('r')).assert_empty();
+        component.send_key(KeyCode::Char('z')).assert_empty();
         assert_eq!(component.data().override_value(), None);
     }
 

--- a/crates/tui/src/view/component/recipe_pane/table.rs
+++ b/crates/tui/src/view/component/recipe_pane/table.rs
@@ -458,7 +458,7 @@ mod tests {
         );
 
         // Reset edited state
-        component.send_key(KeyCode::Char('r')).assert_empty();
+        component.send_key(KeyCode::Char('z')).assert_empty();
         let selected_row =
             component.data().inner().select.data().selected().unwrap();
         assert!(!selected_row.value.is_overridden());


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

I forgot r is already used for the request/response pane. I went with z because it's kinda like undo, which is ctrl-z.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Unintuitive bind

## QA

_How did you test this?_

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
