### PR TITLE
Don't trigger updates for useless events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Retain all request history when collection file is reloaded
   - Previously, pending and failed requests were lost on reload within a single session. These will still be lost when a session is exited.
 - Fix serialization of query parameter lists
+- Don't update UI for useless events (e.g. cursor moves)
 
 ## [2.0.0] - 2024-09-06
 


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

This should limit CPU usage slightly, and also prevents the strange situation where the request timer ticks faster when wiggling the cursor.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Lost events or other odd behavior.

## QA

_How did you test this?_

Manually

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
