### PR TITLE
Add back prettification

### DIFF
--- a/crates/core/src/http/content_type.rs
+++ b/crates/core/src/http/content_type.rs
@@ -104,6 +104,27 @@ impl ContentType {
         }
     }
 
+    /// Make a response body look pretty. If the input isn't valid for this
+    /// content type, return `None`
+    pub fn prettify(&self, body: &str) -> Option<String> {
+        match self {
+            ContentType::Json => {
+                // The easiest way to prettify is to parse and restringify.
+                // There's definitely faster ways that don't require building
+                // the whole data structure in memory, but not via serde
+                if let Ok(parsed) =
+                    serde_json::from_str::<serde_json::Value>(body)
+                {
+                    // serde_json shouldn't fail serializing its own Value type
+                    serde_json::to_string_pretty(&parsed).ok()
+                } else {
+                    // Not valid JSON
+                    None
+                }
+            }
+        }
+    }
+
     /// Stringify a single JSON value into this format
     pub fn value_to_string(self, value: &serde_json::Value) -> String {
         match self {

--- a/crates/tui/src/view/component/recipe_list.rs
+++ b/crates/tui/src/view/component/recipe_list.rs
@@ -483,13 +483,13 @@ mod tests {
         assert_eq!(
             select
                 .items()
-                .map(|item| item.id.as_str())
+                .map(|item| &item.id as &str)
                 .collect_vec()
                 .as_slice(),
             &["recipe2", "recipe22"]
         );
         assert_eq!(
-            select.selected().map(|item| item.id.as_str()),
+            select.selected().map(|item| &item.id as &str),
             Some("recipe2")
         );
 

--- a/crates/tui/src/view/component/response_view.rs
+++ b/crates/tui/src/view/component/response_view.rs
@@ -185,8 +185,13 @@ mod tests {
         view::test_util::TestComponent,
     };
     use crossterm::event::KeyCode;
+    use indexmap::indexmap;
     use rstest::rstest;
-    use slumber_core::{assert_matches, http::Exchange, test_util::Factory};
+    use slumber_core::{
+        assert_matches,
+        http::Exchange,
+        test_util::{header_map, Factory},
+    };
 
     /// Test "Copy Body" menu action
     #[rstest]
@@ -196,6 +201,14 @@ mod tests {
             ..ResponseRecord::factory(())
         },
         "{\"hello\":\"world\"}",
+    )]
+    #[case::json_body(
+        ResponseRecord {
+            headers: header_map(indexmap! {"content-type" => "application/json"}),
+            body: br#"{"hello":"world"}"#.to_vec().into(),
+            ..ResponseRecord::factory(())
+        },
+        "{\n  \"hello\": \"world\"\n}",
     )]
     #[case::binary_body(
         ResponseRecord {
@@ -252,6 +265,16 @@ mod tests {
         },
         None,
         None,
+    )]
+    #[case::json_body(
+        ResponseRecord {
+            headers: header_map(indexmap! {"content-type" => "application/json"}),
+            body: br#"{"hello":"world"}"#.to_vec().into(),
+            ..ResponseRecord::factory(())
+        },
+        None,
+        // Body has been prettified, so we can't use the original
+        Some("{\n  \"hello\": \"world\"\n}"),
     )]
     #[case::binary_body(
         ResponseRecord {


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

I removed automatic prettification when adding the command-based querying, since I figured the querying program could be used for prettification too. But this is a meaningful QoL change, since it now requires users to have `jq` or similar installed _and_ configure it to run automatically (not possible yet, but it will be) just to get what should be a basic and expected feature.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

The prettification blocks the UI thread, because it's much easier to implement that way. We don't prettify large bodies so this is mitigated. This is how it was implemented in the past so it's not a regression.

## QA

_How did you test this?_

Added back some old unit tests, tested manually too.

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
