### PR TITLE
Only allow request cancellation when the selected request is pending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Improve UX of query text box
   - The query is now auto-applied when changed (with a 500ms debounce), and drops focus on the text box when Enter is pressed
 
+### Fixed
+
+- Don't show request cancellation dialog if the selected request isn't building/loading
+
 ## [2.3.0] - 2024-11-11
 
 ### Added

--- a/crates/tui/src/http.rs
+++ b/crates/tui/src/http.rs
@@ -311,6 +311,14 @@ impl RequestStore {
         Ok(())
     }
 
+    /// Is the given request either building or loading?
+    pub fn is_in_progress(&self, id: RequestId) -> bool {
+        matches!(
+            self.get(id),
+            Some(RequestState::Building { .. } | RequestState::Loading { .. },)
+        )
+    }
+
     /// Replace a request state in the store with new state, by mapping it
     /// through a function. This assumes the request state is supposed to be in
     /// the state, so it logs a message if it isn't (panics in debug mode). This

--- a/crates/tui/src/view/component/root.rs
+++ b/crates/tui/src/view/component/root.rs
@@ -151,16 +151,19 @@ impl EventHandler for Root {
                 }
                 Action::Cancel => {
                     if let Some(request_id) = self.selected_request_id.0 {
-                        ViewContext::open_modal(ConfirmModal::new(
-                            "Cancel request?".into(),
-                            move |response| {
-                                if response {
-                                    ViewContext::send_message(
-                                        Message::HttpCancel(request_id),
-                                    );
-                                }
-                            },
-                        ))
+                        // 2024 edition: if-let chain
+                        if context.request_store.is_in_progress(request_id) {
+                            ViewContext::open_modal(ConfirmModal::new(
+                                "Cancel request?".into(),
+                                move |response| {
+                                    if response {
+                                        ViewContext::send_message(
+                                            Message::HttpCancel(request_id),
+                                        );
+                                    }
+                                },
+                            ))
+                        }
                     }
                 }
                 Action::Quit => ViewContext::send_message(Message::Quit),


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

The request cancellation dialog now only shows if relevant

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

## QA

_How did you test this?_

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
