### PR TITLE
Preserve key order of objects in JSON responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Changes
+
+- Preserve key order of objects in JSON responses [#405](https://github.com/LucasPickering/slumber/issues/405)
+
 ## [2.2.0] - 2024-10-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2050,6 +2050,7 @@ version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -2236,7 +2237,6 @@ dependencies = [
  "reqwest",
  "rstest",
  "serde",
- "serde_json",
  "serde_yaml",
  "slumber_config",
  "slumber_core",
@@ -2323,7 +2323,6 @@ dependencies = [
  "reqwest",
  "rstest",
  "serde",
- "serde_json",
  "serde_json_path",
  "serde_yaml",
  "slumber_config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,14 +31,13 @@ ratatui = {version = "0.28.0", default-features = false}
 reqwest = {version = "0.12.5", default-features = false}
 rstest = {version = "0.21.0", default-features = false}
 serde = {version = "1.0.204", default-features = false}
-serde_json = {version = "1.0.120", default-features = false}
 serde_json_path = "0.6.3"
 serde_test = "1.0.176"
 serde_yaml = {version = "0.9.0", default-features = false}
-slumber_cli = {path = "./crates/cli", version = "2.2.0" }
-slumber_config = {path = "./crates/config", version = "2.2.0" }
-slumber_core = {path = "./crates/core", version = "2.2.0" }
-slumber_tui = {path = "./crates/tui", version = "2.2.0" }
+slumber_cli = {path = "./crates/cli", version = "2.2.0"}
+slumber_config = {path = "./crates/config", version = "2.2.0"}
+slumber_core = {path = "./crates/core", version = "2.2.0"}
+slumber_tui = {path = "./crates/tui", version = "2.2.0"}
 strum = {version = "0.26.3", default-features = false}
 tokio = {version = "1.39.2", default-features = false}
 tracing = "0.1.40"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -13,7 +13,7 @@ version = "2.2.0"
 [dependencies]
 anyhow = {workspace = true}
 clap = {version = "4.4.2", features = ["derive"]}
-clap_complete = { version = "4.5.29", features = ["unstable-dynamic"] }
+clap_complete = {version = "4.5.29", features = ["unstable-dynamic"]}
 dialoguer = {version = "0.11.0", default-features = false, features = ["password"]}
 indexmap = {workspace = true}
 itertools = {workspace = true}
@@ -28,7 +28,6 @@ tracing = {workspace = true}
 env-lock = {workspace = true}
 pretty_assertions = {workspace = true}
 rstest = {workspace = true}
-serde_json = {workspace = true}
 slumber_core = {workspace = true, features = ["test"]}
 tokio = {workspace = true, features = ["rt", "macros"]}
 

--- a/crates/cli/src/commands/new.rs
+++ b/crates/cli/src/commands/new.rs
@@ -49,7 +49,6 @@ mod tests {
     use indexmap::indexmap;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
-    use serde_json::json;
     use slumber_core::{
         collection::{
             Chain, ChainSource, Collection, Folder, Method, Profile, Recipe,
@@ -138,7 +137,8 @@ mod tests {
                         method: Method::Post,
                         url: "{{host}}/anything".into(),
                         body: Some(RecipeBody::Raw {
-                            body: json!({"data": "{{chains.example}}"}).into(),
+                            body: "{\n  \"data\": \"{{chains.example}}\"\n}"
+                                .into(),
                             content_type: Some(ContentType::Json),
                         }),
                         ..Recipe::factory(())

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -29,7 +29,7 @@ rstest = {workspace = true, optional = true}
 rusqlite = {version = "0.31.0", default-features = false, features = ["bundled", "chrono", "uuid"]}
 rusqlite_migration = "1.2.0"
 serde = {workspace = true, features = ["derive"]}
-serde_json = {workspace = true}
+serde_json = {version = "1.0.120", default-features = false, features = ["preserve_order"]}
 serde_json_path = "0.6.3"
 serde_yaml = {workspace = true}
 strum = {workspace = true, features = ["derive"]}

--- a/crates/core/src/http/query.rs
+++ b/crates/core/src/http/query.rs
@@ -113,11 +113,11 @@ mod tests {
     #[case::object("$.object", r#"{"a":1,"b":2}"#)]
     fn test_query_to_string_types(#[case] query: &str, #[case] expected: &str) {
         let content = json(json!({
-            "int": 3,
-            "bool": true,
-            "string": "hi!",
             "array": ["hi", 1],
+            "bool": true,
+            "int": 3,
             "object": {"a": 1, "b": 2},
+            "string": "hi!",
         }));
         let query = Query::from_str(query).unwrap();
         let out = query

--- a/crates/core/src/template.rs
+++ b/crates/core/src/template.rs
@@ -425,11 +425,11 @@ mod tests {
 
         let database = CollectionDatabase::factory(());
         let response_body = json!({
-            "string": "Hello World!",
-            "number": 6,
-            "bool": false,
             "array": [1, 2],
+            "bool": false,
+            "number": 6,
             "object": {"a": 1},
+            "string": "Hello World!",
         });
         let response_headers =
             header_map(indexmap! {"Token" => "Secret Value"});

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -25,7 +25,6 @@ persisted = {version = "0.3.1", features = ["serde"]}
 ratatui = {workspace = true, features = ["crossterm", "underline-color", "unstable-widget-ref"]}
 reqwest = {workspace = true}
 serde = {workspace = true}
-serde_json = {workspace = true}
 serde_json_path = {workspace = true}
 serde_yaml = {workspace = true}
 slumber_config = {workspace = true}


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Enable `preserve_order` feature flag of `serde_json` so it uses `IndexMap` internally instead of `HashMap`. We're already pulling in `indexmap` as a dependency.

Closes #405

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

- Duplicated dependency. I confirmed it isn't with `cargo tree -i -p indexmap`, only one version is present
- Response ordering changes for users. Not a big deal

## QA

_How did you test this?_

Manually in TUI

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
