### PR TITLE
Bump Github actions to their latest versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,22 +16,16 @@ jobs:
       # chosen version is fairly arbitrary
       TOOLCHAIN: nightly-2024-04-20
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: ${{env.TOOLCHAIN}}
           components: rustfmt
+          cache: true
 
-      - name: Cache Rust files
-        uses: swatinem/rust-cache@v2
-
-      - name: Rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          toolchain: ${{env.TOOLCHAIN}}
-          command: fmt
-          args: -- --check
+      - name: Rustfmt Check
+        uses: actions-rust-lang/rustfmt@v1
 
   lint:
     name: Check/Lint - ${{ matrix.platform.name }}
@@ -52,7 +46,7 @@ jobs:
             target: aarch64-apple-darwin
     runs-on: ${{ matrix.platform.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Cache Rust files
         uses: swatinem/rust-cache@v2
@@ -62,26 +56,20 @@ jobs:
       - name: Install toolchain
         run: rustup target add ${{ matrix.platform.target }}
 
-      - name: Clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --target ${{ matrix.platform.target }} --all-targets --all-features -- -D clippy::all'
+      - name: Run Clippy
+        run: cargo clippy --target ${{ matrix.platform.target }} --all-targets --all-features -- -D clippy::all
 
   doc:
     name: Check Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Cache Rust files
         uses: swatinem/rust-cache@v2
 
       - name: Doc
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --no-deps --all-features --document-private-items
+        run: cargo doc --no-deps --all-features --document-private-items
         env:
           RUSTDOCFLAGS: -D warnings
 
@@ -104,7 +92,7 @@ jobs:
             target: aarch64-apple-darwin
     runs-on: ${{ matrix.platform.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Cache Rust files
         uses: swatinem/rust-cache@v2
@@ -115,7 +103,4 @@ jobs:
         run: rustup target add ${{ matrix.platform.target }}
 
       - name: Run tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace
+        run: cargo test --workspace

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -39,10 +39,10 @@ jobs:
     name: Build and deploy site and docs
     runs-on: ubuntu-latest
     env:
-      ORANDA_VERSION: v0.5.0
+      ORANDA_VERSION: v0.6.5
     steps:
       # Setup
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           lfs: true
@@ -59,7 +59,7 @@ jobs:
           oranda build
 
       - name: Check HTML for broken internal links
-        uses: untitaker/hyperlink@0.1.29
+        uses: untitaker/hyperlink@0.1.42
         with:
           args: ./public
 
@@ -71,7 +71,7 @@ jobs:
       # go into repo's settings > pages and set "deploy from branch: gh-pages"
       # the other defaults work fine.
       - name: Deploy to Github Pages
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        uses: JamesIves/github-pages-deploy-action@v4.6.8
         # ONLY if we're on master (so no PRs or feature branches allowed!)
         if: ${{ github.ref == 'refs/heads/master' }}
         with:


### PR DESCRIPTION
This PR bumps GitHub workflows to their latest versions, thus avoiding deprecation warnings as seen e.g. [here](https://github.com/LucasPickering/slumber/actions/runs/11541918569).