### PR TITLE
Open bodies in external viewer

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -42,6 +42,8 @@ pub struct Config {
     /// Command to use for in-app editing. If provided, overrides
     /// `VISUAL`/`EDITOR` environment variables
     pub editor: Option<String>,
+    /// Command to use to browse response bodies
+    pub viewer: Option<String>,
     #[serde(flatten)]
     pub http: HttpEngineConfig,
     /// Should templates be rendered inline in the UI, or should we show the
@@ -111,6 +113,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             editor: None,
+            viewer: None,
             http: HttpEngineConfig::default(),
             preview_templates: true,
             input_bindings: Default::default(),

--- a/crates/tui/src/message.rs
+++ b/crates/tui/src/message.rs
@@ -86,6 +86,8 @@ pub enum Message {
         #[debug(skip)]
         on_complete: Callback<PathBuf>,
     },
+    /// Open a file to be viewed in the user's external viewer
+    ViewFile { path: PathBuf },
 
     /// An error occurred in some async process and should be shown to the user
     Error { error: anyhow::Error },

--- a/crates/tui/src/view/component/primary.rs
+++ b/crates/tui/src/view/component/primary.rs
@@ -17,7 +17,10 @@ use crate::{
         draw::{Draw, DrawMetadata, ToStringGenerate},
         event::{Child, Event, EventHandler, Update},
         state::fixed_select::FixedSelectState,
-        util::persistence::{Persisted, PersistedLazy},
+        util::{
+            persistence::{Persisted, PersistedLazy},
+            view_text,
+        },
         Component, ViewContext,
     },
 };
@@ -262,13 +265,23 @@ impl PrimaryView {
             return;
         };
 
-        let message = match action {
-            RecipeMenuAction::EditCollection => Message::CollectionEdit,
-            RecipeMenuAction::CopyUrl => Message::CopyRequestUrl(config),
-            RecipeMenuAction::CopyBody => Message::CopyRequestBody(config),
-            RecipeMenuAction::CopyCurl => Message::CopyRequestCurl(config),
-        };
-        ViewContext::send_message(message);
+        match action {
+            RecipeMenuAction::EditCollection => {
+                ViewContext::send_message(Message::CollectionEdit)
+            }
+            RecipeMenuAction::CopyUrl => {
+                ViewContext::send_message(Message::CopyRequestUrl(config))
+            }
+            RecipeMenuAction::CopyCurl => {
+                ViewContext::send_message(Message::CopyRequestCurl(config))
+            }
+            RecipeMenuAction::CopyBody => {
+                ViewContext::send_message(Message::CopyRequestBody(config))
+            }
+            RecipeMenuAction::ViewBody => {
+                self.recipe_pane.data().with_body_text(view_text)
+            }
+        }
     }
 }
 

--- a/crates/tui/src/view/component/queryable_body.rs
+++ b/crates/tui/src/view/component/queryable_body.rs
@@ -28,7 +28,7 @@ use slumber_core::{
     http::{content_type::ContentType, query::Query, ResponseBody},
     util::{MaybeStr, ResultTraced},
 };
-use std::cell::Cell;
+use std::cell::{Cell, Ref};
 
 /// Display response body as text, with a query box to filter it if the body has
 /// been parsed. The query state can be persisted by persisting this entire
@@ -128,14 +128,11 @@ impl QueryableBody {
         }
     }
 
-    /// Get the exact text that the user sees
-    pub fn visible_text(&self) -> String {
-        // State should always be initialized by the time this is called, but
-        // if it isn't then the user effectively sees nothing
+    /// Get visible body text
+    pub fn visible_text(&self) -> Option<Ref<'_, Text>> {
         self.state
             .get()
-            .map(|state| state.text.to_string())
-            .unwrap_or_default()
+            .map(|state| Ref::map(state, |state| &*state.text))
     }
 }
 

--- a/crates/tui/src/view/component/recipe_pane.rs
+++ b/crates/tui/src/view/component/recipe_pane.rs
@@ -63,6 +63,21 @@ impl RecipePane {
             options,
         })
     }
+
+    /// Execute a function with the recipe's body text, if available. Body text
+    /// is only available for recipes with non-form bodies.
+    pub fn with_body_text(&self, f: impl FnOnce(&Text)) {
+        let Some(state) = self.recipe_state.get() else {
+            return;
+        };
+        let Some(display) = state.data().as_ref() else {
+            return;
+        };
+        let Some(body_text) = display.body_text() else {
+            return;
+        };
+        f(&body_text)
+    }
 }
 
 impl EventHandler for RecipePane {
@@ -185,10 +200,12 @@ pub enum RecipeMenuAction {
     EditCollection,
     #[display("Copy URL")]
     CopyUrl,
-    #[display("Copy Body")]
-    CopyBody,
     #[display("Copy as cURL")]
     CopyCurl,
+    #[display("View Body")]
+    ViewBody,
+    #[display("Copy Body")]
+    CopyBody,
 }
 
 impl RecipeMenuAction {
@@ -200,7 +217,7 @@ impl RecipeMenuAction {
             if has_body {
                 &[]
             } else {
-                &[Self::CopyBody]
+                &[Self::CopyBody, Self::ViewBody]
             }
         } else {
             &[Self::CopyUrl, Self::CopyBody, Self::CopyCurl]

--- a/crates/tui/src/view/component/recipe_pane/recipe.rs
+++ b/crates/tui/src/view/component/recipe_pane/recipe.rs
@@ -10,6 +10,7 @@ use crate::{
         },
         draw::{Draw, DrawMetadata},
         event::{Child, EventHandler},
+        state::Identified,
         util::persistence::PersistedLazy,
         Component,
     },
@@ -19,7 +20,7 @@ use persisted::SingletonKey;
 use ratatui::{
     layout::{Alignment, Layout},
     prelude::Constraint,
-    text::Span,
+    text::{Span, Text},
     widgets::Paragraph,
     Frame,
 };
@@ -29,6 +30,7 @@ use slumber_core::{
     collection::{Method, Recipe, RecipeId},
     http::BuildOptions,
 };
+use std::ops::Deref;
 use strum::{EnumCount, EnumIter};
 
 /// Display a recipe. Note a recipe *node*, this is for genuine bonafide recipe.
@@ -140,6 +142,14 @@ impl RecipeDisplay {
     /// Does the recipe have a body defined?
     pub fn has_body(&self) -> bool {
         self.body.data().is_some()
+    }
+
+    /// Get visible body text
+    pub fn body_text(
+        &self,
+    ) -> Option<impl '_ + Deref<Target = Identified<Text<'static>>>> {
+        let body = self.body.data().as_ref()?;
+        body.text()
     }
 }
 

--- a/crates/tui/src/view/component/request_view.rs
+++ b/crates/tui/src/view/component/request_view.rs
@@ -11,7 +11,7 @@ use crate::{
         draw::{Draw, DrawMetadata, Generate, ToStringGenerate},
         event::{Child, Event, EventHandler, Update},
         state::{Identified, StateCell},
-        util::highlight,
+        util::{highlight, view_text},
         Component, ViewContext,
     },
 };
@@ -59,6 +59,8 @@ enum MenuAction {
     CopyUrl,
     #[display("Copy Body")]
     CopyBody,
+    #[display("View Body")]
+    ViewBody,
 }
 
 impl ToStringGenerate for MenuAction {}
@@ -74,7 +76,8 @@ impl EventHandler for RequestView {
             {
                 [].as_slice()
             } else {
-                &[MenuAction::CopyBody]
+                // No body available - disable these actions
+                &[MenuAction::CopyBody, MenuAction::ViewBody]
             };
             ViewContext::open_modal(ActionsModal::new(disabled));
         } else if let Some(action) = event.local::<MenuAction>() {
@@ -97,6 +100,13 @@ impl EventHandler for RequestView {
                         Some(body.to_string())
                     }) {
                         ViewContext::send_message(Message::CopyText(body));
+                    }
+                }
+                MenuAction::ViewBody => {
+                    if let Some(state) = self.state.get() {
+                        if let Some(body) = state.body.as_deref() {
+                            view_text(body);
+                        }
                     }
                 }
             }

--- a/docs/src/api/configuration/editor.md
+++ b/docs/src/api/configuration/editor.md
@@ -1,4 +1,6 @@
-# In-App Editing
+# In-App Editing and File Viewing
+
+## Editing
 
 Slumber supports editing your collection file without leaving the app. To do so, open the actions menu (`x` by default), then select `Edit Collection`. Slumber will open an external editor to modify the file. To determine which editor to use, Slumber checks these places in the following order:
 
@@ -16,3 +18,21 @@ editor: code --wait
 ```
 
 The command will be parsed like a shell command (although a shell is never actually invoked). For exact details on parsing behavior, see [shellish_parse](https://docs.rs/shellish_parse/latest/shellish_parse/index.html).
+
+## Viewing
+
+You can open your response bodies in a separate file browser if you additional features beyond what Slumber provides. To configure the command to use, set the `viewer` configuration field:
+
+```yaml
+viewer: bat
+```
+
+> The viewer command uses the same format as the `editor` field. The command is parsed with [shellish_parse](https://docs.rs/shellish_parse/latest/shellish_parse/index.html), then a temporary file path is passed as the final argument.
+
+To open a body in the viewer, use the actions menu keybinding (`x` by default, see [input bindings](./input_bindings.md)), and select `View Body`.
+
+Some popular file viewers:
+
+- [bat](https://github.com/sharkdp/bat)
+- [fx](https://fx.wtf/)
+- [jless](https://github.com/PaulJuliusMartinez/jless)

--- a/docs/src/api/configuration/index.md
+++ b/docs/src/api/configuration/index.md
@@ -30,12 +30,13 @@ SLUMBER_CONFIG_PATH=~/dotfiles/slumber.yml slumber
 
 ## Fields
 
-| Field                      | Type                                | Description                                                                                       | Default                    |
-| -------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------- | -------------------------- |
-| `debug`                    | `boolean`                           | Enable developer information                                                                      | `false`                    |
-| `editor`                   | `string`                            | Command to use when opening files for in-app editing. [More info](./editor.md)                    | `VISUAL`/`EDITOR` env vars |
-| `ignore_certificate_hosts` | `string[]`                          | Hostnames whose TLS certificate errors will be ignored. [More info](../../troubleshooting/tls.md) | `[]`                       |
-| `input_bindings`           | `mapping[Action, KeyCombination[]]` | Override default input bindings. [More info](./input_bindings.md)                                 | `{}`                       |
-| `large_body_size`          | `number`                            | Size over which request/response bodies are not formatted/highlighted, for performance (bytes)    | `1000000` (1 MB)           |
-| `preview_templates`        | `boolean`                           | Render template values in the TUI? If false, the raw template will be shown.                      | `true`                     |
-| `theme`                    | [`Theme`](./theme.md)               | Visual customizations                                                                             | `{}`                       |
+| Field                      | Type                                | Description                                                                                       | Default                              |
+| -------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| `debug`                    | `boolean`                           | Enable developer information                                                                      | `false`                              |
+| `editor`                   | `string`                            | Command to use when opening files for in-app editing. [More info](./editor.md)                    | `VISUAL`/`EDITOR` env vars, or `vim` |
+| `ignore_certificate_hosts` | `string[]`                          | Hostnames whose TLS certificate errors will be ignored. [More info](../../troubleshooting/tls.md) | `[]`                                 |
+| `input_bindings`           | `mapping[Action, KeyCombination[]]` | Override default input bindings. [More info](./input_bindings.md)                                 | `{}`                                 |
+| `large_body_size`          | `number`                            | Size over which request/response bodies are not formatted/highlighted, for performance (bytes)    | `1000000` (1 MB)                     |
+| `preview_templates`        | `boolean`                           | Render template values in the TUI? If false, the raw template will be shown.                      | `true`                               |
+| `theme`                    | [`Theme`](./theme.md)               | Visual customizations                                                                             | `{}`                                 |
+| `viewer`                   | `string`                            | Command to use when opening files for viewing. [More info](./editor.md)                           | `less` (Unix), `more` (Windows)      |

--- a/docs/src/api/configuration/input_bindings.md
+++ b/docs/src/api/configuration/input_bindings.md
@@ -31,42 +31,42 @@ input_bindings:
 
 ## Actions
 
-| Action                | Default Binding             | Description                                           |
-| --------------------- | --------------------------- | ----------------------------------------------------- |
-| `left_click`          | None                        |                                                       |
-| `right_click`         | None                        |                                                       |
-| `scroll_up`           | None                        |                                                       |
-| `scroll_down`         | None                        |                                                       |
-| `scroll_left`         | `shift left`                |                                                       |
-| `scroll_right`        | `shift right`               |                                                       |
-| `quit`                | `q`                         | Exit current dialog, or the entire app                |
-| `force_quit`          | `ctrl c`                    | Exit the app, regardless                              |
-| `previous_pane`       | `backtab` (AKA `shift tab`) | Select previous pane in the cycle                     |
-| `next_pane`           | `tab`                       |                                                       |
-| `up`                  | `up`                        |                                                       |
-| `down`                | `down`                      |                                                       |
-| `left`                | `left`                      |                                                       |
-| `right`               | `right`                     |                                                       |
-| `page_up`             | `pgup`                      |                                                       |
-| `page_down`           | `pgdn`                      |                                                       |
-| `home`                | `home`                      |                                                       |
-| `end`                 | `end`                       |                                                       |
-| `submit`              | `enter`                     | Send a request, submit a text box, etc.               |
-| `toggle`              | `space`                     | Toggle a checkbox on/off                              |
-| `cancel`              | `esc`                       | Cancel current dialog or request                      |
-| `edit`                | `e`                         | Apply a temporary override to a recipe value          |
-| `reset`               | `r`                         | Reset temporary recipe override to its default        |
-| `history`             | `h`                         | Open request history for a recipe                     |
-| `search`              | `/`                         | Open/select search for current pane                   |
-| `reload_collection`   | `f5`                        | Force reload collection file                          |
-| `fullscreen`          | `f`                         | Fullscreen current pane                               |
-| `open_actions`        | `x`                         | Open actions menu                                     |
-| `open_help`           | `?`                         | Open help dialog                                      |
-| `select_profile_list` | `p`                         | Open Profile List dialog                              |
-| `select_recipe_list`  | `l`                         | Select Recipe List pane                               |
-| `select_recipe`       | `c`                         | Select Recipe pane                                    |
-| `select_response`     | `s`                         | Select Request/Response pane                          |
-| `select_request`      | `r`                         | Select Request/Response pane (backward compatibility) |
+| Action                | Default Binding             | Description                                             |
+| --------------------- | --------------------------- | ------------------------------------------------------- |
+| `left_click`          | None                        |                                                         |
+| `right_click`         | None                        |                                                         |
+| `scroll_up`           | None                        |                                                         |
+| `scroll_down`         | None                        |                                                         |
+| `scroll_left`         | `shift left`                |                                                         |
+| `scroll_right`        | `shift right`               |                                                         |
+| `quit`                | `q`                         | Exit current dialog, or the entire app                  |
+| `force_quit`          | `ctrl c`                    | Exit the app, regardless                                |
+| `previous_pane`       | `backtab` (AKA `shift tab`) | Select previous pane in the cycle                       |
+| `next_pane`           | `tab`                       |                                                         |
+| `up`                  | `up`                        |                                                         |
+| `down`                | `down`                      |                                                         |
+| `left`                | `left`                      |                                                         |
+| `right`               | `right`                     |                                                         |
+| `page_up`             | `pgup`                      |                                                         |
+| `page_down`           | `pgdn`                      |                                                         |
+| `home`                | `home`                      |                                                         |
+| `end`                 | `end`                       |                                                         |
+| `submit`              | `enter`                     | Send a request, submit a text box, etc.                 |
+| `toggle`              | `space`                     | Toggle a checkbox on/off                                |
+| `cancel`              | `esc`                       | Cancel current dialog or request                        |
+| `edit`                | `e`                         | Apply a temporary override to a recipe value            |
+| `reset`               | `r`                         | Reset temporary recipe override to its default          |
+| `history`             | `h`                         | Open request history for a recipe                       |
+| `search`              | `/`                         | Open/select search for current pane                     |
+| `reload_collection`   | `f5`                        | Force reload collection file                            |
+| `fullscreen`          | `f`                         | Fullscreen current pane                                 |
+| `open_actions`        | `x`                         | Open actions menu                                       |
+| `open_help`           | `?`                         | Open help dialog                                        |
+| `select_profile_list` | `p`                         | Open Profile List dialog                                |
+| `select_recipe_list`  | `l`                         | Select Recipe List pane                                 |
+| `select_recipe`       | `c`                         | Select Recipe pane                                      |
+| `select_response`     | `s`                         | Select Request/Response pane                            |
+| `select_request`      | `r`                         | Select Request/Response pane (backward compatibility)   |
 
 > Note: mouse bindings are not configurable; mouse actions such as `left_click` _can_ be bound to a key combination, which cannot be unbound from the default mouse action.
 


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

This is a primitive implementation of opening recipe/request/response bodies in an external viewer (AKA pager). It adds an action menu item titled "View Body" that opens a subprocess to run the pager. There are a lot of improvements I'd like to make:

- Support a keybinding for opening
- Run the viewer in an embedded terminal, instead of having it take over the entire window
- Support different viewers for different content types (`default` and `json` would be the only two options for now)

Closes #404

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

This is a half-baked implementation, so there's the risk I need to make breaking changes in the future. I'm not too worried about that though, because the only thing that could really break is the config schema, and that's simple enough to keep backward compatible.

## QA

_How did you test this?_

Manual testing. It's tough to write a unit test for and I am feeling supremely lazy.

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
