### PR TITLE
Fix race condition with body parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2308,6 +2308,7 @@ name = "slumber_tui"
 version = "2.2.0"
 dependencies = [
  "anyhow",
+ "bytes",
  "chrono",
  "cli-clipboard",
  "crossterm",

--- a/crates/core/src/db.rs
+++ b/crates/core/src/db.rs
@@ -16,7 +16,7 @@ use rusqlite::{named_params, Connection, DatabaseName, OptionalExtension};
 use serde::{de::DeserializeOwned, Serialize};
 use std::{
     fmt::Debug,
-    ops::DerefMut,
+    ops::{Deref, DerefMut},
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
 };
@@ -361,7 +361,7 @@ impl CollectionDatabase {
 
                     ":status_code": exchange.response.status.as_u16(),
                     ":response_headers": SqlWrap(&exchange.response.headers),
-                    ":response_body": exchange.response.body.bytes(),
+                    ":response_body": exchange.response.body.bytes().deref(),
                 },
             )
             .context(format!(

--- a/crates/core/src/db/convert.rs
+++ b/crates/core/src/db/convert.rs
@@ -209,13 +209,13 @@ impl<'a, 'b> TryFrom<&'a Row<'b>> for Exchange {
                     .get::<_, Option<SqlWrap<Bytes>>>("request_body")?
                     .map(|wrap| wrap.0),
             }),
-            response: Arc::new(ResponseRecord {
+            response: ResponseRecord {
                 status: row.get::<_, SqlWrap<StatusCode>>("status_code")?.0,
                 headers: row
                     .get::<_, SqlWrap<HeaderMap>>("response_headers")?
                     .0,
                 body: row.get::<_, SqlWrap<Bytes>>("response_body")?.0.into(),
-            }),
+            },
         })
     }
 }

--- a/crates/core/src/http.rs
+++ b/crates/core/src/http.rs
@@ -63,7 +63,7 @@ use reqwest::{
     Client, RequestBuilder, Response, Url,
 };
 use serde::{Deserialize, Serialize};
-use std::{collections::HashSet, sync::Arc};
+use std::collections::HashSet;
 use tracing::{info, info_span};
 
 const USER_AGENT: &str = concat!("slumber/", env!("CARGO_PKG_VERSION"));
@@ -375,7 +375,7 @@ impl RequestTicket {
                 let exchange = Exchange {
                     id,
                     request: self.record,
-                    response: Arc::new(response),
+                    response,
                     start_time,
                     end_time,
                 };
@@ -1362,7 +1362,7 @@ mod tests {
             .to_str()
             .unwrap();
         assert_eq!(
-            *exchange.response,
+            exchange.response,
             ResponseRecord {
                 status: StatusCode::OK,
                 headers: header_map([

--- a/crates/core/src/template.rs
+++ b/crates/core/src/template.rs
@@ -538,7 +538,7 @@ mod tests {
             response: ResponseRecord {
                 body: "not json!".into(),
                 ..ResponseRecord::factory(())
-            }.into(),
+            },
             ..Exchange::factory(RecipeId::from("recipe1"))
         }),
         "content type not provided",
@@ -560,7 +560,7 @@ mod tests {
             response: ResponseRecord {
                 body: "not json!".into(),
                 ..ResponseRecord::factory(())
-            }.into(),
+            },
             ..Exchange::factory(RecipeId::from("recipe1"))
         }),
         "Parsing response: expected ident at line 1 column 2",
@@ -582,7 +582,7 @@ mod tests {
             response: ResponseRecord {
                 body: "[1, 2]".into(),
                 ..ResponseRecord::factory(())
-            }.into(),
+            },
             ..Exchange::factory(RecipeId::from("recipe1"))
         }),
         "No results from JSONPath query",

--- a/crates/core/src/template/render.rs
+++ b/crates/core/src/template/render.rs
@@ -539,9 +539,7 @@ impl<'a> ChainTemplateSource<'a> {
             ChainRequestTrigger::Always => send_request().await?,
         };
 
-        // We haven't passed the exchange around so we can unwrap the Arc safely
-        Ok(Arc::try_unwrap(exchange.response)
-            .expect("Request Arc should have only one reference"))
+        Ok(exchange.response)
     }
 
     /// Extract the specified component bytes from the response. For headers,

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -12,6 +12,7 @@ version = "2.2.0"
 
 [dependencies]
 anyhow = {workspace = true}
+bytes = {workspace = true}
 chrono = {workspace = true}
 cli-clipboard = "0.4.0"
 crossterm = {workspace = true, features = ["bracketed-paste", "windows", "events", "event-stream"]}

--- a/crates/tui/src/util.rs
+++ b/crates/tui/src/util.rs
@@ -4,6 +4,7 @@ use crate::{
     view::Confirm,
 };
 use anyhow::Context;
+use bytes::Bytes;
 use crossterm::event;
 use editor_command::EditorBuilder;
 use futures::{future, FutureExt};
@@ -107,7 +108,7 @@ pub async fn signals() -> anyhow::Result<()> {
 pub async fn save_file(
     messages_tx: MessageSender,
     default_path: Option<String>,
-    data: Vec<u8>,
+    data: Bytes,
 ) -> anyhow::Result<()> {
     // If the user closed the prompt, just exit
     let Some(path) =
@@ -255,7 +256,7 @@ mod tests {
         let handle = tokio::spawn(save_file(
             harness.messages_tx().clone(),
             Some("default.txt".into()),
-            b"hello!".to_vec(),
+            b"hello!".as_slice().into(),
         ));
 
         // First we expect a prompt for the file path

--- a/crates/tui/src/view/component/exchange_pane.rs
+++ b/crates/tui/src/view/component/exchange_pane.rs
@@ -236,7 +236,7 @@ impl<'a> Draw<ExchangePaneProps<'a>> for ExchangePane {
                                 ResponseBodyViewProps {
                                     request_id: exchange.id,
                                     recipe_id: &exchange.request.recipe_id,
-                                    response: Arc::clone(&exchange.response),
+                                    response: &exchange.response,
                                 },
                                 content_area,
                                 true,

--- a/crates/tui/src/view/component/root.rs
+++ b/crates/tui/src/view/component/root.rs
@@ -265,7 +265,9 @@ impl PersistedContainer for SelectedRequestId {
 mod tests {
     use super::*;
     use crate::{
-        test_util::{harness, terminal, TestHarness, TestTerminal},
+        test_util::{
+            harness, terminal, TestHarness, TestResponseParser, TestTerminal,
+        },
         view::{
             test_util::TestComponent, util::persistence::DatabasePersistedStore,
         },
@@ -275,12 +277,14 @@ mod tests {
     use rstest::rstest;
     use slumber_core::{assert_matches, http::Exchange, test_util::Factory};
 
+    const PARSER: TestResponseParser = TestResponseParser;
+
     /// Test that, on first render, the view loads the most recent historical
     /// request for the first recipe+profile
     #[rstest]
     fn test_preload_request(harness: TestHarness, terminal: TestTerminal) {
         // Add a request into the DB that we expect to preload
-        let request_store = RequestStore::new(harness.database.clone());
+        let request_store = RequestStore::new(harness.database.clone(), PARSER);
         let collection = Collection::factory(());
         let profile_id = collection.first_profile_id();
         let recipe_id = collection.first_recipe_id();
@@ -314,7 +318,7 @@ mod tests {
         harness: TestHarness,
         terminal: TestTerminal,
     ) {
-        let request_store = RequestStore::new(harness.database.clone());
+        let request_store = RequestStore::new(harness.database.clone(), PARSER);
         let collection = Collection::factory(());
         let recipe_id = collection.first_recipe_id();
         let profile_id = collection.first_profile_id();
@@ -361,7 +365,7 @@ mod tests {
         harness: TestHarness,
         terminal: TestTerminal,
     ) {
-        let request_store = RequestStore::new(harness.database.clone());
+        let request_store = RequestStore::new(harness.database.clone(), PARSER);
         let collection = Collection::factory(());
         let recipe_id = collection.first_recipe_id();
         let profile_id = collection.first_profile_id();
@@ -397,7 +401,7 @@ mod tests {
 
     #[rstest]
     fn test_edit_collection(mut harness: TestHarness, terminal: TestTerminal) {
-        let request_store = RequestStore::new(harness.database.clone());
+        let request_store = RequestStore::new(harness.database.clone(), PARSER);
         let root = Root::new(&harness.collection);
         let mut component = TestComponent::new(
             &harness,


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

This involved a lot of refactoring around response bodies. It removes the Arc that wrapped responses, so that the parsed body can be saved inline. It turns out this Arc wasn't really needed, it just added complexity more than anything.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Big change means potential for bugs. This code is pretty well tested though.

## QA

_How did you test this?_

unit tests

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
