### PR TITLE
Don't store CLI requests in history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Breaking
+
+- Don't store CLI requests in history
+
 ### Changes
 
 - Wrap long error messages in response pane

--- a/crates/cli/src/commands/history.rs
+++ b/crates/cli/src/commands/history.rs
@@ -9,7 +9,7 @@ use clap_complete::ArgValueCompleter;
 use dialoguer::console::Style;
 use slumber_core::{
     collection::{CollectionFile, ProfileId, RecipeId},
-    db::Database,
+    db::{Database, DatabaseMode},
     http::{Exchange, ExchangeSummary, RequestId},
     util::{format_byte_size, format_duration, format_time, MaybeStr},
 };
@@ -62,7 +62,8 @@ impl Subcommand for HistoryCommand {
             it may change or be removed at any time"
         );
         let collection_path = CollectionFile::try_path(None, global.file)?;
-        let database = Database::load()?.into_collection(&collection_path)?;
+        let database = Database::load()?
+            .into_collection(&collection_path, DatabaseMode::ReadOnly)?;
 
         match self.subcommand {
             HistorySubcommand::List { recipe, profile } => {

--- a/crates/core/src/http.rs
+++ b/crates/core/src/http.rs
@@ -380,8 +380,10 @@ impl RequestTicket {
                     end_time,
                 };
 
-                // Error here should *not* kill the request
-                let _ = database.insert_exchange(&exchange);
+                if database.can_write() {
+                    // Error here should *not* kill the request
+                    let _ = database.insert_exchange(&exchange);
+                }
                 Ok(exchange)
             }
 

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -38,7 +38,7 @@ use ratatui::{prelude::CrosstermBackend, Terminal};
 use slumber_config::{Action, Config};
 use slumber_core::{
     collection::{Collection, CollectionFile, ProfileId},
-    db::{CollectionDatabase, Database},
+    db::{CollectionDatabase, Database, DatabaseMode},
     http::{RequestId, RequestSeed},
     template::{Prompter, Template, TemplateChunk, TemplateContext},
 };
@@ -101,7 +101,8 @@ impl Tui {
         // to default, just show an error to the user
         let config = Config::load().reported(&messages_tx).unwrap_or_default();
         // Load a database for this particular collection
-        let database = Database::load()?.into_collection(&collection_path)?;
+        let database = Database::load()?
+            .into_collection(&collection_path, DatabaseMode::ReadWrite)?;
         // Initialize global view context
         TuiContext::init(config);
 


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Storing requests is probably unintuitive because you wouldn't really expect CLI requests to appear in the TUI history menu. The CLI also is going to handle more bulk and large responses because of scripting.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Breaking change, and potentially unintuitive. This will be part of 3.0

## QA

_How did you test this?_

Manually, added some unit tests

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
