### PR TITLE
Support multiple pager commands based on content type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   - `slumber history list` lists all stored requests for a recipe
   - `slumber history get` prints a specific request/response
 - Add `--output` flag to `slumber request` to control where the response body is written to
+- Support MIME type mapping for `pager` config field, so you can set different pagers based on media type. [See docs](https://slumber.lucaspickering.me/book/api/configuration/mime.html)
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,9 +810,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "h2"
@@ -2426,8 +2426,10 @@ dependencies = [
  "derive_more",
  "dirs",
  "env-lock",
+ "glob",
  "indexmap",
  "itertools",
+ "mime",
  "ratatui",
  "rstest",
  "serde",
@@ -2514,6 +2516,7 @@ dependencies = [
  "futures",
  "indexmap",
  "itertools",
+ "mime",
  "notify",
  "persisted",
  "pretty_assertions",

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -14,8 +14,10 @@ version = "2.4.0"
 anyhow = {workspace = true}
 crossterm = {workspace = true}
 derive_more = {workspace = true, features = ["display"]}
+glob = "0.3.2"
 indexmap = {workspace = true}
 itertools = {workspace = true}
+mime = {workspace = true}
 ratatui = {workspace = true, features = ["serde"]}
 serde = {workspace = true}
 slumber_core = {workspace = true}

--- a/crates/config/src/mime.rs
+++ b/crates/config/src/mime.rs
@@ -1,0 +1,182 @@
+use glob::{Pattern, PatternError};
+use indexmap::{indexmap, IndexMap};
+use mime::Mime;
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+/// A map of content type patterns to values. Use this when you need to select a
+/// value based on the `Content-Type` header of a request/response. The patterns
+/// use [glob] for matching, so technically it's trying to match a Unix
+/// path-like string, but that happens to look the same as a MIME type.
+#[derive(Debug, Serialize)]
+#[cfg_attr(test, derive(PartialEq))]
+#[serde(transparent)]
+pub struct MimeMap<V> {
+    /// We take the first matching pattern, so order matters. The most general
+    /// patterns should go last. This could be a vec of tuples since we never
+    /// actually do keyed lookup, but that makes ser/de more complicated.
+    patterns: IndexMap<MimePattern, V>,
+}
+
+impl<V> MimeMap<V> {
+    /// Get the value of the **first** pattern in the map that matches the given
+    /// string. Matching is only performed on the "essence" of the given mime
+    /// type, i.e. the `type/subtype`. This means extensions of the type are
+    /// ignored. It's very unlikely the user would want a different value based
+    /// on extensions.
+    pub fn get(&self, mime: &Mime) -> Option<&V> {
+        self.patterns
+            .iter()
+            .find(|(pattern, _)| pattern.matches(mime.essence_str()))
+            .map(|(_, value)| value)
+    }
+}
+
+// Derive includes an unwanted type bound
+impl<V> Default for MimeMap<V> {
+    fn default() -> Self {
+        Self {
+            patterns: Default::default(),
+        }
+    }
+}
+
+impl<'de, V: Deserialize<'de>> Deserialize<'de> for MimeMap<V> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Deserialize a single value as a map of {"*/*": value}
+
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum MimeMapDeserialize<V> {
+            One(V),
+            Map(IndexMap<MimePattern, V>),
+        }
+
+        let wrapper = MimeMapDeserialize::deserialize(deserializer)?;
+        let patterns = match wrapper {
+            MimeMapDeserialize::One(v) => indexmap! {
+                MimePattern::default() => v
+            },
+            MimeMapDeserialize::Map(map) => map,
+        };
+        Ok(Self { patterns })
+    }
+}
+
+/// Newtype for [glob::Pattern] so we can define ser/de for it
+#[derive(
+    Clone,
+    Debug,
+    derive_more::Display,
+    derive_more::Deref,
+    Serialize,
+    Deserialize,
+    Eq,
+    Hash,
+    PartialEq,
+)]
+#[serde(try_from = "String", into = "String")]
+struct MimePattern(Pattern);
+
+impl Default for MimePattern {
+    fn default() -> Self {
+        Self(Pattern::from_str("*/*").unwrap())
+    }
+}
+
+impl From<MimePattern> for String {
+    fn from(value: MimePattern) -> Self {
+        value.to_string()
+    }
+}
+
+impl FromStr for MimePattern {
+    type Err = PatternError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Check some known aliases
+        let dealiased = match s {
+            "default" => "*/*",
+            "image" => "image/*",
+            // Make sure to capture JSON extensions too
+            "json" => "application/*json",
+            other => other,
+        };
+        Ok(Self(dealiased.parse()?))
+    }
+}
+
+impl TryFrom<String> for MimePattern {
+    type Error = PatternError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+    use serde_test::{assert_de_tokens, Token};
+
+    fn map(entries: &[(&str, &str)]) -> MimeMap<String> {
+        MimeMap {
+            patterns: entries
+                .iter()
+                .map(|(k, v)| {
+                    (k.parse::<MimePattern>().unwrap(), (*v).to_owned())
+                })
+                .collect(),
+        }
+    }
+
+    #[rstest]
+    #[case::string(&[Token::Str("test")], map(&[("*/*", "test")]))]
+    #[case::empty_map(&[Token::Map { len: None }, Token::MapEnd], map(&[]))]
+    #[case::aliases(&[
+            Token::Map { len: Some(2) },
+            Token::Str("json"),
+            Token::Str("json-value"),
+            Token::Str("image"),
+            Token::Str("image-value"),
+            Token::Str("default"),
+            Token::Str("default-value"),
+            Token::MapEnd,
+        ],
+        map(&[
+            ("application/*json", "json-value"),
+            ("image/*","image-value"),
+            ("*/*", "default-value"),
+        ]),
+    )]
+    fn test_deserialize(
+        #[case] tokens: &[Token],
+        #[case] expected: MimeMap<String>,
+    ) {
+        assert_de_tokens(&expected, tokens);
+    }
+
+    #[rstest]
+    #[case::wildcard("text/plain", "text")]
+    #[case::default("image/png", "default")]
+    #[case::priority("audio/ogg", "default")]
+    #[case::json_plain("application/json", "json")]
+    #[case::json_extension("application/ld+json", "json")]
+    #[case::essence("text/csv; charset=utf-8", "csv")]
+    fn test_match_mimes(#[case] mime: Mime, #[case] expected: String) {
+        let map = map(&[
+            ("text/csv", "csv"),
+            ("text/*", "text"),
+            ("json", "json"),
+            ("*/*", "default"),
+            // This should never get hit because it's after the default case
+            ("audio/*", "audio"),
+        ]);
+        let actual = map.get(&mime).unwrap();
+        assert_eq!(actual, &expected);
+    }
+}

--- a/crates/core/src/http.rs
+++ b/crates/core/src/http.rs
@@ -475,7 +475,7 @@ impl Recipe {
         // Set Content-Type based on the body type. This can be overwritten
         // below if the user explicitly passed a Content-Type value
         if let Some(content_type) =
-            self.body.as_ref().and_then(|body| body.mime())
+            self.body.as_ref().and_then(|body| body.explicit_mime())
         {
             headers.insert(
                 header::CONTENT_TYPE,
@@ -658,8 +658,10 @@ impl Authentication<String> {
 
 impl RecipeBody {
     /// Get the value that we should set for the `Content-Type` header,
-    /// according to the body
-    fn mime(&self) -> Option<Mime> {
+    /// according to the body. This will only return `Some` for JSON, as the
+    /// form content types will have this header set automatically by reqwest
+    /// via the builder methods we use.
+    fn explicit_mime(&self) -> Option<Mime> {
         match self {
             RecipeBody::Raw { content_type, .. } => {
                 content_type.as_ref().map(ContentType::to_mime)

--- a/crates/core/src/http/models.rs
+++ b/crates/core/src/http/models.rs
@@ -283,6 +283,11 @@ impl RequestRecord {
         }
     }
 
+    /// Get the value of the request's `Content-Type` header, if any
+    pub fn mime(&self) -> Option<Mime> {
+        content_type_header(&self.headers)
+    }
+
     /// Generate a cURL command equivalent to this request
     ///
     /// This only fails if one of the headers or body is binary and can't be
@@ -471,8 +476,13 @@ pub struct ResponseRecord {
 }
 
 impl ResponseRecord {
-    /// Get the content type of the response body, according to the
-    /// `Content-Type` header
+    /// Get the value of the response's `Content-Type` header, if any
+    pub fn mime(&self) -> Option<Mime> {
+        content_type_header(&self.headers)
+    }
+
+    /// Get the value of the response's `Content-Type` header, and parse it as
+    /// a known/supported content type
     pub fn content_type(&self) -> Option<ContentType> {
         ContentType::from_headers(&self.headers).ok()
     }
@@ -505,6 +515,14 @@ impl ResponseRecord {
                 Some(format!("data.{}", mime.subtype()))
             })
     }
+}
+
+/// Get the value of the `Content-Type` header, parsed as a MIME. `None` if the
+/// header isn't present or isn't a valid MIME type
+fn content_type_header(headers: &HeaderMap) -> Option<Mime> {
+    headers
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok()?.parse().ok())
 }
 
 /// HTTP response body. Content is stored as bytes because it may not

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -21,6 +21,7 @@ editor-command = "1.0.0"
 futures = {workspace = true}
 indexmap = {workspace = true}
 itertools = {workspace = true}
+mime = {workspace = true}
 notify = {version = "6.1.1", default-features = false, features = ["macos_fsevent"]}
 persisted = {version = "0.3.1", features = ["serde"]}
 ratatui = {workspace = true, features = ["crossterm", "underline-color", "unstable-widget-ref"]}

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -277,8 +277,8 @@ impl Tui {
                 // The callback may queue an event to read the file, so we can't
                 // delete it yet. Caller is responsible for cleaning up
             }
-            Message::FileView { path } => {
-                let command = get_pager_command(&path)?;
+            Message::FileView { path, mime } => {
+                let command = get_pager_command(&path, mime.as_ref())?;
                 self.run_command(command)?;
                 // We don't need to read the contents back so we can clean up
                 delete_temp_file(&path);

--- a/crates/tui/src/message.rs
+++ b/crates/tui/src/message.rs
@@ -4,6 +4,7 @@
 use crate::view::Confirm;
 use anyhow::Context;
 use derive_more::From;
+use mime::Mime;
 use slumber_config::Action;
 use slumber_core::{
     collection::{Collection, ProfileId, RecipeId},
@@ -90,7 +91,11 @@ pub enum Message {
         on_complete: Callback<PathBuf>,
     },
     /// Open a file to be viewed in the user's external pager
-    FileView { path: PathBuf },
+    FileView {
+        path: PathBuf,
+        /// MIME type of the file being viewed
+        mime: Option<Mime>,
+    },
 
     /// Launch an HTTP request from the given recipe/profile.
     HttpBeginRequest(RequestConfig),

--- a/crates/tui/src/view/component/primary.rs
+++ b/crates/tui/src/view/component/primary.rs
@@ -296,7 +296,9 @@ impl PrimaryView {
                 ViewContext::send_message(Message::CopyRequestBody(config))
             }
             RecipeMenuAction::ViewBody => {
-                self.recipe_pane.data().with_body_text(view_text)
+                let recipe_pane = self.recipe_pane.data();
+                recipe_pane
+                    .with_body_text(|text| view_text(text, recipe_pane.mime()))
             }
         }
     }

--- a/crates/tui/src/view/component/recipe_pane/body.rs
+++ b/crates/tui/src/view/component/recipe_pane/body.rs
@@ -325,7 +325,10 @@ mod tests {
         component.send_key(KeyCode::Char('e')).assert_empty();
         let (path, on_complete) = assert_matches!(
             harness.pop_message_now(),
-            Message::FileEdit { path, on_complete } => (path, on_complete),
+            Message::FileEdit {
+                path,
+                on_complete,
+            } => (path, on_complete),
         );
         assert_eq!(fs::read(&path).unwrap(), b"hello!");
 

--- a/crates/tui/src/view/component/recipe_pane/recipe.rs
+++ b/crates/tui/src/view/component/recipe_pane/recipe.rs
@@ -24,6 +24,7 @@ use ratatui::{
     widgets::Paragraph,
     Frame,
 };
+use reqwest::header::HeaderName;
 use serde::{Deserialize, Serialize};
 use slumber_config::Action;
 use slumber_core::{
@@ -137,6 +138,17 @@ impl RecipeDisplay {
             form_fields,
             body,
         }
+    }
+
+    /// Get the *preview* value of an HTTP header. This only includes headers
+    /// that are visible in the table, so no implied headers such as
+    /// `Authorization`
+    pub fn header(&self, name: HeaderName) -> Option<String> {
+        self.headers
+            .data()
+            .rows()
+            .find(|(k, _)| *k == name)
+            .map(|(_, value)| value.preview().text().to_string())
     }
 
     /// Does the recipe have a body defined?

--- a/crates/tui/src/view/component/recipe_pane/table.rs
+++ b/crates/tui/src/view/component/recipe_pane/table.rs
@@ -93,6 +93,13 @@ where
         }
     }
 
+    pub fn rows(&self) -> impl Iterator<Item = (&str, &RecipeTemplate)> {
+        self.select
+            .data()
+            .items()
+            .map(|row| (row.key.as_str(), &row.value))
+    }
+
     /// Get the set of disabled/overridden rows for this table
     pub fn to_build_overrides(&self) -> BuildFieldOverrides {
         self.select

--- a/crates/tui/src/view/component/request_view.rs
+++ b/crates/tui/src/view/component/request_view.rs
@@ -103,7 +103,7 @@ impl EventHandler for RequestView {
                 }
                 MenuAction::ViewBody => {
                     if let Some(body) = &self.body {
-                        view_text(body);
+                        view_text(body, self.request.mime());
                     }
                 }
             })

--- a/crates/tui/src/view/component/response_view.rs
+++ b/crates/tui/src/view/component/response_view.rs
@@ -92,7 +92,10 @@ impl EventHandler for ResponseBodyView {
                     ViewContext::send_message(Message::CollectionEdit)
                 }
                 BodyMenuAction::ViewBody => {
-                    view_text(self.body.data().visible_text());
+                    view_text(
+                        self.body.data().visible_text(),
+                        self.response.mime(),
+                    );
                 }
                 BodyMenuAction::CopyBody => {
                     // Use whatever text is visible to the user. This differs

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -40,6 +40,7 @@
   - [Content Type](./api/request_collection/content_type.md)
 - [Configuration](./api/configuration/index.md)
   - [Input Bindings](./api/configuration/input_bindings.md)
+  - [MIME Maps](./api/configuration/mime.md)
   - [Theme](./api/configuration/theme.md)
 
 # Troubleshooting

--- a/docs/src/api/configuration/index.md
+++ b/docs/src/api/configuration/index.md
@@ -64,7 +64,7 @@ Enable developer information in the TUI
 
 **Default:** `VISUAL`/`EDITOR` env vars, or `vim`
 
-Command to use when opening files for in-app editing. [More info](../../user_guide/tui/editor.md)
+Command to use when opening files for in-app editing. [More info](../../user_guide/tui/editor.md#editing)
 
 ### `ignore_certificate_hosts`
 
@@ -110,8 +110,8 @@ Visual customizations for the TUI. [More info](./theme.md)
 
 **Alias:** `viewer` (for historical compatibility)
 
-**Type:** `string`
+**Type:** `string` or `mapping[Mime, string]` (see [MIME Maps](./mime.md))
 
 **Default:** `less` (Unix), `more` (Windows)
 
-Command to use when opening files for viewing. [More info](../../user_guide/tui/editor.md)
+Command to use when opening files for viewing. [More info](../../user_guide/tui/editor.md#paging)

--- a/docs/src/api/configuration/mime.md
+++ b/docs/src/api/configuration/mime.md
@@ -1,0 +1,35 @@
+# MIME Maps
+
+Some configuration fields support a mapping of [MIME types](https://en.wikipedia.org/wiki/Media_type) (AKA media types or content types). This allow you to set multiple values for the configuration field, and the correct value will be selected based on the MIME type of the relevant recipe/request/response.
+
+The keys of this map are glob-formatted (i.e. wildcard) MIME types. For example, if you're configuring your pager and you want to use `hexdump` for all images, `fx` for JSON, and `less` for everything else:
+
+```yaml
+pager:
+  image/*: hexdump
+  application/json: fx
+  "*/*": less
+```
+
+> **Note:** Paths are matched top to bottom, so `*/*` **should always go last**. Any pattern starting with `*` must be wrapped in quotes in order to be parsed as a string.
+
+- `image/png`: matches `image/*`
+- `image/jpeg`: matches `image/*`
+- `application/json`: matches `application/json`
+- `text/csv`: matches `*/*`
+
+## Aliases
+
+In addition to accepting MIME patterns, there are also predefined aliases to make common matches more convenient:
+
+| Alias     | Maps To             |
+| --------- | ------------------- |
+| `default` | `*/*`               |
+| `json`    | `application/*json` |
+| `image`   | `image/*`           |
+
+## Notes on Matching
+
+- Matching is done top to bottom, and **the first matching pattern will be used**. For this reason, your `*/*` pattern **should always be last**.
+- Matching is performed just against the [essence string](https://docs.rs/mime/latest/mime/struct.Mime.html#method.essence_str) of the recipe/request/response's `Content-Type` header, i.e. the `type/subtype` only. In the example `multipart/form-data; boundary=ABCDEFG`, the semicolon and everything after it **is not included in the match**.
+- Matching is performed by the [Rust glob crate](https://docs.rs/glob/latest/glob/struct.Pattern.html). Despite being intended for matching file paths, it works well for MIME types too because they are also `/`-delimited

--- a/docs/src/user_guide/tui/editor.md
+++ b/docs/src/user_guide/tui/editor.md
@@ -44,3 +44,15 @@ Some popular pagers:
 - [bat](https://github.com/sharkdp/bat)
 - [fx](https://fx.wtf/)
 - [jless](https://github.com/PaulJuliusMartinez/jless)
+
+### Setting a content-specific pager
+
+If you want to use a different pager for certain content types, such as using `jless` for JSON, you can pass a map of MIME type patterns to commands. For example:
+
+```yaml
+pager:
+  json: jless
+  default: less
+```
+
+For more details on matching, see [MIME Maps](../../api/configuration/mime.md).

--- a/slumber.yml
+++ b/slumber.yml
@@ -134,7 +134,7 @@ requests:
     name: Big File
     method: POST
     url: "{{host}}/anything"
-    body: !json { data: "{{chains.big_file}}" }
+    body: "{{chains.big_file}}"
 
   delay: !request
     <<: *base


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Support per-content-type pager commands. The `pager` config field now accepts a mapping of MIME type pattern to command. The original single-string format is still accepted as well.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Some of the UI logic to plumb the content type around is a bit grungy, but I think it's simple enough that it's unlikely there's a bug.

## QA

_How did you test this?_

Added unit tests, manual testing.

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
