### PR TITLE
Add Neovim Integration to docs

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -41,6 +41,10 @@
   - [Input Bindings](./api/configuration/input_bindings.md)
   - [Theme](./api/configuration/theme.md)
 
+# Integration
+
+- [Neovim Integration](./integration/neovim-integration.md)
+
 # Troubleshooting
 
 - [Logs](./troubleshooting/logs.md)

--- a/docs/src/api/configuration/input_bindings.md
+++ b/docs/src/api/configuration/input_bindings.md
@@ -13,7 +13,7 @@ input_bindings:
   right: [l]
   scroll_left: [shift h]
   scroll_right: [shift l]
-  select_recipe_list: [p] # Rebind from `l`
+  select_recipe_list: [e] # Rebind from `l`
 ```
 
 Each action maps to a _list_ of key combinations, because you can map multiple combinations to a single action. Hitting any of these combinations will trigger the action. By defining a binding in the config, **you will replace the default binding for that action**. If you want to retain the default binding but add an additional, you will need to include the default in your list of custom bindings. For example, if you want vim bindings but also want to leave the existing arrow key controls in place:
@@ -26,7 +26,7 @@ input_bindings:
   right: [right, l]
   scroll_left: [shift left, shift h]
   scroll_right: [shift right, shift l]
-  select_recipe_list: [p] # Rebind from `l`
+  select_recipe_list: [e] # Rebind from `l`
 ```
 
 ## Actions

--- a/docs/src/api/configuration/input_bindings.md
+++ b/docs/src/api/configuration/input_bindings.md
@@ -13,7 +13,7 @@ input_bindings:
   right: [l]
   scroll_left: [shift h]
   scroll_right: [shift l]
-  select_recipe_list: [e] # Rebind from `l`
+  select_recipe_list: [w] # Rebind from `l`
 ```
 
 Each action maps to a _list_ of key combinations, because you can map multiple combinations to a single action. Hitting any of these combinations will trigger the action. By defining a binding in the config, **you will replace the default binding for that action**. If you want to retain the default binding but add an additional, you will need to include the default in your list of custom bindings. For example, if you want vim bindings but also want to leave the existing arrow key controls in place:
@@ -26,7 +26,7 @@ input_bindings:
   right: [right, l]
   scroll_left: [shift left, shift h]
   scroll_right: [shift right, shift l]
-  select_recipe_list: [e] # Rebind from `l`
+  select_recipe_list: [w] # Rebind from `l`
 ```
 
 ## Actions

--- a/docs/src/integration/neovim-integration.md
+++ b/docs/src/integration/neovim-integration.md
@@ -1,0 +1,35 @@
+# Neovim Integration 
+
+Slumber can be integrated into Neovim to allow you quickly switch between your codebase and slumber.
+
+Ensure you have `which-key` and `toggleterm` installed. Most premade distros (LunarVim, etc) will have these installed by default. 
+
+Add this snippet to your Neovim config:
+```lua
+local Slumber = {}
+Slumber.toggle = function()
+    local Terminal = require("toggleterm.terminal").Terminal
+    local slumber = Terminal:new {
+        cmd = "slumber",
+        hidden = true,
+        direction = "float",
+        float_opts = {
+            border = "none",
+            width = 100000,
+            height = 100000,
+        },
+        on_open = function(_)
+            vim.cmd "startinsert!"
+        end,
+        on_close = function(_) end,
+        count = 99,
+    }
+    slumber:toggle()
+end
+
+local wk = require("which-key")
+wk.add({
+    -- Map space V S to open slumber 
+    { "<leader>vs", Slumber.toggle, desc = "Open in Slumber"}
+})
+```

--- a/docs/src/integration/neovim-integration.md
+++ b/docs/src/integration/neovim-integration.md
@@ -1,6 +1,6 @@
 # Neovim Integration 
 
-Slumber can be integrated into Neovim to allow you quickly switch between your codebase and slumber.
+Slumber can be integrated into Neovim to allow you quickly switch between your codebase and Slumber.
 
 Ensure you have `which-key` and `toggleterm` installed. Most premade distros (LunarVim, etc) will have these installed by default. 
 


### PR DESCRIPTION
## Description

A lot of people who use Neovim integrate other TUI applications into their Neovim. For example I use [lazygit.nvim](https://github.com/kdheepak/lazygit.nvim?tab=readme-ov-file).

I had to write this little Neovim snippet to get slumber to work and I assume many more people would be interested in it (the overlap of Neovim users and TUI users is huge).

Also change P to W on the input binding page. P is the default for profiles and binding P makes Profiles and Recipe List use P.

## Known Risks

None

## QA

Just docs change

## Checklist

- [ X] Have you read `CONTRIBUTING.md` already?
- [ X] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ X] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
