### PR TITLE
Update editor-command to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- Update [editor-command](https://crates.io/crates/editor-command), which replaces [shellish_parse](https://crates.io/crates/shellish_parse) with [shell-words](https://crates.io/crates/shell-words) for editor and pager command parsing
+  - There should be no impact to users
+
 ## [2.4.0] - 2024-12-27
 
 ### Added
@@ -13,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Add filter box to the recipe list
   - This behavior is not necessarily final. Please leave feedback if you think it could be improved.
 
-### Changes
+### Changed
 
 - Wrap long error messages in response pane
 - Include data path in config/collection deserialization errors
@@ -38,7 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Add "View Body" action to response bodies, to open a body in an external viewer such as `less` or `fx` [#404](https://github.com/LucasPickering/slumber/issues/404)
   - By default `less` is used. You can customize this with the [`viewer` config field](https://slumber.lucaspickering.me/book/api/configuration/editor.html)
 
-### Changes
+### Changed
 
 - Preserve key order of objects in JSON responses [#405](https://github.com/LucasPickering/slumber/issues/405)
 
@@ -204,7 +209,7 @@ This release focuses on minor fixes and improvements. There are no new major fea
 
 - Add global `--log` argument to CLI, to print the log file being used for that invocation
 
-### Changes
+### Changed
 
 - Checkbox row state and folder expand/collapse state are now toggled via the spacebar instead of enter
   - Enter now sends a request from anywhere. While this change may be annoying, it will hopefully be more intuitive in the long run.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,11 +573,11 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "editor-command"
-version = "0.1.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa7a3e34d7a5b881150285b40d8c81ba256b398c89dcc5e9384941184ae934c0"
+checksum = "ee98e369cc618396b828ba0231d5bc39857ee1d8e9dcb1c1adef49a21bb5c427"
 dependencies = [
- "shellish_parse",
+ "shell-words",
 ]
 
 [[package]]
@@ -2343,12 +2343,6 @@ name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
-
-[[package]]
-name = "shellish_parse"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c29b912ad681a28566f37b936bba1f3580a93b9391c4a0b12cb1c6b4ed79973"
 
 [[package]]
 name = "shlex"

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -17,7 +17,7 @@ chrono = {workspace = true}
 cli-clipboard = "0.4.0"
 crossterm = {workspace = true, features = ["bracketed-paste", "windows", "events", "event-stream"]}
 derive_more = {workspace = true, features = ["debug", "deref", "deref_mut", "display", "from"]}
-editor-command = "0.1.0"
+editor-command = "1.0.0"
 futures = {workspace = true}
 indexmap = {workspace = true}
 itertools = {workspace = true}

--- a/docs/src/api/configuration/editor.md
+++ b/docs/src/api/configuration/editor.md
@@ -17,7 +17,7 @@ Slumber supports passing additional arguments to the editor. For example, if you
 editor: code --wait
 ```
 
-The command will be parsed like a shell command (although a shell is never actually invoked). For exact details on parsing behavior, see [shellish_parse](https://docs.rs/shellish_parse/latest/shellish_parse/index.html).
+The command will be parsed like a shell command (although a shell is never actually invoked). For exact details on parsing behavior, see [shell-words](https://docs.rs/shell-words/1.1.0/shell_words/fn.split.html).
 
 ## Paging
 
@@ -27,7 +27,7 @@ You can open your response bodies in a separate file browser if you want additio
 pager: bat
 ```
 
-> The pager command uses the same format as the `editor` field. The command is parsed with [shellish_parse](https://docs.rs/shellish_parse/latest/shellish_parse/index.html), then a temporary file path is passed as the final argument.
+> The pager command uses the same format as the `editor` field. The command is parsed with [shell-words](https://docs.rs/shell-words/1.1.0/shell_words/fn.split.html), then a temporary file path is passed as the final argument.
 
 To open a body in the pager, use the actions menu keybinding (`x` by default, see [input bindings](./input_bindings.md)), and select `View Body`.
 


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

This replaces shellish_parse with shell-words, which was already in our dep tree so this eliminates one dep at least.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

It's possible there are some differences between the two that break stuff for users. The tests on editor-command are pretty good though so I'm not too worried.

## QA

_How did you test this?_

Relying on editor-command tests

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
