### PR TITLE
Don't show notification on initial collection load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Update [editor-command](https://crates.io/crates/editor-command), which replaces [shellish_parse](https://crates.io/crates/shellish_parse) with [shell-words](https://crates.io/crates/shell-words) for editor and pager command parsing
   - There should be no impact to users
+- Don't show "Loaded collection from ..." notification on initial load
 
 ## [2.4.0] - 2024-12-27
 

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -426,6 +426,10 @@ impl Tui {
         let messages_tx = self.messages_tx();
         let collection_file = &self.collection_file;
         self.view = View::new(collection_file, database, messages_tx);
+        self.view.notify(format!(
+            "Reloaded collection from {}",
+            collection_file.path().to_string_lossy()
+        ));
     }
 
     /// GOODBYE

--- a/crates/tui/src/view.rs
+++ b/crates/tui/src/view.rs
@@ -75,15 +75,10 @@ impl View {
             None
         };
 
-        let mut view = Self {
+        Self {
             root: Root::new(&collection_file.collection).into(),
             debug_monitor,
-        };
-        view.notify(format!(
-            "Loaded collection from {}",
-            collection_file.path().to_string_lossy()
-        ));
-        view
+        }
     }
 
     /// Draw the view to screen. This needs access to the input engine in order
@@ -222,7 +217,6 @@ mod tests {
         assert_events!(
             Event::Emitted { .. }, // Recipe list selection
             Event::Emitted { .. }, // Primary pane selection
-            Event::Notify(_),
         );
 
         // Events should *still* be in the queue, because we haven't drawn yet
@@ -230,19 +224,11 @@ mod tests {
         view.handle_events(UpdateContext {
             request_store: &mut request_store,
         });
-        assert_events!(
-            Event::Emitted { .. },
-            Event::Emitted { .. },
-            Event::Notify(_),
-        );
+        assert_events!(Event::Emitted { .. }, Event::Emitted { .. },);
 
         // Nothing new
         terminal.draw(|frame| view.draw(frame, &request_store));
-        assert_events!(
-            Event::Emitted { .. },
-            Event::Emitted { .. },
-            Event::Notify(_),
-        );
+        assert_events!(Event::Emitted { .. }, Event::Emitted { .. },);
 
         // *Now* the queue is drained
         view.handle_events(UpdateContext {


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Only shown for reloads. It doesn't really make sense to always start the app with the same message. Also it makes the gifs uglier.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

You don't get immediate notification of what file was loaded. The user can grab the path from the help modal if they're really not sure. 

## QA

_How did you test this?_

Manually

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
