### PR TITLE
Rename viewer -> pager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Refactor UI event handling logic
   - This shouldn't have any noticable impact on the user, but if you notice any bugs please open an issue
 - Include request duration in History modal
+- Rename `viewer` config field to `pager`
+  - The old field name `viewer` is still supported for backward compatibility, but the docs have been updated to suggest the newer name instead
+- Load pager command from the `PAGER` environment variable if available, similar to the `EDITOR` environment variable
 
 ### Fixed
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -42,8 +42,10 @@ pub struct Config {
     /// Command to use for in-app editing. If provided, overrides
     /// `VISUAL`/`EDITOR` environment variables
     pub editor: Option<String>,
-    /// Command to use to browse response bodies
-    pub viewer: Option<String>,
+    /// Command to use to browse response bodies. Aliased for backward
+    /// compatibility with the old name
+    #[serde(alias = "viewer")]
+    pub pager: Option<String>,
     #[serde(flatten)]
     pub http: HttpEngineConfig,
     /// Should templates be rendered inline in the UI, or should we show the
@@ -113,7 +115,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             editor: None,
-            viewer: None,
+            pager: None,
             http: HttpEngineConfig::default(),
             preview_templates: true,
             input_bindings: Default::default(),

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -22,7 +22,7 @@ use crate::{
     message::{Message, MessageSender, RequestConfig},
     util::{
         clear_event_buffer, delete_temp_file, get_editor_command,
-        get_viewer_command, save_file, signals, ResultReported,
+        get_pager_command, save_file, signals, ResultReported,
     },
     view::{PreviewPrompter, UpdateContext, View},
 };
@@ -277,7 +277,7 @@ impl Tui {
                 // delete it yet. Caller is responsible for cleaning up
             }
             Message::FileView { path } => {
-                let command = get_viewer_command(&path)?;
+                let command = get_pager_command(&path)?;
                 self.run_command(command)?;
                 // We don't need to read the contents back so we can clean up
                 delete_temp_file(&path);
@@ -442,7 +442,7 @@ impl Tui {
     }
 
     /// Run a **blocking** subprocess that will take over the terminal. Used
-    /// for opening an external editor or viewer.
+    /// for opening an external editor or pager.
     fn run_command(&mut self, mut command: Command) -> anyhow::Result<()> {
         let span = info_span!("Running command", ?command).entered();
         let error_context = format!("Error spawning command `{command:?}`");

--- a/crates/tui/src/message.rs
+++ b/crates/tui/src/message.rs
@@ -89,7 +89,7 @@ pub enum Message {
         #[debug(skip)]
         on_complete: Callback<PathBuf>,
     },
-    /// Open a file to be viewed in the user's external viewer
+    /// Open a file to be viewed in the user's external pager
     FileView { path: PathBuf },
 
     /// Launch an HTTP request from the given recipe/profile.

--- a/crates/tui/src/util.rs
+++ b/crates/tui/src/util.rs
@@ -208,24 +208,23 @@ pub fn get_editor_command(file: &Path) -> anyhow::Result<Command> {
         })
 }
 
-/// Get a command to open the given file in the user's configured file viewer.
+/// Get a command to open the given file in the user's configured file pager.
 /// Default is `less` on Unix, `more` on Windows. Return an error if the command
 /// couldn't be built.
-pub fn get_viewer_command(file: &Path) -> anyhow::Result<Command> {
-    // Use a built-in viewer
+pub fn get_pager_command(file: &Path) -> anyhow::Result<Command> {
+    // Use a built-in pager
     let default = if cfg!(windows) { "more" } else { "less" };
 
-    // Unlike the editor, there is no standard env var to store the viewer, so
-    // we rely solely on the configuration field.
     EditorBuilder::new()
         // Config field takes priority over environment variables
-        .source(TuiContext::get().config.viewer.as_deref())
+        .source(TuiContext::get().config.pager.as_deref())
+        .source(env::var("PAGER").ok())
         .source(Some(default))
         .path(file)
         .build()
         .with_context(|| {
             format!(
-                "Error opening viewer; see {}",
+                "Error opening pager; see {}",
                 doc_link("api/configuration/editor"),
             )
         })

--- a/crates/tui/src/view/util.rs
+++ b/crates/tui/src/view/util.rs
@@ -133,7 +133,7 @@ pub fn str_to_text(s: &str) -> Text<'static> {
         .into()
 }
 
-/// Open a [Text] object in the user's external viewer. This will write the text
+/// Open a [Text] object in the user's external pager. This will write the text
 /// to a random temporary file, without having to copy the contents. If an
 /// error occurs, it will be traced and reported to the user.
 pub fn view_text(text: &Text) {

--- a/docs/src/api/configuration/editor.md
+++ b/docs/src/api/configuration/editor.md
@@ -19,17 +19,17 @@ editor: code --wait
 
 The command will be parsed like a shell command (although a shell is never actually invoked). For exact details on parsing behavior, see [shellish_parse](https://docs.rs/shellish_parse/latest/shellish_parse/index.html).
 
-## Viewing
+## Paging
 
-You can open your response bodies in a separate file browser if you additional features beyond what Slumber provides. To configure the command to use, set the `viewer` configuration field:
+You can open your response bodies in a separate file browser if you want additional features beyond what Slumber provides. To configure the command to use, set the `PAGER` environment variable or the `pager` configuration field:
 
 ```yaml
-viewer: bat
+pager: bat
 ```
 
-> The viewer command uses the same format as the `editor` field. The command is parsed with [shellish_parse](https://docs.rs/shellish_parse/latest/shellish_parse/index.html), then a temporary file path is passed as the final argument.
+> The pager command uses the same format as the `editor` field. The command is parsed with [shellish_parse](https://docs.rs/shellish_parse/latest/shellish_parse/index.html), then a temporary file path is passed as the final argument.
 
-To open a body in the viewer, use the actions menu keybinding (`x` by default, see [input bindings](./input_bindings.md)), and select `View Body`.
+To open a body in the pager, use the actions menu keybinding (`x` by default, see [input bindings](./input_bindings.md)), and select `View Body`.
 
 Some popular file viewers:
 

--- a/docs/src/api/configuration/index.md
+++ b/docs/src/api/configuration/index.md
@@ -39,4 +39,5 @@ SLUMBER_CONFIG_PATH=~/dotfiles/slumber.yml slumber
 | `large_body_size`          | `number`                            | Size over which request/response bodies are not formatted/highlighted, for performance (bytes)    | `1000000` (1 MB)                     |
 | `preview_templates`        | `boolean`                           | Render template values in the TUI? If false, the raw template will be shown.                      | `true`                               |
 | `theme`                    | [`Theme`](./theme.md)               | Visual customizations                                                                             | `{}`                                 |
-| `viewer`                   | `string`                            | Command to use when opening files for viewing. [More info](./editor.md)                           | `less` (Unix), `more` (Windows)      |
+| `pager`                    | `string`                            | Command to use when opening files for viewing. [More info](./editor.md)                           | `less` (Unix), `more` (Windows)      |
+| `viewer`                   | See `pager`                         | Alias for `pager`, for backward compatibility                                                     | See `pager`                          |


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

When I originally implemented the pager functionality in #414, I didn't realize "pager" is the common term for this. I had seen the term before but thought "viewer" was more intuitive. I have since realized I was wrong. I've renamed the field in the config, code and documentation. Additionally, I realized `PAGER` is the common env var for this, so I added support for pulling from that, in the same way we pull from `EDITOR`.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

This is very low risk because the old field name is still supported. Nothing will change about any existing user's workflows.

## QA

_How did you test this?_

Tested manually

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
