### PR TITLE
Redraw after local tasks complete

### DIFF
--- a/crates/tui/src/message.rs
+++ b/crates/tui/src/message.rs
@@ -154,10 +154,10 @@ pub enum Message {
         #[debug(skip)]
         on_complete: Callback<Vec<TemplateChunk>>,
     },
-    /// An empty event to trigger a draw when a template preview is done being
-    /// rendered. This is a bit hacky, but it's an explicit way to tell the TUI
-    /// "we know something in the view has changed asynchronously".
-    TemplatePreviewComplete,
+
+    /// Trigger a redraw. This should be called whenever we have reason to
+    /// believe the UI may have changed due to a background task
+    Tick,
 }
 
 /// A static callback included in a message

--- a/crates/tui/src/view/common/text_box.rs
+++ b/crates/tui/src/view/common/text_box.rs
@@ -177,10 +177,10 @@ impl TextBox {
     /// Emit a change event. Should be called whenever text _content_ is changed
     fn change(&mut self) {
         let is_valid = self.is_valid();
-        if let Some(debounce) = &self.on_change_debounce {
+        let emitter = self.handle();
+        if let Some(debounce) = &mut self.on_change_debounce {
             if is_valid {
                 // Defer the change event until after the debounce period
-                let emitter = self.handle();
                 debounce.start(move || emitter.emit(TextBoxEvent::Change));
             } else {
                 debounce.cancel();
@@ -201,7 +201,7 @@ impl TextBox {
     /// Cancel any pending debounce. Should be called on submit or cancel, when
     /// the user is no longer making changes
     fn cancel_debounce(&mut self) {
-        if let Some(debounce) = &self.on_change_debounce {
+        if let Some(debounce) = &mut self.on_change_debounce {
             debounce.cancel();
         }
     }

--- a/crates/tui/src/view/component/queryable_body.rs
+++ b/crates/tui/src/view/component/queryable_body.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     context::TuiContext,
-    util::run_command,
+    util::{run_command, spawn_local},
     view::{
         common::{
             text_box::{TextBox, TextBoxEvent, TextBoxProps},
@@ -30,7 +30,7 @@ use slumber_core::{
     util::MaybeStr,
 };
 use std::{borrow::Cow, mem, sync::Arc};
-use tokio::task::{self, AbortHandle};
+use tokio::task::AbortHandle;
 
 /// Display response body as text, with a query box to run commands on the body.
 /// The query state can be persisted by persisting this entire container.
@@ -206,7 +206,7 @@ impl QueryableBody {
         body: Bytes,
         on_complete: impl 'static + FnOnce(String, anyhow::Result<Vec<u8>>),
     ) -> AbortHandle {
-        task::spawn_local(async move {
+        spawn_local(async move {
             let shell = &TuiContext::get().config.commands.shell;
             let result = run_command(shell, &command, Some(&body))
                 .await

--- a/crates/tui/src/view/component/response_view.rs
+++ b/crates/tui/src/view/component/response_view.rs
@@ -302,6 +302,8 @@ mod tests {
                 // component
             })
             .await;
+            // Background task sends a message to redraw
+            assert_matches!(harness.pop_message_now(), Message::Tick);
             component.drain_draw().assert_empty();
         }
 

--- a/crates/tui/src/view/context.rs
+++ b/crates/tui/src/view/context.rs
@@ -119,7 +119,7 @@ impl ViewContext {
 
     /// Queue a view event to be handled by the component tree
     pub fn push_event(event: Event) {
-        Self::with_mut(|context| context.event_queue.push(event))
+        Self::with_mut(|context| context.event_queue.push(event));
     }
 
     /// Pop an event off the event queue


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

This eliminates the 250ms delay between a local task completing and the next redraw. Redraws are only triggered by messages in the queue (and not events), so we can send an empty message to trigger a redraw.

I think it'd be a good idea to make _all_ tasks run on the main thread, since we're heavily I/O bound anyway. Should cut down on wasted effort, and eliminate the `Send` bound on everything.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Changes to the core of the event loop are always risky. Mitigated with a whole bunch of existing tests.

## QA

_How did you test this?_

Hit buttons and shit

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
