### PR TITLE
Replace callbacks and local events with emitted events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   - This should make errors much less cryptic and frustrating
 - Improve UX of query text box
   - The query is now auto-applied when changed (with a 500ms debounce), and drops focus on the text box when Enter is pressed
+- Refactor UI event handling logic
+  - This shouldn't have any noticable impact on the user, but if you notice any bugs please open an issue
 
 ### Fixed
 

--- a/crates/core/src/collection/models.rs
+++ b/crates/core/src/collection/models.rs
@@ -586,7 +586,14 @@ impl Collection {
 impl crate::test_util::Factory for Collection {
     fn factory(_: ()) -> Self {
         use crate::test_util::by_id;
-        let recipe = Recipe::factory(());
+        // Include a body in the recipe, so body-related behavior can be tested
+        let recipe = Recipe {
+            body: Some(RecipeBody::Raw {
+                body: r#"{"message": "hello"}"#.into(),
+                content_type: Some(ContentType::Json),
+            }),
+            ..Recipe::factory(())
+        };
         let profile = Profile::factory(());
         Collection {
             recipes: by_id([recipe]).into(),

--- a/crates/tui/src/message.rs
+++ b/crates/tui/src/message.rs
@@ -1,7 +1,7 @@
 //! Async message passing! This is how inputs and other external events trigger
 //! state updates.
 
-use crate::view::{Confirm, LocalEvent};
+use crate::view::Confirm;
 use anyhow::Context;
 use derive_more::From;
 use slumber_config::Action;
@@ -112,9 +112,6 @@ pub enum Message {
         /// Action mapped via input bindings. This is what most consumers use
         action: Option<Action>,
     },
-
-    /// Trigger a localized UI event
-    Local(Box<dyn 'static + LocalEvent + Send + Sync>),
 
     /// Send an informational notification to the user
     Notify(String),

--- a/crates/tui/src/view/common/button.rs
+++ b/crates/tui/src/view/common/button.rs
@@ -5,9 +5,8 @@ use crate::{
     view::{
         context::UpdateContext,
         draw::{Draw, DrawMetadata, Generate},
-        event::{Event, EventHandler, Update},
+        event::{Emitter, EmitterId, Event, EventHandler, Update},
         state::fixed_select::{FixedSelect, FixedSelectState},
-        ViewContext,
     },
 };
 use ratatui::{
@@ -51,6 +50,7 @@ impl<'a> Generate for Button<'a> {
 /// type `T`.
 #[derive(Debug, Default)]
 pub struct ButtonGroup<T: FixedSelect> {
+    emitter_id: EmitterId,
     select: FixedSelectState<T>,
 }
 
@@ -64,9 +64,7 @@ impl<T: FixedSelect> EventHandler for ButtonGroup<T> {
             Action::Right => self.select.next(),
             Action::Submit => {
                 // Propagate the selected item as a dynamic event
-                ViewContext::push_event(Event::new_local(
-                    self.select.selected(),
-                ));
+                self.emit(self.select.selected());
             }
             _ => return Update::Propagate(event),
         }
@@ -102,5 +100,15 @@ impl<T: FixedSelect> Draw for ButtonGroup<T> {
                 *area,
             )
         }
+    }
+}
+
+/// The only type of event we can emit is a button being selected, so just
+/// emit the button type
+impl<T: FixedSelect> Emitter for ButtonGroup<T> {
+    type Emitted = T;
+
+    fn id(&self) -> EmitterId {
+        self.emitter_id
     }
 }

--- a/crates/tui/src/view/component/exchange_pane.rs
+++ b/crates/tui/src/view/component/exchange_pane.rs
@@ -3,7 +3,6 @@ use crate::{
     view::{
         common::{tabs::Tabs, Pane},
         component::{
-            primary::PrimaryPane,
             request_view::{RequestView, RequestViewProps},
             response_view::{
                 ResponseBodyView, ResponseBodyViewProps, ResponseHeadersView,
@@ -13,9 +12,9 @@ use crate::{
         },
         context::UpdateContext,
         draw::{Draw, DrawMetadata, Generate},
-        event::{Child, Event, EventHandler, Update},
+        event::{Child, Emitter, EmitterId, Event, EventHandler, Update},
         util::persistence::PersistedLazy,
-        RequestState, ViewContext,
+        RequestState,
     },
 };
 use derive_more::Display;
@@ -42,6 +41,7 @@ use strum::{EnumCount, EnumIter};
 /// pane isn't selected.
 #[derive(Debug, Default)]
 pub struct ExchangePane {
+    emitter_id: EmitterId,
     tabs: Component<PersistedLazy<SingletonKey<Tab>, Tabs<Tab>>>,
     request: Component<RequestView>,
     response_headers: Component<ResponseHeadersView>,
@@ -77,11 +77,7 @@ enum Tab {
 impl EventHandler for ExchangePane {
     fn update(&mut self, _: &mut UpdateContext, event: Event) -> Update {
         match event.action() {
-            Some(Action::LeftClick) => {
-                ViewContext::push_event(Event::new_local(
-                    PrimaryPane::Exchange,
-                ));
-            }
+            Some(Action::LeftClick) => self.emit(ExchangePaneEvent::Click),
             _ => return Update::Propagate(event),
         }
         Update::Consumed
@@ -269,4 +265,19 @@ impl<'a> Draw<ExchangePaneProps<'a>> for ExchangePane {
             }
         }
     }
+}
+
+/// Notify parent when this pane is clicked
+impl Emitter for ExchangePane {
+    type Emitted = ExchangePaneEvent;
+
+    fn id(&self) -> EmitterId {
+        self.emitter_id
+    }
+}
+
+/// Emitted event for the exchange pane component
+#[derive(Debug)]
+pub enum ExchangePaneEvent {
+    Click,
 }

--- a/crates/tui/src/view/component/internal.rs
+++ b/crates/tui/src/view/component/internal.rs
@@ -5,7 +5,7 @@
 use crate::view::{
     context::UpdateContext,
     draw::{Draw, DrawMetadata},
-    event::{Child, Event, ToChild, Update},
+    event::{Child, Emitter, Event, ToChild, Update},
 };
 use crossterm::event::MouseEvent;
 use derive_more::Display;
@@ -202,6 +202,14 @@ impl<T> Component<T> {
     /// Move the inner component out
     pub fn into_data(self) -> T {
         self.inner
+    }
+
+    /// Forward to [Emitter::emitted]
+    pub fn emitted<'a>(&self, event: &'a Event) -> Option<&'a T::Emitted>
+    where
+        T: Emitter,
+    {
+        self.data().emitted(event)
     }
 
     /// Draw the component to the frame. This will update global state, then

--- a/crates/tui/src/view/component/request_view.rs
+++ b/crates/tui/src/view/component/request_view.rs
@@ -5,6 +5,7 @@ use crate::{
         common::{
             actions::ActionsModal,
             header_table::HeaderTable,
+            modal::ModalHandle,
             text_window::{TextWindow, TextWindowProps},
         },
         context::UpdateContext,
@@ -30,6 +31,7 @@ use strum::{EnumCount, EnumIter};
 #[derive(Debug, Default)]
 pub struct RequestView {
     state: StateCell<RequestId, State>,
+    actions_handle: ModalHandle<ActionsModal<MenuAction>>,
     body_text_window: Component<TextWindow>,
 }
 
@@ -79,9 +81,9 @@ impl EventHandler for RequestView {
                 // No body available - disable these actions
                 &[MenuAction::CopyBody, MenuAction::ViewBody]
             };
-            ViewContext::open_modal(ActionsModal::new(disabled));
-        } else if let Some(action) = event.local::<MenuAction>() {
-            match action {
+            self.actions_handle.open(ActionsModal::new(disabled));
+        } else if let Some(menu_action) = self.actions_handle.emitted(&event) {
+            match menu_action {
                 MenuAction::EditCollection => {
                     ViewContext::send_message(Message::CollectionEdit)
                 }

--- a/crates/tui/src/view/context.rs
+++ b/crates/tui/src/view/context.rs
@@ -173,17 +173,12 @@ mod tests {
     fn test_event_queue(_harness: TestHarness) {
         assert_events!(); // Start empty
 
-        ViewContext::push_event(Event::new_local(3u32));
         ViewContext::push_event(Event::CloseModal { submitted: false });
-        assert_events!(
-            Event::Local(event) if event.downcast_ref::<u32>() == Some(&3),
-            Event::CloseModal{ submitted: false },
-        );
+        assert_events!(Event::CloseModal { submitted: false },);
 
-        assert_matches!(ViewContext::pop_event(), Some(Event::Local(_)));
         assert_matches!(
             ViewContext::pop_event(),
-            Some(Event::CloseModal { submitted: false })
+            Some(Event::CloseModal { .. })
         );
         assert_events!(); // Empty again
     }


### PR DESCRIPTION

## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Using events instead of callbacks to trigger behavior guarantees that components will have mutable access, and that the TUI will be rerendered after an update. The emitter trait gives each component that can emit events a unique ID, so we can't mix up events of the same type from different instances. It also ensures each component emits events of a single known type, so we get better type coercion from the event trait objects.

In some ways this adds complexity because we end up doing multiple rounds of event handling, which led to some bugs I had to fix. I think overall it's an improvement though, because it's more consistent. 

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

This is a major refactor, so there's tons of risk of tiny bugs showing up related to UI events. Existing tests mitigate this a bit, but I'm going to let it soak on master for a bit and use it myself to see if I notice anything.

## QA

_How did you test this?_

Lots of existing tests that I updated

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
