### PR TITLE
Add search box to recipe list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Add search box to the recipe list
+
 ### Changes
 
 - Wrap long error messages in response pane

--- a/crates/core/src/collection/recipe_tree.rs
+++ b/crates/core/src/collection/recipe_tree.rs
@@ -37,6 +37,7 @@ pub struct RecipeLookupKey(Vec<RecipeId>);
 
 /// A node in the recipe tree, either a folder or recipe
 #[derive(Debug, From, Serialize, Deserialize, EnumDiscriminants)]
+#[strum_discriminants(name(RecipeNodeType))]
 #[cfg_attr(any(test, feature = "test"), derive(PartialEq))]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 #[allow(clippy::large_enum_variant)]

--- a/crates/tui/src/view/component/exchange_pane.rs
+++ b/crates/tui/src/view/component/exchange_pane.rs
@@ -29,8 +29,7 @@ use ratatui::{
 use serde::{Deserialize, Serialize};
 use slumber_config::Action;
 use slumber_core::{
-    collection::RecipeNodeDiscriminants, http::RequestRecord,
-    util::format_byte_size,
+    collection::RecipeNodeType, http::RequestRecord, util::format_byte_size,
 };
 use std::sync::Arc;
 use strum::{EnumCount, EnumIter};
@@ -51,7 +50,7 @@ pub struct ExchangePane {
 pub struct ExchangePaneProps<'a> {
     /// Do we have a recipe, folder, or neither selected? Used to determine
     /// placeholder
-    pub selected_recipe_kind: Option<RecipeNodeDiscriminants>,
+    pub selected_recipe_kind: Option<RecipeNodeType>,
     pub request_state: Option<&'a RequestState>,
 }
 
@@ -112,10 +111,7 @@ impl<'a> Draw<ExchangePaneProps<'a>> for ExchangePane {
         }
         .generate();
         // If a recipe is selected, history is available so show the hint
-        if matches!(
-            props.selected_recipe_kind,
-            Some(RecipeNodeDiscriminants::Recipe)
-        ) {
+        if matches!(props.selected_recipe_kind, Some(RecipeNodeType::Recipe)) {
             let text = input_engine.add_hint("History", Action::History);
             block = block.title(Title::from(text).alignment(Alignment::Right));
         }
@@ -127,14 +123,14 @@ impl<'a> Draw<ExchangePaneProps<'a>> for ExchangePane {
             None => {
                 return;
             }
-            Some(RecipeNodeDiscriminants::Folder) => {
+            Some(RecipeNodeType::Folder) => {
                 frame.render_widget(
                     "Select a recipe to see its request history",
                     area,
                 );
                 return;
             }
-            Some(RecipeNodeDiscriminants::Recipe) => {}
+            Some(RecipeNodeType::Recipe) => {}
         }
 
         // Split out the areas we *may* need

--- a/crates/tui/src/view/component/primary.rs
+++ b/crates/tui/src/view/component/primary.rs
@@ -41,7 +41,7 @@ use ratatui::{
 use serde::{Deserialize, Serialize};
 use slumber_config::Action;
 use slumber_core::collection::{
-    Collection, ProfileId, RecipeId, RecipeNodeDiscriminants,
+    Collection, ProfileId, RecipeId, RecipeNodeType,
 };
 use strum::{EnumCount, EnumIter};
 
@@ -142,7 +142,7 @@ impl PrimaryView {
             .data()
             .selected_node()
             .and_then(|(id, kind)| {
-                if matches!(kind, RecipeNodeDiscriminants::Recipe) {
+                if matches!(kind, RecipeNodeType::Recipe) {
                     Some(id)
                 } else {
                     None

--- a/crates/tui/src/view/component/recipe_list.rs
+++ b/crates/tui/src/view/component/recipe_list.rs
@@ -17,7 +17,7 @@ use ratatui::{text::Text, Frame};
 use serde::{Deserialize, Serialize};
 use slumber_config::Action;
 use slumber_core::collection::{
-    HasId, RecipeId, RecipeLookupKey, RecipeNodeDiscriminants, RecipeTree,
+    HasId, RecipeId, RecipeLookupKey, RecipeNodeType, RecipeTree,
 };
 use std::collections::HashSet;
 
@@ -76,9 +76,7 @@ impl RecipeListPane {
 
     /// ID and kind of whatever recipe/folder in the list is selected. `None`
     /// iff the list is empty
-    pub fn selected_node(
-        &self,
-    ) -> Option<(&RecipeId, RecipeNodeDiscriminants)> {
+    pub fn selected_node(&self) -> Option<(&RecipeId, RecipeNodeType)> {
         self.select
             .data()
             .selected()
@@ -233,18 +231,18 @@ pub enum RecipeListPaneEvent {
 struct RecipeListItem {
     id: RecipeId,
     name: String,
-    kind: RecipeNodeDiscriminants,
+    kind: RecipeNodeType,
     depth: usize,
     collapsed: bool,
 }
 
 impl RecipeListItem {
     fn is_folder(&self) -> bool {
-        matches!(self.kind, RecipeNodeDiscriminants::Folder)
+        matches!(self.kind, RecipeNodeType::Folder)
     }
 
     fn is_recipe(&self) -> bool {
-        matches!(self.kind, RecipeNodeDiscriminants::Recipe)
+        matches!(self.kind, RecipeNodeType::Recipe)
     }
 }
 
@@ -276,9 +274,9 @@ impl<'a> Generate for &'a RecipeListItem {
         Self: 'this,
     {
         let icon = match self.kind {
-            RecipeNodeDiscriminants::Folder if self.collapsed => "▶",
-            RecipeNodeDiscriminants::Folder => "▼",
-            RecipeNodeDiscriminants::Recipe => "",
+            RecipeNodeType::Folder if self.collapsed => "▶",
+            RecipeNodeType::Folder => "▼",
+            RecipeNodeType::Recipe => "",
         };
 
         // Apply indentation

--- a/crates/tui/src/view/state/select.rs
+++ b/crates/tui/src/view/state/select.rs
@@ -221,6 +221,15 @@ impl<Item, State: SelectStateData> SelectState<Item, State> {
         self.select_delta(1);
     }
 
+    /// Select the first item in the list that matches the given predicate. If
+    /// no items match, the selection remains unchanged
+    pub fn find(&mut self, predicate: impl Fn(&Item) -> bool) {
+        let match_index = self.items().position(predicate);
+        if let Some(index) = match_index {
+            self.select_index(index);
+        }
+    }
+
     /// Select an item by index
     fn select_index(&mut self, index: usize) {
         let state = self.state.get_mut();
@@ -628,6 +637,17 @@ mod tests {
             SelectStateEvent::Select(0),
             SelectStateEvent::Select(1),
         ])
+    }
+
+    /// Test the `find` method
+    #[rstest]
+    fn test_find() {
+        let mut select = SelectState::<_, ListState>::builder(vec![
+            "alpha", "bravo", "charlie",
+        ])
+        .build();
+        select.find(|item| item.contains("avo"));
+        assert_eq!(select.selected(), Some(&"bravo"));
     }
 
     #[fixture]


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Add a search box to the bottom of the recipe list, to make it easy to jump between recipes. The behavior I went with is: whenever the text changes, immediately jump to the first recipe in the list whose name contains the query (comparison is caseless). I want to test this out myself to see if it's annoying or good. Some potential changes:
- Filter instead of search (so we hide items that don't match)
- Add a debounce, or don't search until the user hits Enter
- Instead of exiting on Enter, jump to the next match
- Match on ID as well
- Add persistence

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

This behavior may be bad, so I'm going to mitigate by testing myself in practice.

## QA

_How did you test this?_

Added unit tests

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
