### PR TITLE
Fix error loading requests with empty header values from history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   - [See docs](https://slumber.lucaspickering.me/book/troubleshooting/shell_completions.html) for more info and a list of supported shells
 - Add `slumber gen` alias to `--help` documentation
 
+### Fixed
+
+- Fix error loading requests with empty header values from history [#400](https://github.com/LucasPickering/slumber/issues/400)
+
 ## [2.1.0] - 2024-09-27
 
 ### Added

--- a/crates/core/src/db/convert.rs
+++ b/crates/core/src/db/convert.rs
@@ -302,6 +302,9 @@ impl<'a> ToSql for SqlWrap<&'a HeaderMap> {
 
 impl FromSql for SqlWrap<HeaderMap> {
     fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+        // There's no easy way to re-use the header parsing logic from the http
+        // crate, so we have to reimplement it ourselves
+
         fn header_line(
             input: &mut &[u8],
         ) -> PResult<(HeaderName, HeaderValue)> {
@@ -312,7 +315,7 @@ impl FromSql for SqlWrap<HeaderMap> {
                     HEADER_FIELD_DELIM,
                 ),
                 terminated(
-                    take_while(1.., |c| c != HEADER_LINE_DELIM)
+                    take_while(0.., |c| c != HEADER_LINE_DELIM)
                         .try_map(HeaderValue::from_bytes),
                     HEADER_LINE_DELIM,
                 ),


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Just a simple parsing bug. I assumed header values couldn't be empty, which is wrong. I DID confirm that empty header names are invalid (not allowed by the `http` crate) so don't need to worry about that.

Closes #400

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

This is a temporary fix. I'd love to use a library for the parsing, but it's not clear if I can tap into reqwest/hyper/httparse to do this, so I need to work on it a bit more.

## QA

_How did you test this?_

Manually :(

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
