### PR TITLE
Improvements to command querying

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,8 @@ jobs:
 
       - name: Install toolchain
         run: rustup target add ${{ matrix.platform.target }}
+        env:
+          RUST_BACKTRACE: 1
 
       - name: Run tests
         run: cargo test --workspace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Replace JSONPath querying with general purpose shell commands for querying response bodies
+  - Now you can access any CLI tools you want for transforming response bodies, such as `jq` or `grep`
+  - By default, commands are executed via `sh` (or `cmd` on Windows), but this is configured via the [`commands.shell` field](https://slumber.lucaspickering.me/book/api/configuration/index.html)
 - Add `slumber history` subcommand. Currently it has two operations:
   - `slumber history list` lists all stored requests for a recipe
   - `slumber history get` prints a specific request/response

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2323,12 +2323,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
-name = "shellish_parse"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c29b912ad681a28566f37b936bba1f3580a93b9391c4a0b12cb1c6b4ed79973"
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2513,7 +2507,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_yaml",
- "shellish_parse",
+ "shell-words",
  "slumber_config",
  "slumber_core",
  "strum",

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -135,6 +135,8 @@ pub struct CommandsConfig {
     /// Wrapping shell to parse and execute commands
     /// If empty, commands will be parsed with shell-words and run natievly
     pub shell: Vec<String>,
+    /// Default query command for responses
+    pub query_default: Option<String>,
 }
 
 impl Default for CommandsConfig {
@@ -150,6 +152,7 @@ impl Default for CommandsConfig {
 
         Self {
             shell: default_shell.iter().map(|s| s.to_string()).collect(),
+            query_default: None,
         }
     }
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -39,6 +39,8 @@ const FILE: &str = "config.yml";
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct Config {
+    /// Configuration for in-app query and side effect commands
+    pub commands: CommandsConfig,
     /// Command to use for in-app editing. If provided, overrides
     /// `VISUAL`/`EDITOR` environment variables
     pub editor: Option<String>,
@@ -114,6 +116,7 @@ impl Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
+            commands: CommandsConfig::default(),
             editor: None,
             pager: None,
             http: HttpEngineConfig::default(),
@@ -121,6 +124,32 @@ impl Default for Config {
             input_bindings: Default::default(),
             theme: Default::default(),
             debug: false,
+        }
+    }
+}
+
+/// Configuration for in-app query and side effect commands
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct CommandsConfig {
+    /// Wrapping shell to parse and execute commands
+    /// If empty, commands will be parsed with shell-words and run natievly
+    pub shell: Vec<String>,
+}
+
+impl Default for CommandsConfig {
+    fn default() -> Self {
+        // We use the defaults from docker, because it's well tested and
+        // reasonably intuitive
+        // https://docs.docker.com/reference/dockerfile/#shell
+        let default_shell: &[&str] = if cfg!(windows) {
+            &["cmd", "/S", "/C"]
+        } else {
+            &["/bin/sh", "-c"]
+        };
+
+        Self {
+            shell: default_shell.iter().map(|s| s.to_string()).collect(),
         }
     }
 }

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -27,7 +27,7 @@ ratatui = {workspace = true, features = ["crossterm", "underline-color", "unstab
 reqwest = {workspace = true}
 serde = {workspace = true}
 serde_yaml = {workspace = true}
-shellish_parse = "2.2.0"
+shell-words = "1.1.0"
 slumber_config = {workspace = true}
 slumber_core = {workspace = true}
 strum = {workspace = true}

--- a/crates/tui/src/test_util.rs
+++ b/crates/tui/src/test_util.rs
@@ -143,10 +143,11 @@ impl TestTerminal {
 
 /// Run a future in a local set, so it can use [tokio::task::spawn_local]. This
 /// will wait until all spawned tasks are done.
-pub async fn run_local(future: impl Future<Output = ()>) {
+pub async fn run_local<T>(future: impl Future<Output = T>) -> T {
     let local = LocalSet::new();
-    local.run_until(future).await; // Let the future spawn tasks
+    let output = local.run_until(future).await; // Let the future spawn tasks
     local.await; // Wait until all tasks are done
+    output
 }
 
 /// Assert that the event queue matches the given list of patterns. Each event

--- a/crates/tui/src/util.rs
+++ b/crates/tui/src/util.rs
@@ -243,6 +243,9 @@ pub async fn run_command(
     let args = tokens;
     let mut process = tokio::process::Command::new(program)
         .args(args)
+        // Stop the command on drop. This will leave behind a zombie process,
+        // but tokio should reap it in the background. See method docs
+        .kill_on_drop(true)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/crates/tui/src/view.rs
+++ b/crates/tui/src/view.rs
@@ -24,7 +24,6 @@ use crate::{
         component::{Component, Root, RootProps},
         debug::DebugMonitor,
         event::{Event, Update},
-        state::Notification,
     },
 };
 use anyhow::anyhow;
@@ -137,8 +136,7 @@ impl View {
 
     /// Queue an event to send an informational notification to the user
     pub fn notify(&mut self, message: impl ToString) {
-        let notification = Notification::new(message.to_string());
-        ViewContext::push_event(Event::Notify(notification));
+        ViewContext::notify(message);
     }
 
     /// Queue an event to update the view according to an input event from the

--- a/crates/tui/src/view/common/text_box.rs
+++ b/crates/tui/src/view/common/text_box.rs
@@ -47,6 +47,7 @@ type Validator = Box<dyn Fn(&str) -> bool>;
 impl TextBox {
     /// Set initialize value for the text box
     pub fn default_value(mut self, default: String) -> Self {
+        // Don't call set_text here, because we don't want to emit an event
         self.state.text = default;
         self.state.end();
         self
@@ -101,10 +102,15 @@ impl TextBox {
         self.state.text
     }
 
-    /// Set text, and move the cursor to the end. This will **not** emit events
+    /// Set text, and move the cursor to the end. If the text changed, emit a
+    /// change event.
     pub fn set_text(&mut self, text: String) {
+        let changed = text != self.state.text;
         self.state.text = text;
         self.state.end();
+        if changed {
+            self.change();
+        }
     }
 
     /// Check if the current input text is valid. Always returns true if there
@@ -166,6 +172,7 @@ impl TextBox {
 
     /// Emit a change event. Should be called whenever text _content_ is changed
     fn change(&mut self) {
+        println!("change");
         let is_valid = self.is_valid();
         if let Some(debounce) = &self.on_change_debounce {
             if self.is_valid() {
@@ -402,7 +409,6 @@ impl PersistedContainer for TextBox {
 
     fn restore_persisted(&mut self, value: Self::Value) {
         self.set_text(value);
-        self.submit();
     }
 }
 

--- a/crates/tui/src/view/common/text_window.rs
+++ b/crates/tui/src/view/common/text_window.rs
@@ -331,7 +331,7 @@ mod tests {
         let text =
             Text::from("line 1\nline 2 is longer\nline 3\nline 4\nline 5")
                 .into();
-        let mut component = TestComponent::new(
+        let mut component = TestComponent::with_props(
             &harness,
             &terminal,
             TextWindow::default(),
@@ -416,7 +416,7 @@ mod tests {
     ) {
         let text =
             Text::from("intro\n💚💙💜 this is a longer line\noutro").into();
-        TestComponent::new(
+        TestComponent::with_props(
             &harness,
             &terminal,
             TextWindow::default(),
@@ -443,7 +443,7 @@ mod tests {
         harness: TestHarness,
     ) {
         let text = Text::raw("💚💙💜💚💙💜").into();
-        TestComponent::new(
+        TestComponent::with_props(
             &harness,
             &terminal,
             TextWindow::default(),
@@ -473,7 +473,7 @@ mod tests {
         let text =
             Text::from_iter(["1 this is a long line", "2", "3", "4", "5"])
                 .into();
-        let mut component = TestComponent::new(
+        let mut component = TestComponent::with_props(
             &harness,
             &terminal,
             TextWindow::default(),
@@ -516,7 +516,7 @@ mod tests {
         let text =
             Text::from_iter(["1 this is a long line", "2", "3", "4", "5"])
                 .into();
-        let mut component = TestComponent::new(
+        let mut component = TestComponent::with_props(
             &harness,
             &terminal,
             TextWindow::default(),

--- a/crates/tui/src/view/component/primary.rs
+++ b/crates/tui/src/view/component/primary.rs
@@ -483,7 +483,7 @@ mod tests {
         terminal: &'term TestTerminal,
     ) -> TestComponent<'term, PrimaryView, PrimaryViewProps<'static>> {
         let view = PrimaryView::new(&harness.collection);
-        let mut component = TestComponent::new(
+        let mut component = TestComponent::with_props(
             harness,
             terminal,
             view,

--- a/crates/tui/src/view/component/queryable_body.rs
+++ b/crates/tui/src/view/component/queryable_body.rs
@@ -128,7 +128,8 @@ impl QueryableBody {
             let command = command.to_owned();
             let emitter = self.detach();
             let handle = task::spawn_local(async move {
-                let result = run_command(&command, Some(&body))
+                let shell = &TuiContext::get().config.commands.shell;
+                let result = run_command(shell, &command, Some(&body))
                     .await
                     .with_context(|| format!("Error running `{command}`"));
                 emitter.emit(QueryComplete(result.map_err(Rc::new)));

--- a/crates/tui/src/view/component/recipe_list.rs
+++ b/crates/tui/src/view/component/recipe_list.rs
@@ -5,7 +5,7 @@ use crate::{
             actions::ActionsModal,
             list::List,
             modal::ModalHandle,
-            text_box::{TextBox, TextBoxEvent},
+            text_box::{TextBox, TextBoxEvent, TextBoxProps},
             Pane,
         },
         component::recipe_pane::RecipeMenuAction,
@@ -259,8 +259,12 @@ impl Draw for RecipeListPane {
             true,
         );
 
-        self.filter
-            .draw(frame, (), filter_area, self.filter_focused);
+        self.filter.draw(
+            frame,
+            TextBoxProps::default(),
+            filter_area,
+            self.filter_focused,
+        );
     }
 }
 
@@ -461,7 +465,6 @@ mod tests {
             &harness,
             &terminal,
             RecipeListPane::new(&harness.collection.recipes),
-            (),
         );
         // Clear initial events
         assert_matches!(

--- a/crates/tui/src/view/component/recipe_pane/authentication.rs
+++ b/crates/tui/src/view/component/recipe_pane/authentication.rs
@@ -341,7 +341,6 @@ mod tests {
             &harness,
             &terminal,
             AuthenticationDisplay::new(RecipeId::factory(()), authentication),
-            (),
         );
 
         // Check initial state
@@ -394,7 +393,6 @@ mod tests {
             &harness,
             &terminal,
             AuthenticationDisplay::new(RecipeId::factory(()), authentication),
-            (),
         );
 
         // Edit password
@@ -419,7 +417,6 @@ mod tests {
             &harness,
             &terminal,
             AuthenticationDisplay::new(RecipeId::factory(()), authentication),
-            (),
         );
 
         // Check initial state
@@ -459,7 +456,6 @@ mod tests {
             &harness,
             &terminal,
             AuthenticationDisplay::new(recipe_id, authentication),
-            (),
         );
 
         assert_eq!(
@@ -487,7 +483,6 @@ mod tests {
             &harness,
             &terminal,
             AuthenticationDisplay::new(recipe_id, authentication),
-            (),
         );
 
         assert_eq!(

--- a/crates/tui/src/view/component/recipe_pane/body.rs
+++ b/crates/tui/src/view/component/recipe_pane/body.rs
@@ -315,7 +315,6 @@ mod tests {
             &harness,
             &terminal,
             RecipeBodyDisplay::new(&body, recipe_id.clone()),
-            (),
         );
 
         // Check initial state
@@ -379,7 +378,6 @@ mod tests {
             &harness,
             &terminal,
             RecipeBodyDisplay::new(&body, recipe_id),
-            (),
         );
 
         assert_eq!(

--- a/crates/tui/src/view/component/recipe_pane/table.rs
+++ b/crates/tui/src/view/component/recipe_pane/table.rs
@@ -385,7 +385,7 @@ mod tests {
                 },
             ),
         ];
-        let mut component = TestComponent::new(
+        let mut component = TestComponent::with_props(
             &harness,
             &terminal,
             RecipeFieldTable::new(TestRowKey(recipe_id.clone()), rows),
@@ -446,7 +446,7 @@ mod tests {
                 },
             ),
         ];
-        let mut component = TestComponent::new(
+        let mut component = TestComponent::with_props(
             &harness,
             &terminal,
             RecipeFieldTable::new(TestRowKey(recipe_id.clone()), rows),
@@ -517,7 +517,7 @@ mod tests {
                 },
             ),
         ];
-        let component = TestComponent::new(
+        let component = TestComponent::with_props(
             &harness,
             &terminal,
             RecipeFieldTable::new(TestRowKey(recipe_id.clone()), rows),

--- a/crates/tui/src/view/component/response_view.rs
+++ b/crates/tui/src/view/component/response_view.rs
@@ -1,6 +1,7 @@
 //! Display for HTTP responses
 
 use crate::{
+    context::TuiContext,
     message::Message,
     view::{
         common::{
@@ -144,7 +145,10 @@ impl<'a> Draw<ResponseBodyViewProps<'a>> for ResponseBodyView {
             request_id: props.request_id,
             body: PersistedLazy::new(
                 ResponseQueryPersistedKey(props.recipe_id.clone()),
-                QueryableBody::new(Arc::clone(props.response)),
+                QueryableBody::new(
+                    Arc::clone(props.response),
+                    TuiContext::get().config.commands.query_default.clone(),
+                ),
             )
             .into(),
         });

--- a/crates/tui/src/view/component/response_view.rs
+++ b/crates/tui/src/view/component/response_view.rs
@@ -228,7 +228,7 @@ mod tests {
             response: response.into(),
             ..Exchange::factory(())
         };
-        let mut component = TestComponent::new(
+        let mut component = TestComponent::with_props(
             &harness,
             &terminal,
             ResponseBodyView::default(),
@@ -306,7 +306,7 @@ mod tests {
             response: response.into(),
             ..Exchange::factory(())
         };
-        let mut component = TestComponent::new(
+        let mut component = TestComponent::with_props(
             &harness,
             &terminal,
             ResponseBodyView::default(),

--- a/crates/tui/src/view/component/root.rs
+++ b/crates/tui/src/view/component/root.rs
@@ -310,7 +310,7 @@ mod tests {
             Exchange::factory((Some(profile_id.clone()), recipe_id.clone()));
         harness.database.insert_exchange(&exchange).unwrap();
 
-        let mut component = TestComponent::new(
+        let mut component = TestComponent::with_props(
             &harness,
             &terminal,
             Root::new(&collection),
@@ -353,7 +353,7 @@ mod tests {
             &Some(old_exchange.id),
         );
 
-        let mut component = TestComponent::new(
+        let mut component = TestComponent::with_props(
             &harness,
             &terminal,
             Root::new(&collection),
@@ -404,7 +404,7 @@ mod tests {
             )
             .unwrap();
 
-        let mut component = TestComponent::new(
+        let mut component = TestComponent::with_props(
             &harness,
             &terminal,
             Root::new(&collection),
@@ -424,7 +424,7 @@ mod tests {
     fn test_edit_collection(mut harness: TestHarness, terminal: TestTerminal) {
         let request_store = RequestStore::new(harness.database.clone());
         let root = Root::new(&harness.collection);
-        let mut component = TestComponent::new(
+        let mut component = TestComponent::with_props(
             &harness,
             &terminal,
             root,

--- a/crates/tui/src/view/context.rs
+++ b/crates/tui/src/view/context.rs
@@ -5,6 +5,7 @@ use crate::{
         common::modal::Modal,
         component::RecipeOverrideStore,
         event::{Event, EventQueue},
+        state::Notification,
     },
 };
 use slumber_core::{collection::Collection, db::CollectionDatabase};
@@ -129,6 +130,12 @@ impl ViewContext {
     /// Open a modal
     pub fn open_modal<M: 'static + Modal>(modal: M) {
         Self::push_event(Event::OpenModal(Box::new(modal)));
+    }
+
+    /// Queue an event to send an informational notification to the user
+    pub fn notify(message: impl ToString) {
+        let notification = Notification::new(message.to_string());
+        Self::push_event(Event::Notify(notification));
     }
 
     /// Get a clone of the async message sender. Generally you should use

--- a/crates/tui/src/view/state/select.rs
+++ b/crates/tui/src/view/state/select.rs
@@ -477,7 +477,7 @@ mod tests {
     ) {
         let select = SelectState::builder(items.0).build();
         let mut component =
-            TestComponent::new(&harness, &terminal, select, items.1);
+            TestComponent::with_props(&harness, &terminal, select, items.1);
         component.drain_draw().assert_empty();
         assert_eq!(component.data().selected(), Some(&"a"));
         component.send_key(KeyCode::Down).assert_empty();
@@ -499,7 +499,7 @@ mod tests {
             .subscribe([SelectStateEventType::Select])
             .build();
         let mut component =
-            TestComponent::new(&harness, &terminal, select, items.1);
+            TestComponent::with_props(&harness, &terminal, select, items.1);
 
         // Initial selection
         assert_eq!(component.data().selected(), Some(&"a"));
@@ -527,7 +527,7 @@ mod tests {
             .subscribe([SelectStateEventType::Submit])
             .build();
         let mut component =
-            TestComponent::new(&harness, &terminal, select, items.1);
+            TestComponent::with_props(&harness, &terminal, select, items.1);
         component.drain_draw().assert_empty();
 
         component
@@ -550,7 +550,7 @@ mod tests {
     ) {
         let select = SelectState::builder(items.0).build();
         let mut component =
-            TestComponent::new(&harness, &terminal, select, items.1);
+            TestComponent::with_props(&harness, &terminal, select, items.1);
 
         assert_matches!(
             component.send_key(KeyCode::Enter).events(),
@@ -613,7 +613,7 @@ mod tests {
             .items()
             .map(|item| item.0.to_string())
             .collect::<List>();
-        let mut component = TestComponent::new(
+        let mut component = TestComponent::with_props(
             &harness,
             &terminal,
             PersistedLazy::new(Key, select),

--- a/crates/tui/src/view/test_util.rs
+++ b/crates/tui/src/view/test_util.rs
@@ -51,6 +51,18 @@ where
     Props: Clone,
     T: Draw<Props> + ToChild,
 {
+    /// [Self::with_props], but with default initial props
+    pub fn new(
+        harness: &TestHarness,
+        terminal: &'term TestTerminal,
+        data: T,
+    ) -> Self
+    where
+        Props: Default,
+    {
+        Self::with_props(harness, terminal, data, Props::default())
+    }
+
     /// Create a new component, then draw it to the screen and drain the event
     /// queue. Components aren't useful until they've been drawn once, because
     /// they won't receive events until they're marked as visible. For this
@@ -59,7 +71,7 @@ where
     ///
     /// This takes a a reference to the terminal so it can draw without having
     /// to plumb the terminal around to every draw call.
-    pub fn new(
+    pub fn with_props(
         harness: &TestHarness,
         terminal: &'term TestTerminal,
         data: T,

--- a/docs/src/api/configuration/editor.md
+++ b/docs/src/api/configuration/editor.md
@@ -31,7 +31,7 @@ pager: bat
 
 To open a body in the pager, use the actions menu keybinding (`x` by default, see [input bindings](./input_bindings.md)), and select `View Body`.
 
-Some popular file viewers:
+Some popular pagers:
 
 - [bat](https://github.com/sharkdp/bat)
 - [fx](https://fx.wtf/)

--- a/docs/src/api/configuration/index.md
+++ b/docs/src/api/configuration/index.md
@@ -33,6 +33,7 @@ SLUMBER_CONFIG_PATH=~/dotfiles/slumber.yml slumber
 | Field                      | Type                                | Description                                                                                       | Default                                      |
 | -------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------- | -------------------------------------------- |
 | `commands.shell`           | `string[]`                          | Shell used to execute commands within the TUI. [More info](#commands)                             | `[sh, -c]` (Unix), `[cmd, /S, /C]` (Windows) |
+| `commands.query_default`   | `string`                            | Default query command for all responses                                                           | `""`                                         |
 | `debug`                    | `boolean`                           | Enable developer information                                                                      | `false`                                      |
 | `editor`                   | `string`                            | Command to use when opening files for in-app editing. [More info](./editor.md)                    | `VISUAL`/`EDITOR` env vars, or `vim`         |
 | `ignore_certificate_hosts` | `string[]`                          | Hostnames whose TLS certificate errors will be ignored. [More info](../../troubleshooting/tls.md) | `[]`                                         |

--- a/docs/src/api/configuration/index.md
+++ b/docs/src/api/configuration/index.md
@@ -30,14 +30,35 @@ SLUMBER_CONFIG_PATH=~/dotfiles/slumber.yml slumber
 
 ## Fields
 
-| Field                      | Type                                | Description                                                                                       | Default                              |
-| -------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------ |
-| `debug`                    | `boolean`                           | Enable developer information                                                                      | `false`                              |
-| `editor`                   | `string`                            | Command to use when opening files for in-app editing. [More info](./editor.md)                    | `VISUAL`/`EDITOR` env vars, or `vim` |
-| `ignore_certificate_hosts` | `string[]`                          | Hostnames whose TLS certificate errors will be ignored. [More info](../../troubleshooting/tls.md) | `[]`                                 |
-| `input_bindings`           | `mapping[Action, KeyCombination[]]` | Override default input bindings. [More info](./input_bindings.md)                                 | `{}`                                 |
-| `large_body_size`          | `number`                            | Size over which request/response bodies are not formatted/highlighted, for performance (bytes)    | `1000000` (1 MB)                     |
-| `preview_templates`        | `boolean`                           | Render template values in the TUI? If false, the raw template will be shown.                      | `true`                               |
-| `theme`                    | [`Theme`](./theme.md)               | Visual customizations                                                                             | `{}`                                 |
-| `pager`                    | `string`                            | Command to use when opening files for viewing. [More info](./editor.md)                           | `less` (Unix), `more` (Windows)      |
-| `viewer`                   | See `pager`                         | Alias for `pager`, for backward compatibility                                                     | See `pager`                          |
+| Field                      | Type                                | Description                                                                                       | Default                                      |
+| -------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| `commands.shell`           | `string[]`                          | Shell used to execute commands within the TUI. [More info](#commands)                             | `[sh, -c]` (Unix), `[cmd, /S, /C]` (Windows) |
+| `debug`                    | `boolean`                           | Enable developer information                                                                      | `false`                                      |
+| `editor`                   | `string`                            | Command to use when opening files for in-app editing. [More info](./editor.md)                    | `VISUAL`/`EDITOR` env vars, or `vim`         |
+| `ignore_certificate_hosts` | `string[]`                          | Hostnames whose TLS certificate errors will be ignored. [More info](../../troubleshooting/tls.md) | `[]`                                         |
+| `input_bindings`           | `mapping[Action, KeyCombination[]]` | Override default input bindings. [More info](./input_bindings.md)                                 | `{}`                                         |
+| `large_body_size`          | `number`                            | Size over which request/response bodies are not formatted/highlighted, for performance (bytes)    | `1000000` (1 MB)                             |
+| `preview_templates`        | `boolean`                           | Render template values in the TUI? If false, the raw template will be shown.                      | `true`                                       |
+| `theme`                    | [`Theme`](./theme.md)               | Visual customizations                                                                             | `{}`                                         |
+| `pager`                    | `string`                            | Command to use when opening files for viewing. [More info](./editor.md)                           | `less` (Unix), `more` (Windows)              |
+| `viewer`                   | See `pager`                         | Alias for `pager`, for backward compatibility                                                     | See `pager`                                  |
+
+## Commands
+
+Slumber allows you to execute shell commands within the TUI, e.g. for querying and transforming response bodies. By default, the command you enter is passed to `sh` (or `cmd` on Windows) for parsing and execution. This allows you to access shell behavior such as piping. The command to execute is passed as the final argument to the shell, and the response body is passed as stdin to the spawned process.
+
+If you want to use a different shell (e.g. to access your shell aliases), you can override the `commands.shell` config field. For example, to use [fish](https://fishshell.com/):
+
+```yaml
+commands:
+  shell: ["fish", "-c"]
+```
+
+If you don't want to use a shell at all, you can pass `[]`:
+
+```yaml
+commands:
+  shell: []
+```
+
+In this case, any commands to be executed will be parsed with [shell-words](https://docs.rs/shell-words/1.1.0/shell_words/fn.split.html) and executed directly. For example, `echo -n test` will run `echo` with the arguments `-n` and `test`.


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

- Kill pending query process when a new one is started
- Add a keybind (`?`, same as help dialog) to view the error when a command fails
  - We report a notification when this happens that includes the keybind
- Add `commands.shell` config field, to define how all commands should be executed
  - Defaults to `sh -c`, so you can now use pipes in the query out of the box
- Add `commands.default_query` to define an initial query string for all responses. For example, `default_query: jq` will pre-populate the box with `jq` so you can start writing actual queries faster

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

- Help dialog
- Default/persistence interaction
- I haven't tested this on Windows at all

## QA

_How did you test this?_

Added a good amount of unit tests

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
