### PR TITLE
Debounce query text box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Wrap long error messages in response pane
 - Include data path in config/collection deserialization errors
   - This should make errors much less cryptic and frustrating
+- Improve UX of query text box
+  - The query is now auto-applied when changed (with a 500ms debounce), and drops focus on the text box when Enter is pressed
 
 ## [2.3.0] - 2024-11-11
 

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -262,14 +262,14 @@ impl Tui {
                 )?;
             }
 
-            Message::EditFile { path, on_complete } => {
+            Message::FileEdit { path, on_complete } => {
                 let command = get_editor_command(&path)?;
                 self.run_command(command)?;
                 on_complete(path);
                 // The callback may queue an event to read the file, so we can't
                 // delete it yet. Caller is responsible for cleaning up
             }
-            Message::ViewFile { path } => {
+            Message::FileView { path } => {
                 let command = get_viewer_command(&path)?;
                 self.run_command(command)?;
                 // We don't need to read the contents back so we can clean up
@@ -315,6 +315,8 @@ impl Tui {
             Message::Input { event, action } => {
                 self.view.handle_input(event, action);
             }
+
+            Message::Local(event) => self.view.local(event),
 
             Message::Notify(message) => self.view.notify(message),
             Message::PromptStart(prompt) => {

--- a/crates/tui/src/view.rs
+++ b/crates/tui/src/view.rs
@@ -12,6 +12,7 @@ mod util;
 
 pub use common::modal::{IntoModal, ModalPriority};
 pub use context::{UpdateContext, ViewContext};
+pub use event::LocalEvent;
 pub use styles::Styles;
 pub use util::{Confirm, PreviewPrompter};
 
@@ -139,6 +140,11 @@ impl View {
     pub fn notify(&mut self, message: impl ToString) {
         let notification = Notification::new(message.to_string());
         ViewContext::push_event(Event::Notify(notification));
+    }
+
+    /// Trigger a localized UI event
+    pub fn local(&mut self, event: Box<dyn LocalEvent>) {
+        ViewContext::push_event(Event::Local(event));
     }
 
     /// Queue an event to update the view according to an input event from the

--- a/crates/tui/src/view/component/recipe_pane/body.rs
+++ b/crates/tui/src/view/component/recipe_pane/body.rs
@@ -164,7 +164,7 @@ impl RawBody {
             return;
         };
 
-        ViewContext::send_message(Message::EditFile {
+        ViewContext::send_message(Message::FileEdit {
             path,
             on_complete: Box::new(|path| {
                 ViewContext::push_event(Event::new_local(SaveBodyOverride(
@@ -317,7 +317,7 @@ mod tests {
         component.send_key(KeyCode::Char('e')).assert_empty();
         let (path, on_complete) = assert_matches!(
             harness.pop_message_now(),
-            Message::EditFile { path, on_complete } => (path, on_complete),
+            Message::FileEdit { path, on_complete } => (path, on_complete),
         );
         assert_eq!(fs::read(&path).unwrap(), b"hello!");
 


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

The query text box on the response body pane now auto-applies the query with a 500ms debounce. Pressing enter now applies the query immediately _and_ exits focus.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Some users may find this unintuitive, but IMO it's a small but significant improvement.

## QA

_How did you test this?_

Manual testing, and added a unit test

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
