### PR TITLE
Refactor view state

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,4 +105,4 @@ jobs:
           RUST_BACKTRACE: 1
 
       - name: Run tests
-        run: cargo test --workspace
+        run: cargo test --workspace --no-fail-fast

--- a/crates/core/src/db/convert.rs
+++ b/crates/core/src/db/convert.rs
@@ -210,6 +210,7 @@ impl<'a, 'b> TryFrom<&'a Row<'b>> for Exchange {
                     .map(|wrap| wrap.0),
             }),
             response: Arc::new(ResponseRecord {
+                id,
                 status: row.get::<_, SqlWrap<StatusCode>>("status_code")?.0,
                 headers: row
                     .get::<_, SqlWrap<HeaderMap>>("response_headers")?

--- a/crates/core/src/http.rs
+++ b/crates/core/src/http.rs
@@ -363,7 +363,7 @@ impl RequestTicket {
         let result = async {
             let response = self.client.execute(self.request).await?;
             // Load the full response and convert it to our format
-            ResponseRecord::from_response(response).await
+            ResponseRecord::from_response(id, response).await
         }
         .await;
         let end_time = Utc::now();
@@ -404,6 +404,7 @@ impl ResponseRecord {
     /// because the response content is not necessarily loaded when we first get
     /// the response. Only fails if the response content fails to load.
     async fn from_response(
+        id: RequestId,
         response: Response,
     ) -> reqwest::Result<ResponseRecord> {
         // Copy response metadata out first, because we need to move the
@@ -415,6 +416,7 @@ impl ResponseRecord {
         let body = response.bytes().await?.into();
 
         Ok(ResponseRecord {
+            id,
             status,
             headers,
             body,
@@ -1365,6 +1367,7 @@ mod tests {
         assert_eq!(
             *exchange.response,
             ResponseRecord {
+                id: exchange.id,
                 status: StatusCode::OK,
                 headers: header_map([
                     ("content-type", "text/plain"),

--- a/crates/core/src/template.rs
+++ b/crates/core/src/template.rs
@@ -441,6 +441,7 @@ mod tests {
             ..RequestRecord::factory(())
         };
         let response = ResponseRecord {
+            id: request.id,
             body: response_body.into(),
             headers: response_headers,
             ..ResponseRecord::factory(())
@@ -1043,6 +1044,7 @@ mod tests {
             ..RequestRecord::factory(())
         };
         let response = ResponseRecord {
+            id: request.id,
             body: json!(["foo", "bar"]).into(),
             headers: response_headers,
             ..ResponseRecord::factory(())

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -114,15 +114,18 @@ impl Tui {
             .await
             .reported(&messages_tx)
             .unwrap_or_else(|| CollectionFile::with_path(collection_path));
-        let view =
-            View::new(&collection_file, database.clone(), messages_tx.clone());
+        let request_store = RequestStore::new(database.clone());
+        let view = View::new(
+            &collection_file,
+            &request_store,
+            database.clone(),
+            messages_tx.clone(),
+        );
 
         // The code to revert the terminal takeover is in `Tui::drop`, so we
         // shouldn't take over the terminal until right before creating the
         // `Tui`.
         let terminal = initialize_terminal()?;
-
-        let request_store = RequestStore::new(database.clone());
 
         let app = Tui {
             terminal,
@@ -288,17 +291,23 @@ impl Tui {
                 self.send_request(request_config)?
             }
             Message::HttpBuildError { error } => {
-                self.request_store.build_error(error);
+                let state = self.request_store.build_error(error);
+                self.view.update_request(state);
             }
             Message::HttpLoading { request } => {
-                self.request_store.loading(request);
+                let state = self.request_store.loading(request);
+                self.view.update_request(state);
             }
-            Message::HttpComplete(result) => match result {
-                Ok(exchange) => self.request_store.response(exchange),
-                Err(error) => self.request_store.request_error(error),
-            },
+            Message::HttpComplete(result) => {
+                let state = match result {
+                    Ok(exchange) => self.request_store.response(exchange),
+                    Err(error) => self.request_store.request_error(error),
+                };
+                self.view.update_request(state);
+            }
             Message::HttpCancel(request_id) => {
-                self.request_store.cancel(request_id)
+                let state = self.request_store.cancel(request_id);
+                self.view.update_request(state);
             }
 
             // Force quit short-circuits the view/message cycle, to make sure
@@ -409,10 +418,12 @@ impl Tui {
         self.collection_file.collection = collection.into();
 
         // Rebuild the whole view, because tons of things can change
-        let database = self.database.clone();
-        let messages_tx = self.messages_tx();
-        let collection_file = &self.collection_file;
-        self.view = View::new(collection_file, database, messages_tx);
+        self.view = View::new(
+            &self.collection_file,
+            &self.request_store,
+            self.database.clone(),
+            self.messages_tx(),
+        );
     }
 
     /// GOODBYE
@@ -423,8 +434,7 @@ impl Tui {
 
     /// Draw the view onto the screen
     fn draw(&mut self) -> anyhow::Result<()> {
-        self.terminal
-            .draw(|frame| self.view.draw(frame, &self.request_store))?;
+        self.terminal.draw(|frame| self.view.draw(frame))?;
         Ok(())
     }
 

--- a/crates/tui/src/view/component.rs
+++ b/crates/tui/src/view/component.rs
@@ -13,6 +13,6 @@ mod response_view;
 mod root;
 
 pub use internal::Component;
-pub use root::{Root, RootProps};
+pub use root::Root;
 // Exported for the view context
 pub use recipe_pane::RecipeOverrideStore;

--- a/crates/tui/src/view/component/queryable_body.rs
+++ b/crates/tui/src/view/component/queryable_body.rs
@@ -412,10 +412,12 @@ mod tests {
     use crossterm::event::KeyCode;
     use persisted::{PersistedKey, PersistedStore};
     use ratatui::text::Span;
-    use reqwest::StatusCode;
     use rstest::{fixture, rstest};
     use serde::Serialize;
-    use slumber_core::http::{ResponseBody, ResponseRecord};
+    use slumber_core::{
+        http::{ResponseBody, ResponseRecord},
+        test_util::Factory,
+    };
 
     const TEXT: &[u8] = b"{\"greeting\":\"hello\"}";
 
@@ -433,12 +435,12 @@ mod tests {
     #[fixture]
     fn response() -> Arc<ResponseRecord> {
         ResponseRecord {
-            status: StatusCode::OK,
             // Note: do NOT set the content-type header here. It enables syntax
             // highlighting, which makes buffer assertions hard. JSON-specific
             // behavior is tested in ResponseView
             headers: Default::default(),
             body: ResponseBody::new(TEXT.into()),
+            ..ResponseRecord::factory(())
         }
         .into()
     }


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

This refactors the exchange pane and it's children to be single-use, meaning we trash the component and build a new one whenever the request state changes. This makes the state management much simpler. I'd like to move toward this pattern more in general.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

State bugs. We have decent test coverage to guard against this.

## QA

_How did you test this?_

Bit of manual testing, mostly relying on existing tests

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
