### PR TITLE
Add REST Importer for Jetbrains / VSCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Add REST Importer for VSCode and Jetbrains
+
 ### Changed
 
 - Update [editor-command](https://crates.io/crates/editor-command), which replaces [shellish_parse](https://crates.io/crates/shellish_parse) with [shell-words](https://crates.io/crates/shell-words) for editor and pager command parsing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1947,6 +1947,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rest_parser"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "575c220d2c01ec29da1d36c6fbd1deb7fe001597336f54f22f5f1a35cbeaa5c8"
+dependencies = [
+ "anyhow",
+ "base64",
+ "httparse",
+ "indexmap",
+ "nom",
+ "url",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2495,6 +2509,7 @@ dependencies = [
  "openapiv3",
  "pretty_assertions",
  "reqwest",
+ "rest_parser",
  "rstest",
  "serde",
  "serde_json",

--- a/crates/cli/src/commands/import.rs
+++ b/crates/cli/src/commands/import.rs
@@ -9,6 +9,9 @@ use std::{
 };
 
 /// Generate a Slumber request collection from an external format
+///
+/// See docs for more info on formats:
+/// https://slumber.lucaspickering.me/book/cli/import.html
 #[derive(Clone, Debug, Parser)]
 pub struct ImportCommand {
     /// Input format
@@ -25,8 +28,12 @@ enum Format {
     /// Insomnia export format (JSON or YAML)
     Insomnia,
     /// OpenAPI v3.0 (JSON or YAML) v3.1 not supported but may work
-    /// https://spec.openapis.org/oas/v3.0.3
     Openapi,
+    /// VSCode `.rest` or JetBrains `.http` format [aliases: vscode, jetbrains]
+    // Use visible_alias (and remove from doc comment) after
+    // https://github.com/clap-rs/clap/pull/5480
+    #[value(alias = "vscode", alias = "jetbrains")]
+    Rest,
 }
 
 impl Subcommand for ImportCommand {
@@ -37,6 +44,7 @@ impl Subcommand for ImportCommand {
                 slumber_import::from_insomnia(&self.input_file)?
             }
             Format::Openapi => slumber_import::from_openapi(&self.input_file)?,
+            Format::Rest => slumber_import::from_rest(&self.input_file)?,
         };
 
         // Write the output

--- a/crates/import/Cargo.toml
+++ b/crates/import/Cargo.toml
@@ -16,6 +16,7 @@ indexmap = {workspace = true, features = ["serde"]}
 itertools = {workspace = true}
 mime = {workspace = true}
 openapiv3 = "2.0.0"
+rest_parser = "0.1.6"
 reqwest = {workspace = true}
 serde = {workspace = true}
 serde_json = {workspace = true}

--- a/crates/import/src/lib.rs
+++ b/crates/import/src/lib.rs
@@ -1,5 +1,7 @@
 mod insomnia;
 mod openapi;
+mod rest;
 
 pub use insomnia::from_insomnia;
 pub use openapi::from_openapi;
+pub use rest::from_rest;

--- a/crates/import/src/rest.rs
+++ b/crates/import/src/rest.rs
@@ -1,0 +1,648 @@
+//! Import request collections from VSCode `.rest` files or Jetbrains `.http`
+//! files. VSCode: https://github.com/Huachao/vscode-restclient
+//! Jetbrains: https://www.jetbrains.com/help/idea/http-client-in-product-code-editor.html
+
+use anyhow::anyhow;
+use indexmap::IndexMap;
+use itertools::Itertools;
+use serde::de::IgnoredAny;
+use slumber_core::{
+    collection::{
+        Authentication, Chain, ChainId, ChainOutputTrim, ChainSource,
+        Collection, HasId, Method, Profile, ProfileId, Recipe, RecipeBody,
+        RecipeId, RecipeNode, RecipeTree, SelectorMode,
+    },
+    http::content_type::ContentType,
+    template::{Identifier, Template},
+    util::ResultTraced,
+};
+
+use reqwest::header;
+use rest_parser::{
+    headers::Authorization as RestAuthorization,
+    template::{Template as RestTemplate, TemplatePart as RestTemplatePart},
+    Body as RestBody, RestFlavor, RestFormat, RestRequest, RestVariables,
+};
+use std::path::Path;
+use tracing::error;
+
+/// Convert a VSCode `.rest` file or a Jetbrains `.http` file into a slumber
+/// collection
+pub fn from_rest(rest_file: impl AsRef<Path>) -> anyhow::Result<Collection> {
+    let rest_file = rest_file.as_ref();
+    // Parse the file and determine the flavor using the extension
+    let rest_format = RestFormat::parse_file(rest_file)?;
+    let collection = try_build_collection(rest_format)?;
+    Ok(collection)
+}
+
+/// In Rest "Chains" and "Requests" are connected
+/// The only chain is loading from a file
+#[derive(Debug)]
+struct CompleteRecipe {
+    recipe: Recipe,
+    chain: Option<Chain>,
+}
+
+#[derive(Debug)]
+struct CompleteBody {
+    recipe_body: RecipeBody,
+    chain: Option<Chain>,
+}
+
+/// Convert a REST Template into a Slumber Template
+fn try_build_slumber_template(
+    template: RestTemplate,
+) -> anyhow::Result<Template> {
+    // Rest templates allow spaces in variables
+    // For example `{{ HOST}}` or `{{ HOST }}`
+    // These must be removed before putting it through the slumber
+    // template parser
+    let raw_template = template
+        .parts
+        .into_iter()
+        .map(|part| match part {
+            RestTemplatePart::Text(text) => text,
+            RestTemplatePart::Variable(var) => {
+                "{{".to_string() + var.as_str() + "}}"
+            }
+        })
+        .join("");
+
+    raw_template
+        .parse()
+        .map_err(|err| anyhow!("Failed to parse REST template! {err}"))
+}
+
+/// Convert a map of REST templates to Slumber templates (like headers or
+/// queries)
+/// Errors will be logged and skipped if an invalid template is passed in
+fn build_slumber_templates(
+    template_map: IndexMap<String, RestTemplate>,
+) -> IndexMap<String, Template> {
+    template_map
+        .into_iter()
+        .filter_map(|(k, v)| {
+            try_build_slumber_template(v).map(|t| (k, t)).traced().ok()
+        })
+        .collect()
+}
+
+/// Convert REST Authentication to Slumber Authentication
+fn build_authentication(r_auth: RestAuthorization) -> Authentication {
+    match r_auth {
+        RestAuthorization::Bearer(bearer) => {
+            Authentication::Bearer(Template::raw(bearer))
+        }
+        RestAuthorization::Basic { username, password } => {
+            Authentication::Basic {
+                username: Template::raw(username),
+                password: password.map(Template::raw),
+            }
+        }
+    }
+}
+
+/// REST supports loading bodies from external files,
+/// this is connected to the request.
+/// In slumber, this needs to be converted into a request and
+/// a chain
+fn try_build_chain_from_load_body(
+    filepath: RestTemplate,
+    recipe_id: &str,
+    headers: &IndexMap<String, RestTemplate>,
+    variables: &RestVariables,
+) -> anyhow::Result<Chain> {
+    let full_id = format!("{recipe_id}_body");
+    let id: Identifier = Identifier::escape(&full_id);
+
+    let path = try_build_slumber_template(filepath)?;
+
+    let content_type =
+        guess_is_json(headers, variables).then_some(ContentType::Json);
+
+    Ok(Chain {
+        id: id.into(),
+        content_type,
+        trim: ChainOutputTrim::None,
+        source: ChainSource::File { path },
+        sensitive: false,
+        selector: None,
+        selector_mode: SelectorMode::Single,
+    })
+}
+
+/// Attempt to use headers to determine if the request is JSON
+fn guess_is_json(
+    r_headers: &IndexMap<String, RestTemplate>,
+    variables: &RestVariables,
+) -> bool {
+    r_headers.iter().any(|(name, value)| {
+        name.to_lowercase() == header::CONTENT_TYPE.as_str()
+            && value.render(variables) == mime::APPLICATION_JSON.to_string()
+    })
+}
+
+/// If the request has JSON headers, mark it as such
+fn guess_content_type(
+    headers: &IndexMap<String, RestTemplate>,
+    variables: &RestVariables,
+) -> Option<ContentType> {
+    guess_is_json(headers, variables).then_some(ContentType::Json)
+}
+
+fn try_build_body(
+    body: RestBody,
+    recipe_id: &str,
+    headers: &IndexMap<String, RestTemplate>,
+    variables: &RestVariables,
+) -> anyhow::Result<CompleteBody> {
+    // We only want the text for now
+    let (template, chain, content_type) = match body {
+        RestBody::Text(text) => (
+            try_build_slumber_template(text)?,
+            None,
+            guess_content_type(headers, variables),
+        ),
+        RestBody::SaveToFile { text, .. } => {
+            (try_build_slumber_template(text)?, None, None)
+        }
+        RestBody::LoadFromFile { filepath, .. } => {
+            let chain = try_build_chain_from_load_body(
+                filepath, recipe_id, headers, variables,
+            )?;
+            let template = Template::from_chain(chain.id().clone());
+            (template, Some(chain), None)
+        }
+    };
+
+    let recipe_body = RecipeBody::Raw {
+        body: template,
+        content_type,
+    };
+
+    Ok(CompleteBody { recipe_body, chain })
+}
+
+/// Build the query variables
+/// Logging and skipping any invalid templates
+fn build_query(
+    r_query: IndexMap<String, RestTemplate>,
+) -> Vec<(String, Template)> {
+    r_query
+        .into_iter()
+        .filter_map(|(k, v)| {
+            try_build_slumber_template(v).map(|t| (k, t)).traced().ok()
+        })
+        .collect()
+}
+
+fn try_build_recipe(
+    request: RestRequest,
+    index: usize,
+    variables: &RestVariables,
+) -> anyhow::Result<CompleteRecipe> {
+    let name = request.name.unwrap_or("Request".to_string());
+
+    let slug = Identifier::escape(&name);
+    // Add the index to prevent duplicate ID error
+    let id: RecipeId = format!("{slug}_{index}").into();
+
+    // Slumber doesn't support template methods, so we fill in now
+    let rendered_method = request.method.render(variables);
+
+    // The rest parser does not enforce method names
+    // It must be checked here
+    let method: Method = rendered_method
+        .parse()
+        .map_err(|_| anyhow!("Unsupported method: {:?}!", request.method))?;
+    let url = try_build_slumber_template(request.url)?;
+    let authentication = request.authorization.map(build_authentication);
+    let query = build_query(request.query);
+
+    let complete_body = request
+        .body
+        .map(|b| try_build_body(b, &id, &request.headers, variables));
+
+    let (body, chain) = match complete_body {
+        Some(Ok(complete)) => (Some(complete.recipe_body), complete.chain),
+        Some(Err(err)) => {
+            error!("Failed to convert body! {err}");
+            (None, None)
+        }
+        _ => (None, None),
+    };
+
+    let headers = build_slumber_templates(request.headers);
+
+    let recipe = Recipe {
+        id,
+        name: name.into(),
+        method,
+        url,
+        authentication,
+        body,
+        headers,
+        query,
+    };
+
+    Ok(CompleteRecipe { recipe, chain })
+}
+
+/// Rest has no request nesting feature so a tree will always be flat
+fn build_recipe_tree_with_chains(
+    completed: Vec<CompleteRecipe>,
+) -> (RecipeTree, IndexMap<ChainId, Chain>) {
+    let mut chains: IndexMap<ChainId, Chain> = IndexMap::new();
+    let recipe_node_map = completed
+        .into_iter()
+        .map(|CompleteRecipe { recipe, chain }| {
+            if let Some(load_chain) = chain {
+                chains.insert(load_chain.id().clone(), load_chain);
+            }
+
+            (recipe.id().clone(), RecipeNode::Recipe(recipe))
+        })
+        .collect::<IndexMap<RecipeId, RecipeNode>>();
+
+    let recipe_tree = RecipeTree::new(recipe_node_map)
+        .expect("IDs are injected by the recipe converter!");
+
+    (recipe_tree, chains)
+}
+
+fn flavor_name_and_id(flavor: RestFlavor) -> (String, String) {
+    let (name, id) = match flavor {
+        RestFlavor::Jetbrains => ("Jetbrains HTTP File", "http_file"),
+        RestFlavor::Vscode => ("VSCode Rest File", "rest_file"),
+        RestFlavor::Generic => ("Rest File", "rest_file"),
+    };
+    (name.into(), id.into())
+}
+
+/// There is no profile system in Rest,
+/// here is a default to use
+fn build_profile_map(
+    flavor: RestFlavor,
+    variables: RestVariables,
+) -> IndexMap<ProfileId, Profile> {
+    let (flavor_name, flavor_id) = flavor_name_and_id(flavor);
+    let profile_id: ProfileId = flavor_id.into();
+    let default_profile = Profile {
+        id: profile_id.clone(),
+        name: Some(flavor_name),
+        default: true,
+        data: build_slumber_templates(variables),
+    };
+
+    IndexMap::from([(profile_id.clone(), default_profile)])
+}
+
+fn try_build_collection(rest_format: RestFormat) -> anyhow::Result<Collection> {
+    let RestFormat {
+        requests,
+        variables,
+        flavor,
+    } = rest_format;
+
+    let completed_recipes = requests
+        .into_iter()
+        .enumerate()
+        .filter_map(|(index, req)| {
+            try_build_recipe(req, index, &variables).traced().ok()
+        })
+        .collect::<Vec<_>>();
+
+    let (recipes, chains) = build_recipe_tree_with_chains(completed_recipes);
+
+    let profiles = build_profile_map(flavor, variables);
+
+    Ok(Collection {
+        profiles,
+        chains,
+        recipes,
+        _ignore: IgnoredAny,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+    use slumber_core::test_util::test_data_dir;
+
+    use super::*;
+
+    fn example_vars() -> RestVariables {
+        IndexMap::from([
+            ("HOST".into(), RestTemplate::new("https://httpbin.org")),
+            ("FIRST_NAME".into(), RestTemplate::new("John")),
+            ("LAST_NAME".into(), RestTemplate::new("Smith")),
+            (
+                "FULL_NAME".into(),
+                RestTemplate::new("{{FIRST_NAME}} {{LAST_NAME}}"),
+            ),
+        ])
+    }
+
+    fn test_template(value: &str) -> Template {
+        value.parse().unwrap()
+    }
+
+    #[test]
+    fn can_convert_basic_request() {
+        let test_req = RestRequest {
+            name: Some("My Request!".into()),
+            url: RestTemplate::new("https://httpbin.org"),
+            query: IndexMap::from([
+                ("name".into(), RestTemplate::new("joe")),
+                ("age".into(), RestTemplate::new("46")),
+            ]),
+            method: RestTemplate::new("GET"),
+            ..RestRequest::default()
+        };
+
+        let CompleteRecipe { recipe, .. } =
+            try_build_recipe(test_req, 0, &IndexMap::new()).unwrap();
+
+        assert_eq!(recipe.url, test_template("https://httpbin.org"));
+        assert_eq!(
+            recipe.query.get(1).unwrap(),
+            &("age".into(), test_template("46"))
+        );
+        assert_eq!(recipe.method, Method::Get);
+        assert_eq!(recipe.id().clone(), RecipeId::from("My_Request__0"));
+    }
+
+    #[test]
+    fn can_convert_with_vars() {
+        let test_req = RestRequest {
+            url: RestTemplate::new("{{HOST}}/get"),
+            query: IndexMap::from([
+                ("first_name".into(), RestTemplate::new("{{FIRST_NAME}}")),
+                ("full_name".into(), RestTemplate::new("{{FULL_NAME}}")),
+            ]),
+            method: RestTemplate::new("POST"),
+            ..RestRequest::default()
+        };
+
+        let vars = example_vars();
+        let CompleteRecipe { recipe, .. } =
+            try_build_recipe(test_req, 0, &vars).unwrap();
+
+        assert_eq!(recipe.url, test_template("{{HOST}}/get"));
+        assert_eq!(
+            recipe.query.get(0).unwrap(),
+            &("first_name".into(), test_template("{{FIRST_NAME}}"))
+        );
+        assert_eq!(
+            recipe.query.get(1).unwrap(),
+            &("full_name".into(), test_template("{{FULL_NAME}}"))
+        );
+        assert_eq!(recipe.method, Method::Post);
+    }
+
+    #[test]
+    fn fails_on_bad_method() {
+        let test_req = RestRequest {
+            url: RestTemplate::new("{{HOST}}/get"),
+            method: RestTemplate::new("INVALID"),
+            ..RestRequest::default()
+        };
+
+        let got = try_build_recipe(test_req, 0, &IndexMap::new());
+        assert!(got.is_err());
+    }
+
+    #[test]
+    fn can_build_load_chain() {
+        let test_req = RestRequest {
+            url: RestTemplate::new("{{HOST}}/post"),
+            method: RestTemplate::new("POST"),
+            headers: IndexMap::from([(
+                "Content-Type".into(),
+                RestTemplate::new("application/json"),
+            )]),
+            body: Some(RestBody::LoadFromFile {
+                process_variables: false,
+                encoding: None,
+                filepath: RestTemplate::new("./test_data/rest_pets.json"),
+            }),
+            ..RestRequest::default()
+        };
+
+        let CompleteRecipe { chain, .. } =
+            try_build_recipe(test_req, 0, &IndexMap::new()).unwrap();
+
+        let chain = chain.unwrap();
+        assert_eq!(chain.id().clone(), ChainId::from("Request_0_body"));
+        let expected_source = ChainSource::File {
+            path: Template::raw("./test_data/rest_pets.json".into()),
+        };
+        assert_eq!(chain.source, expected_source);
+        assert_eq!(chain.content_type, Some(ContentType::Json));
+    }
+
+    #[test]
+    fn can_build_raw_body() {
+        let test_req = RestRequest {
+            url: RestTemplate::new("{{HOST}}/post"),
+            method: RestTemplate::new("POST"),
+            body: Some(RestBody::Text(RestTemplate::new("test data"))),
+            ..RestRequest::default()
+        };
+
+        let CompleteRecipe { recipe, .. } =
+            try_build_recipe(test_req, 0, &example_vars()).unwrap();
+
+        let body = recipe.body.unwrap();
+        assert_eq!(
+            body,
+            RecipeBody::Raw {
+                body: test_template("test data"),
+                content_type: None,
+            }
+        );
+    }
+
+    #[test]
+    fn can_build_json_body() {
+        let test_req = RestRequest {
+            url: RestTemplate::new("{{HOST}}/post"),
+            method: RestTemplate::new("POST"),
+            headers: IndexMap::from([(
+                "Content-Type".into(),
+                RestTemplate::new("application/json"),
+            )]),
+            body: Some(RestBody::Text(RestTemplate::new(
+                "{\"animal\": \"penguin\"}",
+            ))),
+            ..RestRequest::default()
+        };
+
+        let CompleteRecipe { recipe, .. } =
+            try_build_recipe(test_req, 0, &example_vars()).unwrap();
+
+        let body = recipe.body.unwrap();
+        assert_eq!(
+            body,
+            RecipeBody::Raw {
+                body: test_template("{\"animal\": \"penguin\"}"),
+                content_type: Some(ContentType::Json),
+            }
+        );
+    }
+
+    #[test]
+    fn can_build_collection_from_rest_format() {
+        let test_req_1 = RestRequest {
+            name: Some("Query Request".into()),
+            url: RestTemplate::new("https://httpbin.org"),
+            query: IndexMap::from([
+                ("name".into(), RestTemplate::new("joe")),
+                ("age".into(), RestTemplate::new("46")),
+            ]),
+            method: RestTemplate::new("GET"),
+            ..RestRequest::default()
+        };
+
+        let test_req_2 = RestRequest {
+            url: RestTemplate::new("{{HOST}}/post"),
+            method: RestTemplate::new("POST"),
+            headers: IndexMap::from([(
+                "Content-Type".into(),
+                RestTemplate::new("application/json"),
+            )]),
+            body: Some(RestBody::Text(RestTemplate::new(
+                "{\"animal\": \"penguin\"}",
+            ))),
+            ..RestRequest::default()
+        };
+
+        let format = RestFormat {
+            requests: vec![test_req_1, test_req_2],
+            flavor: RestFlavor::Jetbrains,
+            variables: example_vars(),
+        };
+
+        let Collection { recipes, .. } = try_build_collection(format).unwrap();
+
+        let recipe_1 = recipes.get(&RecipeId::from("Query_Request_0")).unwrap();
+        let recipe_2 = recipes.get(&RecipeId::from("Request_1")).unwrap();
+
+        println!("{recipe_1:?}");
+        match (recipe_1, recipe_2) {
+            (
+                RecipeNode::Recipe(Recipe { body: body1, .. }),
+                RecipeNode::Recipe(Recipe { body: body2, .. }),
+            ) => {
+                assert_eq!(body1, &None,);
+                assert_eq!(
+                    body2,
+                    &Some(RecipeBody::Raw {
+                        body: test_template("{\"animal\": \"penguin\"}"),
+                        content_type: Some(ContentType::Json),
+                    })
+                );
+            }
+            _ => panic!("Invalid! {recipe_1:?} {recipe_2:?}"),
+        }
+    }
+
+    fn remove_whitespace(s: &str) -> String {
+        s.chars().filter(|c| !c.is_whitespace()).collect()
+    }
+
+    #[test]
+    fn can_handle_parse_error() {
+        let test_req_1 = RestRequest {
+            name: Some("Query Request".into()),
+            url: RestTemplate::new("bad template }} for url {{ "),
+            query: IndexMap::from([
+                ("name".into(), RestTemplate::new("joe")),
+                ("age".into(), RestTemplate::new("46")),
+            ]),
+            method: RestTemplate::new("GET"),
+            ..RestRequest::default()
+        };
+
+        let vars = example_vars();
+        let rec = try_build_recipe(test_req_1, 0, &vars);
+        // Should fail to parse this recipe because of bad URL template
+        assert!(rec.is_err());
+
+        let test_req_2 = RestRequest {
+            name: Some("Query Request".into()),
+            url: RestTemplate::new("https://httpbin.org"),
+            query: IndexMap::from([
+                (
+                    "name".into(),
+                    RestTemplate::new("bad template {{ for query"),
+                ),
+                ("age".into(), RestTemplate::new("46")),
+            ]),
+            method: RestTemplate::new("GET"),
+            ..RestRequest::default()
+        };
+
+        let vars = example_vars();
+        let rec = try_build_recipe(test_req_2, 0, &vars);
+        // Should parse and just ignore the invalid query var
+        assert!(rec.is_ok());
+    }
+
+    #[test]
+    fn can_load_collection_from_file() {
+        let test_http_path = test_data_dir().join("rest_http_bin.http");
+        let test_slumber_path = test_data_dir().join("rest_imported.yml");
+
+        let collection = from_rest(test_http_path).unwrap();
+        let loaded_collection = Collection::load(&test_slumber_path).unwrap();
+
+        assert_eq!(collection.profiles, loaded_collection.profiles);
+        assert_eq!(collection.chains, loaded_collection.chains);
+
+        // Saving and loading messes with the JSON whitespace
+        // Compare it here
+
+        let recipe_1 = RecipeId::from("SimpleGet_0");
+        let recipe_2 = RecipeId::from("JsonPost_1");
+        let recipe_3 = RecipeId::from("Request_2");
+        let recipe_4 = RecipeId::from("Pet_json_3");
+        assert_eq!(
+            collection.recipes.try_get_recipe(&recipe_1).unwrap(),
+            loaded_collection.recipes.try_get_recipe(&recipe_1).unwrap()
+        );
+        assert_eq!(
+            collection.recipes.try_get_recipe(&recipe_3).unwrap(),
+            loaded_collection.recipes.try_get_recipe(&recipe_3).unwrap()
+        );
+        assert_eq!(
+            collection.recipes.try_get_recipe(&recipe_4).unwrap(),
+            loaded_collection.recipes.try_get_recipe(&recipe_4).unwrap()
+        );
+
+        // This request should have slightly different whitespace because it is
+        // JSON parsed To avoid rendering the output, just clean up the
+        // debug output and compare that
+        let bod_1 = collection.recipes.try_get_recipe(&recipe_2).unwrap();
+        let bod_2 = collection.recipes.try_get_recipe(&recipe_2).unwrap();
+
+        match (bod_1, bod_2) {
+            (
+                Recipe {
+                    body: Some(RecipeBody::Raw { body: b1, .. }),
+                    ..
+                },
+                Recipe {
+                    body: Some(RecipeBody::Raw { body: b2, .. }),
+                    ..
+                },
+            ) => {
+                let deb_1 = remove_whitespace(&format!("{b1:?}"));
+                let deb_2 = remove_whitespace(&format!("{b2:?}"));
+                assert_eq!(deb_1, deb_2);
+            }
+            _ => panic!("Invalid Json"),
+        };
+    }
+}

--- a/docs/src/cli/import.md
+++ b/docs/src/cli/import.md
@@ -27,11 +27,11 @@ slumber import insomnia insomnia.json slumber.yml
 Supported formats:
 
 - Insomnia
-- OpenAPI v3.0
+- [OpenAPI v3.0](https://spec.openapis.org/oas/v3.0.3)
   - Note: Despite the minor version bump, OpenAPI v3.1 is _not_ backward compatible with v3.0. If you have a v3.1 spec, it _may_ work with this importer, but no promises.
+- [VSCode `.rest`](https://github.com/Huachao/vscode-restclient)
+- [JetBrains `.http`](https://www.jetbrains.com/help/idea/http-client-in-product-code-editor.html)
 
 Requested formats:
-
-- [JetBrains HTTP](https://github.com/LucasPickering/slumber/issues/122)
 
 If you'd like another format supported, please [open an issue](https://github.com/LucasPickering/slumber/issues/new).

--- a/test_data/rest_http_bin.http
+++ b/test_data/rest_http_bin.http
@@ -1,0 +1,41 @@
+@HOST = http://httpbin.org
+### SimpleGet
+
+GET {{ HOST}}/get HTTP/1.1
+
+/// Another comment
+
+###
+# @name JsonPost
+@FIRST=Joe
+@LAST=Smith
+@FULL={{ FIRST }} {{LAST}}
+
+POST {{HOST}}/post?hello=123 HTTP/1.1
+Authorization: Basic Zm9vOmJhcg==
+Content-Type: application/json
+X-Http-Method-Override: PUT
+
+{
+    "data": "my data",
+    "name": "{{FULL}}"
+}
+
+
+#######
+@ENDPOINT = post
+
+POST https://httpbin.org/{{ENDPOINT}} HTTP/1.1
+Authorization: Bearer efaxijasdfjasdfa
+Content-Type: application/x-www-form-urlencoded
+My-Header: hello
+Other-Header: goodbye
+
+first={{ FIRST}}&last={{LAST}}&full={{FULL}}
+
+### Pet.json
+
+POST {{HOST}}/post HTTP/1.1
+Content-Type: application/json
+
+< ./test_data/rest_pets.json

--- a/test_data/rest_imported.yml
+++ b/test_data/rest_imported.yml
@@ -1,0 +1,63 @@
+profiles:
+  http_file:
+    name: Jetbrains HTTP File
+    default: true
+    data:
+      HOST: http://httpbin.org
+      FIRST: Joe
+      LAST: Smith
+      FULL: '{{FIRST}} {{LAST}}'
+      ENDPOINT: post
+chains:
+  Pet_json_3_body:
+    source: !file
+      path: ./test_data/rest_pets.json
+    sensitive: false
+    selector: null
+    selector_mode: single
+    content_type: json
+    trim: none
+requests:
+  SimpleGet_0: !request
+    name: SimpleGet
+    method: GET
+    url: '{{HOST}}/get'
+    body: null
+    authentication: null
+    query: []
+    headers: {}
+  JsonPost_1: !request
+    name: JsonPost
+    method: POST
+    url: '{{HOST}}/post'
+    body: !json
+      data: my data
+      name: '{{FULL}}'
+    authentication: !basic
+      username: foo
+      password: bar
+    query:
+    - hello=123
+    headers:
+      Content-Type: application/json
+      X-Http-Method-Override: PUT
+  Request_2: !request
+    name: Request
+    method: POST
+    url: https://httpbin.org/{{ENDPOINT}}
+    body: first={{FIRST}}&last={{LAST}}&full={{FULL}}
+    authentication: !bearer efaxijasdfjasdfa
+    query: []
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+      My-Header: hello
+      Other-Header: goodbye
+  Pet_json_3: !request
+    name: Pet.json
+    method: POST
+    url: '{{HOST}}/post'
+    body: '{{chains.Pet_json_3_body}}'
+    authentication: null
+    query: []
+    headers:
+      Content-Type: application/json

--- a/test_data/rest_pets.json
+++ b/test_data/rest_pets.json
@@ -1,0 +1,4 @@
+{
+    "name": "my pets",
+    "animals": ["cat", "dog", "frog"]
+}


### PR DESCRIPTION
## Description

A few months ago I filed a pull request to add this in but I got busy so it ended up getting closed. ([Addresses this](https://github.com/LucasPickering/slumber/issues/122)) Anyway, I'm back and decided to reintegrate it! Here is the previous closed issue with more details: https://github.com/LucasPickering/slumber/pull/205

I made the REST Parser a separate crate because it was quite complex and would be useful for other projects as well. You can check it out here: https://github.com/benfaerber/rest_parser

The old version had a Jetbrains environment loading feature which I did not include because it added a ton of complexity and not too much benefit.

Import using:
```
slumber import rest ./test_data/rest_http_bin.http ./test_data/rest_slumber.yml
```
```
slumber import vscode ./test_data/rest_http_bin.http ./test_data/rest_slumber.yml
```
```
slumber import jetbrains ./test_data/rest_http_bin.http ./test_data/rest_slumber.yml
```

## Known Risks
- Adding a new crate
- Touching the importer

## QA

Lots of unit tests in `rest.rs` and some test data.

## Checklist

- [ X] Have you read `CONTRIBUTING.md` already?
- [ X] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ X] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
