### PR TITLE
Refactor event handling to use combinators, show query errors inline

### DIFF
--- a/crates/tui/src/util.rs
+++ b/crates/tui/src/util.rs
@@ -49,6 +49,17 @@ where
     }
 }
 
+/// A flag that starts as false and can only be enabled
+#[derive(Copy, Clone, Debug, Default, derive_more::Deref)]
+pub struct Flag(bool);
+
+impl Flag {
+    /// Enable the flag
+    pub fn set(&mut self) {
+        self.0 = true;
+    }
+}
+
 /// Clear all input events in the terminal event buffer
 pub fn clear_event_buffer() {
     while let Ok(true) = event::poll(Duration::from_millis(0)) {

--- a/crates/tui/src/view/common/actions.rs
+++ b/crates/tui/src/view/common/actions.rs
@@ -66,17 +66,15 @@ where
     ActionsModal<T>: Draw,
 {
     fn update(&mut self, _: &mut UpdateContext, event: Event) -> Update {
-        if let Some(event) = self.actions.emitted(&event) {
+        event.m().emitted(self.actions.handle(), |event| {
             if let SelectStateEvent::Submit(index) = event {
-                // Close modal first so the parent can consume the emitted event
+                // Close modal first so the parent can consume the emitted
+                // event
                 self.close(true);
-                let action = self.actions.data()[*index];
+                let action = self.actions.data()[index];
                 self.emit(action);
             }
-            Update::Consumed
-        } else {
-            Update::Propagate(event)
-        }
+        })
     }
 
     fn children(&mut self) -> Vec<Component<Child<'_>>> {

--- a/crates/tui/src/view/common/button.rs
+++ b/crates/tui/src/view/common/button.rs
@@ -56,19 +56,15 @@ pub struct ButtonGroup<T: FixedSelect> {
 
 impl<T: FixedSelect> EventHandler for ButtonGroup<T> {
     fn update(&mut self, _: &mut UpdateContext, event: Event) -> Update {
-        let Some(action) = event.action() else {
-            return Update::Propagate(event);
-        };
-        match action {
+        event.m().action(|action, propagate| match action {
             Action::Left => self.select.previous(),
             Action::Right => self.select.next(),
             Action::Submit => {
                 // Propagate the selected item as a dynamic event
                 self.emit(self.select.selected());
             }
-            _ => return Update::Propagate(event),
-        }
-        Update::Consumed
+            _ => propagate.set(),
+        })
     }
 
     // Do *not* treat the select state as a child, because the default select

--- a/crates/tui/src/view/common/tabs.rs
+++ b/crates/tui/src/view/common/tabs.rs
@@ -26,15 +26,11 @@ impl<T: FixedSelect> Tabs<T> {
 
 impl<T: FixedSelect> EventHandler for Tabs<T> {
     fn update(&mut self, _: &mut UpdateContext, event: Event) -> Update {
-        let Some(action) = event.action() else {
-            return Update::Propagate(event);
-        };
-        match action {
+        event.m().action(|action, propagate| match action {
             Action::Left => self.tabs.previous(),
             Action::Right => self.tabs.next(),
-            _ => return Update::Propagate(event),
-        }
-        Update::Consumed
+            _ => propagate.set(),
+        })
     }
 }
 

--- a/crates/tui/src/view/common/text_window.rs
+++ b/crates/tui/src/view/common/text_window.rs
@@ -177,10 +177,7 @@ impl TextWindow {
 
 impl EventHandler for TextWindow {
     fn update(&mut self, _: &mut UpdateContext, event: Event) -> Update {
-        let Some(action) = event.action() else {
-            return Update::Propagate(event);
-        };
-        match action {
+        event.m().action(|action, propagate| match action {
             Action::Up | Action::ScrollUp => self.scroll_up(1),
             Action::Down | Action::ScrollDown => self.scroll_down(1),
             Action::ScrollLeft => self.scroll_left(1),
@@ -189,9 +186,8 @@ impl EventHandler for TextWindow {
             Action::PageDown => self.scroll_down(self.window_height.get()),
             Action::Home => self.scroll_to(0),
             Action::End => self.scroll_to(usize::MAX),
-            _ => return Update::Propagate(event),
-        }
-        Update::Consumed
+            _ => propagate.set(),
+        })
     }
 }
 

--- a/crates/tui/src/view/component/exchange_pane.rs
+++ b/crates/tui/src/view/component/exchange_pane.rs
@@ -75,11 +75,10 @@ enum Tab {
 
 impl EventHandler for ExchangePane {
     fn update(&mut self, _: &mut UpdateContext, event: Event) -> Update {
-        match event.action() {
-            Some(Action::LeftClick) => self.emit(ExchangePaneEvent::Click),
-            _ => return Update::Propagate(event),
-        }
-        Update::Consumed
+        event.m().action(|action, propagate| match action {
+            Action::LeftClick => self.emit(ExchangePaneEvent::Click),
+            _ => propagate.set(),
+        })
     }
 
     fn children(&mut self) -> Vec<Component<Child<'_>>> {

--- a/crates/tui/src/view/component/history.rs
+++ b/crates/tui/src/view/component/history.rs
@@ -6,7 +6,7 @@ use crate::{
         common::{list::List, modal::Modal},
         component::Component,
         draw::{Draw, DrawMetadata, Generate},
-        event::{Child, Event, EventHandler, Update},
+        event::{Child, Emitter, Event, EventHandler, Update},
         state::select::{SelectState, SelectStateEvent, SelectStateEventType},
         UpdateContext, ViewContext,
     },
@@ -73,16 +73,13 @@ impl Modal for History {
 
 impl EventHandler for History {
     fn update(&mut self, _: &mut UpdateContext, event: Event) -> Update {
-        if let Some(event) = self.select.emitted(&event) {
+        event.m().emitted(self.select.handle(), |event| {
             if let SelectStateEvent::Select(index) = event {
                 ViewContext::push_event(Event::HttpSelectRequest(Some(
-                    self.select.data()[*index].id(),
+                    self.select.data()[index].id(),
                 )))
             }
-        } else {
-            return Update::Propagate(event);
-        }
-        Update::Consumed
+        })
     }
 
     fn children(&mut self) -> Vec<Component<Child<'_>>> {

--- a/crates/tui/src/view/component/internal.rs
+++ b/crates/tui/src/view/component/internal.rs
@@ -5,7 +5,7 @@
 use crate::view::{
     context::UpdateContext,
     draw::{Draw, DrawMetadata},
-    event::{Child, Emitter, Event, ToChild, Update},
+    event::{Child, Emitter, EmitterId, Event, ToChild, Update},
 };
 use crossterm::event::MouseEvent;
 use derive_more::Display;
@@ -204,23 +204,6 @@ impl<T> Component<T> {
         self.inner
     }
 
-    /// Forward to [Emitter::emitted]
-    pub fn emitted<'a>(&self, event: &'a Event) -> Option<&'a T::Emitted>
-    where
-        T: Emitter,
-    {
-        self.data().emitted(event)
-    }
-
-    /// Forward to [Emitter::emitted_owned]
-    /// TODO rename
-    pub fn emitted_owned(&self, event: Event) -> Result<T::Emitted, Event>
-    where
-        T: Emitter,
-    {
-        self.data().emitted_owned(event)
-    }
-
     /// Draw the component to the frame. This will update global state, then
     /// defer to the component's [Draw] implementation for the actual draw.
     pub fn draw<Props>(
@@ -281,6 +264,19 @@ impl<T: Default> Default for Component<T> {
 impl<T> From<T> for Component<T> {
     fn from(inner: T) -> Self {
         Self::new(inner)
+    }
+}
+
+impl<T: Emitter> Emitter for Component<T> {
+    type Emitted = T::Emitted;
+
+    fn id(&self) -> EmitterId {
+        self.data().id()
+    }
+
+    fn type_name(&self) -> &'static str {
+        // Use the name of the contained emitter
+        self.name
     }
 }
 

--- a/crates/tui/src/view/component/internal.rs
+++ b/crates/tui/src/view/component/internal.rs
@@ -212,6 +212,15 @@ impl<T> Component<T> {
         self.data().emitted(event)
     }
 
+    /// Forward to [Emitter::emitted_owned]
+    /// TODO rename
+    pub fn emitted_owned(&self, event: Event) -> Result<T::Emitted, Event>
+    where
+        T: Emitter,
+    {
+        self.data().emitted_owned(event)
+    }
+
     /// Draw the component to the frame. This will update global state, then
     /// defer to the component's [Draw] implementation for the actual draw.
     pub fn draw<Props>(

--- a/crates/tui/src/view/component/misc.rs
+++ b/crates/tui/src/view/component/misc.rs
@@ -26,25 +26,15 @@ use ratatui::{
     Frame,
 };
 use slumber_core::template::{Prompt, Select};
-use std::{fmt::Debug, rc::Rc};
+use std::fmt::Debug;
 use strum::{EnumCount, EnumIter};
 
 /// Modal to display an error. Typically the error is [anyhow::Error], but it
 /// could also be wrapped in a smart pointer.
 #[derive(Debug)]
-pub struct ErrorModal<E = anyhow::Error>(E);
+pub struct ErrorModal(anyhow::Error);
 
-impl<E> ErrorModal<E> {
-    pub fn new(error: E) -> Self {
-        Self(error)
-    }
-}
-
-impl<E> Modal for ErrorModal<E>
-where
-    E: Debug,
-    Self: Draw,
-{
+impl Modal for ErrorModal {
     fn priority(&self) -> ModalPriority {
         ModalPriority::High // beep beep coming through
     }
@@ -58,22 +48,16 @@ where
     }
 }
 
-impl<E> EventHandler for ErrorModal<E> {}
+impl EventHandler for ErrorModal {}
 
-impl Draw for ErrorModal<anyhow::Error> {
-    fn draw(&self, frame: &mut Frame, _: (), metadata: DrawMetadata) {
-        frame.render_widget(self.0.generate(), metadata.area());
-    }
-}
-
-impl Draw for ErrorModal<Rc<anyhow::Error>> {
+impl Draw for ErrorModal {
     fn draw(&self, frame: &mut Frame, _: (), metadata: DrawMetadata) {
         frame.render_widget(self.0.generate(), metadata.area());
     }
 }
 
 impl IntoModal for anyhow::Error {
-    type Target = ErrorModal<anyhow::Error>;
+    type Target = ErrorModal;
 
     fn into_modal(self) -> Self::Target {
         ErrorModal(self)

--- a/crates/tui/src/view/component/recipe_pane.rs
+++ b/crates/tui/src/view/component/recipe_pane.rs
@@ -84,8 +84,9 @@ impl RecipePane {
 
 impl EventHandler for RecipePane {
     fn update(&mut self, _: &mut UpdateContext, event: Event) -> Update {
-        if let Some(action) = event.action() {
-            match action {
+        event
+            .m()
+            .action(|action, propagate| match action {
                 Action::LeftClick => self.emit(RecipePaneEvent::Click),
                 Action::OpenActions => {
                     let state = self.recipe_state.get_mut();
@@ -98,15 +99,12 @@ impl EventHandler for RecipePane {
                         ),
                     ))
                 }
-                _ => return Update::Propagate(event),
-            }
-        } else if let Some(menu_action) = self.actions_handle.emitted(&event) {
-            // Menu actions are handled by the parent, so forward them
-            self.emit(RecipePaneEvent::MenuAction(*menu_action));
-        } else {
-            return Update::Propagate(event);
-        }
-        Update::Consumed
+                _ => propagate.set(),
+            })
+            .emitted(self.actions_handle, |menu_action| {
+                // Menu actions are handled by the parent, so forward them
+                self.emit(RecipePaneEvent::MenuAction(menu_action));
+            })
     }
 
     fn children(&mut self) -> Vec<Component<Child<'_>>> {

--- a/crates/tui/src/view/component/recipe_pane/authentication.rs
+++ b/crates/tui/src/view/component/recipe_pane/authentication.rs
@@ -99,19 +99,17 @@ impl AuthenticationDisplay {
 
 impl EventHandler for AuthenticationDisplay {
     fn update(&mut self, _: &mut UpdateContext, event: Event) -> Update {
-        let action = event.action();
-        if let Some(Action::Edit) = action {
-            self.state.open_edit_modal(self.handle());
-        } else if let Some(Action::Reset) = action {
-            self.state.reset_override();
-        } else if let Some(SaveAuthenticationOverride(value)) =
-            self.emitted(&event)
-        {
-            self.state.set_override(value);
-        } else {
-            return Update::Propagate(event);
-        }
-        Update::Consumed
+        event
+            .m()
+            .action(|action, propagate| match action {
+                Action::Edit => self.state.open_edit_modal(self.handle()),
+                Action::Reset => self.state.reset_override(),
+
+                _ => propagate.set(),
+            })
+            .emitted(self.handle(), |SaveAuthenticationOverride(value)| {
+                self.state.set_override(&value)
+            })
     }
 
     fn children(&mut self) -> Vec<Component<Child<'_>>> {

--- a/crates/tui/src/view/component/recipe_pane/body.rs
+++ b/crates/tui/src/view/component/recipe_pane/body.rs
@@ -210,17 +210,16 @@ impl RawBody {
 
 impl EventHandler for RawBody {
     fn update(&mut self, _: &mut UpdateContext, event: Event) -> Update {
-        let action = event.action();
-        if let Some(Action::Edit) = action {
-            self.open_editor();
-        } else if let Some(Action::Reset) = action {
-            self.body.reset_override();
-        } else if let Some(SaveBodyOverride(path)) = self.emitted(&event) {
-            self.load_override(path);
-        } else {
-            return Update::Propagate(event);
-        }
-        Update::Consumed
+        event
+            .m()
+            .action(|action, propagate| match action {
+                Action::Edit => self.open_editor(),
+                Action::Reset => self.body.reset_override(),
+                _ => propagate.set(),
+            })
+            .emitted(self.handle(), |SaveBodyOverride(path)| {
+                self.load_override(&path)
+            })
     }
 
     fn children(&mut self) -> Vec<Component<Child<'_>>> {

--- a/crates/tui/src/view/component/response_view.rs
+++ b/crates/tui/src/view/component/response_view.rs
@@ -88,10 +88,15 @@ impl ResponseBodyView {
 
 impl EventHandler for ResponseBodyView {
     fn update(&mut self, _: &mut UpdateContext, event: Event) -> Update {
-        if let Some(Action::OpenActions) = event.action() {
-            self.actions_handle.open(ActionsModal::default());
-        } else if let Some(menu_action) = self.actions_handle.emitted(&event) {
-            match menu_action {
+        event
+            .m()
+            .action(|action, propagate| match action {
+                Action::OpenActions => {
+                    self.actions_handle.open(ActionsModal::default())
+                }
+                _ => propagate.set(),
+            })
+            .emitted(self.actions_handle, |menu_action| match menu_action {
                 BodyMenuAction::EditCollection => {
                     ViewContext::send_message(Message::CollectionEdit)
                 }
@@ -118,11 +123,7 @@ impl EventHandler for ResponseBodyView {
                         });
                     }
                 }
-            }
-        } else {
-            return Update::Propagate(event);
-        }
-        Update::Consumed
+            })
     }
 
     fn children(&mut self) -> Vec<Component<Child<'_>>> {

--- a/crates/tui/src/view/state/select.rs
+++ b/crates/tui/src/view/state/select.rs
@@ -314,13 +314,9 @@ where
     State: Debug + SelectStateData,
 {
     fn update(&mut self, _: &mut UpdateContext, event: Event) -> Update {
-        let Some(action) = event.action() else {
-            return Update::Propagate(event);
-        };
-
-        // Up/down keys and scrolling. Scrolling will only work if .set_area()
-        // is called on the wrapping Component by our parent
-        match action {
+        event.m().action(|action, propagate| match action {
+            // Up/down keys and scrolling. Scrolling will only work if
+            // .set_area() is called on the wrapping Component by our parent
             Action::Up | Action::ScrollUp => self.previous(),
             Action::Down | Action::ScrollDown => self.next(),
             // Don't eat these events unless the user has subscribed
@@ -334,9 +330,8 @@ where
             {
                 self.emit_for_selected(SelectStateEvent::Submit)
             }
-            _ => return Update::Propagate(event),
-        }
-        Update::Consumed
+            _ => propagate.set(),
+        })
     }
 }
 

--- a/crates/tui/src/view/test_util.rs
+++ b/crates/tui/src/view/test_util.rs
@@ -311,28 +311,27 @@ impl<'a, Component> PropagatedEvents<'a, Component> {
     /// a specific sequence. Requires `PartialEq` to be implemented for the
     /// emitted event type.
     pub fn assert_emitted(
-        &self,
+        self,
         expected: impl IntoIterator<Item = Component::Emitted>,
     ) where
         Component: Emitter,
         Component::Emitted: PartialEq,
     {
+        let handle = self.component.handle();
         let emitted = self
             .events
-            .iter()
+            .into_iter()
             .map(|event| {
-                self.component.emitted(event).unwrap_or_else(|| {
+                handle.emitted(event).unwrap_or_else(|event| {
                     panic!(
                         "Expected only emitted events to have been propagated, \
-                        but received: {event:#?}\nAll: {:#?}",
-                        self.events()
+                        but received: {event:#?}",
                     )
                 })
             })
             .collect::<Vec<_>>();
         let expected = expected.into_iter().collect_vec();
-        let expected = expected.iter().collect_vec();
-        assert_eq!(emitted.as_slice(), expected.as_slice());
+        assert_eq!(emitted, expected);
     }
 
     /// Get propagated events as a slice

--- a/docs/src/user_guide/tui/filter_query.md
+++ b/docs/src/user_guide/tui/filter_query.md
@@ -14,12 +14,6 @@ _Example of using pipes in a query command_
 
 Keep in mind that your queries are being executed as shell commands on your system. You should avoid running any commands that interact with the file system, such as using `>` or `<` to pipe to/from files. TODO add more about side-effect commands once implemented
 
-## Errors
-
-We can't all be perfect. Sometimes you run a command that fails. To view the error, press `?` (make sure you exit the text box first!).
-
-![View query error](../../images/query_error.gif)
-
 ## Which shell does Slumber use?
 
 By default, Slumber executes your command via `sh -c` on Unix and `cmd /S /C` on Windows. You can customize this via the [`commands.shell` configuration field](../../api/configuration/index.md#commandsshell). For example, to use `fish` instead of `sh`:


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

- Use combinators on `Update` instead of a variety of `match`/`if let`/`let...else` to match events
  - This is more consistent, more ergonomic, and makes it easy to get an owned value out of a propagated event
- Show query errors directly in the response pane instead of hidden in a help dialog
  - This un-overrides the `OpenHelp` action
  - It's unlikely someone would want to browse the request while their query has failed, they probably just want to see the error. To get the request back they can easily just delete the query
- Fix bug where query state wasn't being reset for an empty string

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

I touched a lot of event handling code so it's possible something broke. Unit tests should cover almost everything, manual testing before the next release should get the rest.

## QA

_How did you test this?_

A bit of manual testing, mostly leaning on existing unit tests.

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
