### PR TITLE
Improve performance for large bodies more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -439,6 +439,11 @@ chains:
 ### Changed
 
 - Don't print full stack trace for failed CLI commands
+- Disable formatting and highlighting for response bodies over 1MB (size threshold customizable [in the config](https://slumber.lucaspickering.me/book/api/configuration/index.html))
+
+### Fixes
+
+- Improve performance of handling large response bodies
 
 ## [0.16.0] - 2024-04-01
 

--- a/crates/core/src/http.rs
+++ b/crates/core/src/http.rs
@@ -302,6 +302,15 @@ pub struct HttpEngineConfig {
     pub large_body_size: usize,
 }
 
+impl HttpEngineConfig {
+    /// Is the given size (e.g. request or response body size) larger than the
+    /// configured "large" body size? Large bodies are treated differently, for
+    /// performance reasons.
+    pub fn is_large(&self, size: usize) -> bool {
+        size > self.large_body_size
+    }
+}
+
 impl Default for HttpEngineConfig {
     fn default() -> Self {
         Self {

--- a/crates/core/src/http/models.rs
+++ b/crates/core/src/http/models.rs
@@ -460,8 +460,10 @@ impl ResponseRecord {
             .ok();
         // Store whether we succeeded or not, so we know not to try again
         if self.body.parsed.set(body).is_err() {
-            // Unfortunately we don't have any helpful context to include here.
-            // The body could potentially be huge so don't log it.
+            // This indicates a logic error, because this should only be
+            // called once, when the response is first received.
+            // Unfortunately we don't have any helpful context to include
+            // here. The body could potentially be huge so don't log it.
             error!("Response body parsed twice");
         }
     }
@@ -515,8 +517,9 @@ pub struct ResponseBody {
     /// Raw body
     data: Bytes,
     /// For responses of a known content type, we can parse the body into a
-    /// real data structure. This is populated *eagerly*. Call
-    /// [ResponseRecord::parse_body] to set the parsed body.
+    /// real data structure. This is populated manually; Call
+    /// [ResponseRecord::parse_body] to set the parsed body. This uses a lock
+    /// so it can be parsed and populated in a background thread.
     #[serde(skip)]
     parsed: OnceLock<Option<Box<dyn ResponseContent>>>,
 }

--- a/crates/tui/src/view/util.rs
+++ b/crates/tui/src/view/util.rs
@@ -3,7 +3,11 @@
 pub mod highlight;
 pub mod persistence;
 
-use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use itertools::Itertools;
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    text::{Line, Text},
+};
 use slumber_core::template::{Prompt, PromptChannel, Prompter, Select};
 
 /// A data structure for representation a yes/no confirmation. This is similar
@@ -61,4 +65,15 @@ pub fn centered_rect(
         .direction(Direction::Horizontal)
         .constraints([buffer_x, width, buffer_x].as_ref())
         .split(columns[1])[1]
+}
+
+/// Convert a `&str` to an **owned** `Text` object. This is functionally the
+/// same as `s.to_owned().into()`, but prevents having to clone the entire text
+/// twice (once to create the `String` and again when breaking it apart into
+/// lines).
+pub fn str_to_text(s: &str) -> Text<'static> {
+    s.lines()
+        .map(|line| Line::from(line.to_owned()))
+        .collect_vec()
+        .into()
 }


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

 - Disable formatting/highlighting on bodies large than the "large" body size threshold (1MB by default, but it's configurable)
 - Run body parsing in a background task

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

- large bodies still result in pretty poor UI performance while visible on the screen, it's just not nearly as bad as it used to be
- Lack of prettyification/highlighting might be confusing. I didn't want to spend screen real estate on a message, so supplement with a red indicator on the response size, plus some documentation

## QA

_How did you test this?_

manually in UI

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
