### PR TITLE
Optimize display of large text bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - Fixed `ignore_certificate_hosts` and `large_body_size` fields not being loaded from config
+- Improve performance of large response bodies [#356](https://github.com/LucasPickering/slumber/issues/356)
+  - This includes disabling prettyification and syntax highlighting on bodies over 1 MB (this size is configurable, via the `large_body_size` [config field](https://slumber.lucaspickering.me/book/api/configuration/index.html))
+  - Loading a large response body should no longer cause the UI to freeze or low framerate
 
 ## [2.2.0] - 2024-10-22
 

--- a/crates/tui/src/view/state.rs
+++ b/crates/tui/src/view/state.rs
@@ -6,6 +6,7 @@ pub mod select;
 use chrono::{DateTime, Utc};
 use derive_more::Deref;
 use std::cell::{Ref, RefCell};
+use uuid::Uuid;
 
 /// An internally mutable cell for UI state. Certain state needs to be updated
 /// during the draw phase, typically because it's derived from parent data
@@ -81,6 +82,34 @@ impl<K, V> Default for StateCell<K, V> {
         Self {
             state: RefCell::new(None),
         }
+    }
+}
+
+/// A uniquely identified immutable value. Useful for detecting changes in
+/// values that are expensive to do full comparisons on.
+#[derive(Debug, Deref)]
+pub struct Identified<T> {
+    id: Uuid,
+    #[deref]
+    value: T,
+}
+
+impl<T> Identified<T> {
+    pub fn new(value: T) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            value,
+        }
+    }
+
+    pub fn id(&self) -> Uuid {
+        self.id
+    }
+}
+
+impl<T> From<T> for Identified<T> {
+    fn from(value: T) -> Self {
+        Self::new(value)
     }
 }
 


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

It turns out calculating the width of a text body is expensive for large bodies, because we have to count every grapheme. This change caches the text dimensions so we only have to calculate it when the text changes.

Further progress on #356

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Code complexity

## QA

_How did you test this?_

manually. No functionality change means it's hard to write tests for this

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
