### PR TITLE
Rename `slumber complete` -> `slumber completions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Add `slumber completions` subcommand
+  - Right now only static completions are available (e.g. subcommands). In the future I am to add dynamic completions based on your collection file (e.g. recipe and profile IDs)
+
 ## [2.1.0] - 2024-09-27
 
 ### Added

--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -1,5 +1,5 @@
 pub mod collections;
-pub mod complete;
+pub mod completions;
 pub mod generate;
 pub mod history;
 pub mod import;

--- a/crates/cli/src/commands/complete.rs
+++ b/crates/cli/src/commands/complete.rs
@@ -1,10 +1,8 @@
-use crate::{Args, GlobalArgs, Subcommand};
+use crate::{Args, GlobalArgs, Subcommand, COMMAND_NAME};
 use anyhow::anyhow;
 use clap::{CommandFactory, Parser};
 use clap_complete::Shell;
 use std::{io, process::ExitCode};
-
-const COMMAND_NAME: &str = "slumber";
 
 /// Generate shell completions
 #[derive(Clone, Debug, Parser)]

--- a/crates/cli/src/commands/completions.rs
+++ b/crates/cli/src/commands/completions.rs
@@ -6,13 +6,13 @@ use std::{io, process::ExitCode};
 
 /// Generate shell completions
 #[derive(Clone, Debug, Parser)]
-pub struct CompleteCommand {
+pub struct CompletionsCommand {
     /// Shell type. Default to $SHELL
     #[clap(long)]
     shell: Option<Shell>,
 }
 
-impl Subcommand for CompleteCommand {
+impl Subcommand for CompletionsCommand {
     async fn execute(self, _: GlobalArgs) -> anyhow::Result<ExitCode> {
         let shell = self
             .shell

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -11,7 +11,7 @@ mod commands;
 mod util;
 
 use crate::commands::{
-    collections::CollectionsCommand, complete::CompleteCommand,
+    collections::CollectionsCommand, completions::CompletionsCommand,
     generate::GenerateCommand, history::HistoryCommand, import::ImportCommand,
     new::NewCommand, request::RequestCommand, show::ShowCommand,
 };
@@ -57,7 +57,7 @@ pub struct GlobalArgs {
 #[derive(Clone, Debug, clap::Subcommand)]
 pub enum CliCommand {
     Collections(CollectionsCommand),
-    Complete(CompleteCommand),
+    Completions(CompletionsCommand),
     Generate(GenerateCommand),
     History(HistoryCommand),
     Import(ImportCommand),
@@ -71,7 +71,7 @@ impl CliCommand {
     pub async fn execute(self, global: GlobalArgs) -> anyhow::Result<ExitCode> {
         match self {
             Self::Collections(command) => command.execute(global).await,
-            Self::Complete(command) => command.execute(global).await,
+            Self::Completions(command) => command.execute(global).await,
             Self::Generate(command) => command.execute(global).await,
             Self::History(command) => command.execute(global).await,
             Self::Import(command) => command.execute(global).await,

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -18,11 +18,14 @@ use crate::commands::{
 use clap::Parser;
 use std::{path::PathBuf, process::ExitCode};
 
+const COMMAND_NAME: &str = "slumber";
+
 #[derive(Debug, Parser)]
 #[clap(
     author,
     version,
     about,
+    name = COMMAND_NAME,
     long_about = "Configurable HTTP client with both TUI and CLI interfaces"
 )]
 pub struct Args {


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

I did some spot checks on other commands to see what's common to name this subcommand. There's:

- `rustup completions`
- `kubectl completion`
- `rg complete-<shell>`

So I went with rustup because it's the most widespread for users.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Lack of dynamic completions is frustrating.

## QA

_How did you test this?_

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
