### PR TITLE
Include request duration in History modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   - The query is now auto-applied when changed (with a 500ms debounce), and drops focus on the text box when Enter is pressed
 - Refactor UI event handling logic
   - This shouldn't have any noticable impact on the user, but if you notice any bugs please open an issue
+- Include request duration in History modal
 
 ### Fixed
 

--- a/crates/tui/src/view/component/history.rs
+++ b/crates/tui/src/view/component/history.rs
@@ -123,7 +123,14 @@ impl Generate for &RequestStateSummary {
                 Span::styled("Request error", styles.text.error)
             }
         };
-        vec![self.time().generate(), " ".into(), description].into()
+        vec![
+            self.start_time().generate(),
+            " / ".into(),
+            self.duration().generate(),
+            " ".into(),
+            description,
+        ]
+        .into()
     }
 }
 


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Just a nice QoL change

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Modal is a bit more cramped now, so larger status codes may overflow

## QA

_How did you test this?_

Manual

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
