### PR TITLE
Add modal padding, add doc links to help modal and --help

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -25,6 +25,8 @@ const COMMAND_NAME: &str = "slumber";
 /// Configurable HTTP client with both TUI and CLI interfaces
 ///
 /// If subcommand is omitted, start the TUI.
+///
+/// https://slumber.lucaspickering.me/book/
 #[derive(Debug, Parser)]
 #[clap(author, version, about, name = COMMAND_NAME)]
 pub struct Args {

--- a/crates/core/src/util.rs
+++ b/crates/core/src/util.rs
@@ -20,7 +20,6 @@ use std::{
 use tokio::sync::{Mutex, OwnedRwLockWriteGuard, RwLock};
 use tracing::error;
 
-const WEBSITE: &str = "https://slumber.lucaspickering.me";
 /// Link to the GitHub New Issue form
 pub const NEW_ISSUE_LINK: &str =
     "https://github.com/LucasPickering/slumber/issues/new/choose";
@@ -36,7 +35,12 @@ pub const NEW_ISSUE_LINK: &str =
 /// );
 /// ```
 pub fn doc_link(path: &str) -> String {
-    format!("{WEBSITE}/book/{path}.html")
+    const ROOT: &str = "https://slumber.lucaspickering.me/book/";
+    if path.is_empty() {
+        ROOT.into()
+    } else {
+        format!("{ROOT}{path}.html")
+    }
 }
 
 /// Parse bytes from a reader into YAML. This will merge any anchors/aliases.

--- a/crates/tui/src/view/common/modal.rs
+++ b/crates/tui/src/view/common/modal.rs
@@ -9,6 +9,7 @@ use crate::{
     },
 };
 use ratatui::{
+    layout::Margin,
     prelude::Constraint,
     text::Line,
     widgets::{Block, Borders, Clear},
@@ -174,19 +175,24 @@ impl Draw for ModalQueue {
             let (width, height) = modal.data().dimensions();
 
             // The child gave us the content dimensions, we need to add one cell
-            // of buffer for the border
+            // of buffer for the border, plus one cell of padding in X so text
+            // doesn't butt up against the border, which interferes with
+            // word-based selection
+            let margin = Margin::new(1, 0);
             let mut area = centered_rect(width, height, metadata.area());
-            area.x -= 1;
-            area.y -= 1;
-            area.width += 2;
-            area.height += 2;
+            let x_buffer = margin.horizontal + 1;
+            let y_buffer = margin.vertical + 1;
+            area.x -= x_buffer;
+            area.y -= y_buffer;
+            area.width += x_buffer * 2;
+            area.height += y_buffer * 2;
 
             let block = Block::default()
                 .title(modal.data().title())
                 .borders(Borders::ALL)
                 .border_style(styles.modal.border)
                 .border_type(styles.modal.border_type);
-            let inner_area = block.inner(area);
+            let inner_area = block.inner(area).inner(margin);
 
             // Draw the outline of the modal
             frame.render_widget(Clear, area);

--- a/crates/tui/src/view/component/help.rs
+++ b/crates/tui/src/view/component/help.rs
@@ -14,7 +14,7 @@ use ratatui::{
     Frame,
 };
 use slumber_config::{Action, Config, InputBinding};
-use slumber_core::util::paths;
+use slumber_core::util::{doc_link, paths};
 
 const CRATE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -53,7 +53,7 @@ pub struct HelpModal;
 
 impl HelpModal {
     /// Number of lines in the general section (not including header)
-    const GENERAL_LENGTH: u16 = 4;
+    const GENERAL_LENGTH: u16 = 5;
 
     /// Get the list of bindings that will be shown in the modal
     fn bindings() -> impl Iterator<Item = (Action, &'static InputBinding)> {
@@ -97,6 +97,7 @@ impl Draw for HelpModal {
             title: Some("General"),
             rows: [
                 ("Version", Line::from(CRATE_VERSION)),
+                ("Docs", doc_link("").into()),
                 ("Configuration", Config::path().display().to_string().into()),
                 ("Log", paths::log_file().display().to_string().into()),
                 (


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

- Add doc link to help modal
- Add doc link to `--help` output
- Add one cell of X padding on the inside of modals, to separate contained text from the border
  - Enables word-based selection and link highlighting

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Modals fit 2 less columns now

## QA

_How did you test this?_

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
