### PR TITLE
Fix input bindings involving shift and a character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - Fix error loading requests with empty header values from history [#400](https://github.com/LucasPickering/slumber/issues/400)
+- Fix input bindings involving `shift` and a character (e.g. `shift g`) [#401](https://github.com/LucasPickering/slumber/issues/401)
 
 ## [2.1.0] - 2024-09-27
 

--- a/crates/tui/src/input.rs
+++ b/crates/tui/src/input.rs
@@ -89,8 +89,11 @@ impl InputEngine {
                 self.bindings
                     .iter()
                     .find(|(_, binding)| binding.matches(key))
-                    .inspect(|(action,binding)| {
-                        trace!(event = ?key, ?action, ?binding, "Matched key event to binding");
+                    .inspect(|(action, binding)| {
+                        trace!(
+                            event = ?key, ?action, ?binding,
+                            "Matched key event to binding"
+                        );
                     })
                     .map(|(action, _)| *action)
             }

--- a/crates/tui/src/view.rs
+++ b/crates/tui/src/view.rs
@@ -36,7 +36,7 @@ use slumber_core::{
     http::RequestId,
 };
 use std::{fmt::Debug, sync::Arc};
-use tracing::{debug, trace_span, warn};
+use tracing::{trace, trace_span, warn};
 
 /// Primary entrypoint for the view. This contains the main draw functions, as
 /// well as bindings for externally modifying the view state. We use a component
@@ -171,7 +171,7 @@ impl View {
             trace_span!("View event", ?event).in_scope(|| {
                 match self.root.update_all(&mut context, event) {
                     Update::Consumed => {
-                        debug!("View event consumed")
+                        trace!("View event consumed")
                     }
                     // Consumer didn't eat the event - huh?
                     Update::Propagate(_) => {


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

When a key combination involves "shift", crossterm reports the keycode as a capital letter (e.g. KeyCode::Char('G')). This was breaking the equality matching.

Closes #401

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Further fragile logic. Mitigated with some tests. I totally believe there's other input bugs in there though.

## QA

_How did you test this?_

Added some unit tests, tested in the TUI

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
