### PR TITLE
Build action menus dynamically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Add `--output` flag to `slumber request` to control where the response body is written to
 - Support MIME type mapping for `pager` config field, so you can set different pagers based on media type. [See docs](https://slumber.lucaspickering.me/book/api/configuration/mime.html)
 
+### Fixed
+
+- Fix certain recipe-related menu actions being enabled when they shouldn't be
+
 ## [2.5.0] - 2025-01-06
 
 ### Added

--- a/crates/tui/src/view.rs
+++ b/crates/tui/src/view.rs
@@ -21,6 +21,7 @@ use crate::{
     message::{Message, MessageSender},
     util::ResultReported,
     view::{
+        common::modal::Modal,
         component::{Component, Root},
         debug::DebugMonitor,
         event::Event,
@@ -123,7 +124,7 @@ impl View {
     /// Queue an event to open a new modal. The input can be anything that
     /// converts to modal content
     pub fn open_modal(&mut self, modal: impl IntoModal + 'static) {
-        ViewContext::open_modal(modal.into_modal());
+        modal.into_modal().open();
     }
 
     /// Queue an event to send an informational notification to the user

--- a/crates/tui/src/view/common/actions.rs
+++ b/crates/tui/src/view/common/actions.rs
@@ -2,37 +2,44 @@ use crate::view::{
     common::{list::List, modal::Modal},
     component::Component,
     context::UpdateContext,
-    draw::{Draw, DrawMetadata, Generate},
-    event::{Child, Emitter, EmitterId, Event, EventHandler, OptionEvent},
-    state::{
-        fixed_select::{FixedSelect, FixedSelectState},
-        select::{SelectStateEvent, SelectStateEventType},
+    draw::{Draw, DrawMetadata, ToStringGenerate},
+    event::{
+        Child, Emitter, Event, EventHandler, LocalEvent, OptionEvent, ToEmitter,
     },
+    state::select::{SelectState, SelectStateEvent, SelectStateEventType},
 };
-use ratatui::{
-    layout::Constraint,
-    text::{Line, Span},
-    widgets::ListState,
-    Frame,
-};
+use itertools::Itertools;
+use ratatui::{layout::Constraint, text::Line, Frame};
+use std::fmt::Display;
+use strum::IntoEnumIterator;
 
-/// Modal to list and trigger arbitrary actions. The list of available actions
-/// is defined by the generic parameter
+/// Modal to list and trigger arbitrary actions. The user opens the action menu
+/// with a keybinding, at which point the list of available actions is built
+/// dynamically via [EventHandler::menu_actions]. When an action is selected,
+/// the modal is closed and that action will be emitted as a dynamic event, to
+/// be handled by the component that originally supplied it. Each component that
+/// provides actions should store an [Emitter] specifically for its actions,
+/// which will be provided to each supplied action and can be used to check and
+/// consume the action events.
 #[derive(Debug)]
-pub struct ActionsModal<T: FixedSelect> {
-    emitter_id: EmitterId,
+pub struct ActionsModal {
     /// Join the list of global actions into the given one
-    actions: Component<FixedSelectState<T, ListState>>,
+    actions: Component<SelectState<MenuAction>>,
 }
 
-impl<T: FixedSelect> ActionsModal<T> {
+impl ActionsModal {
     /// Create a new actions modal, optional disabling certain actions based on
     /// some external condition(s).
-    pub fn new(disabled_actions: &[T]) -> Self {
+    pub fn new(actions: Vec<MenuAction>) -> Self {
+        let disabled_indexes = actions
+            .iter()
+            .enumerate()
+            .filter(|(_, action)| !action.enabled)
+            .map(|(i, _)| i)
+            .collect_vec();
         Self {
-            emitter_id: EmitterId::new(),
-            actions: FixedSelectState::builder()
-                .disabled_items(disabled_actions)
+            actions: SelectState::builder(actions)
+                .disabled_indexes(disabled_indexes)
                 .subscribe([SelectStateEventType::Submit])
                 .build()
                 .into(),
@@ -40,39 +47,38 @@ impl<T: FixedSelect> ActionsModal<T> {
     }
 }
 
-impl<T: FixedSelect> Default for ActionsModal<T> {
-    fn default() -> Self {
-        Self::new(&[])
-    }
-}
-
-impl<T> Modal for ActionsModal<T>
-where
-    T: FixedSelect,
-    ActionsModal<T>: Draw,
-{
+impl Modal for ActionsModal {
     fn title(&self) -> Line<'_> {
         "Actions".into()
     }
 
     fn dimensions(&self) -> (Constraint, Constraint) {
-        (Constraint::Length(30), Constraint::Length(T::COUNT as u16))
+        (
+            Constraint::Length(30),
+            Constraint::Length(self.actions.data().len() as u16),
+        )
+    }
+
+    fn on_close(self: Box<Self>, submitted: bool) {
+        if submitted {
+            let action = self
+                .actions
+                .into_data()
+                .into_selected()
+                .expect("User submitted something");
+            // Emit an event on behalf of the component that supplied this
+            // action. The component will use its own supplied emitter ID to
+            // consume the event
+            action.emitter.emit(action.value);
+        }
     }
 }
 
-impl<T> EventHandler for ActionsModal<T>
-where
-    T: FixedSelect,
-    ActionsModal<T>: Draw,
-{
+impl EventHandler for ActionsModal {
     fn update(&mut self, _: &mut UpdateContext, event: Event) -> Option<Event> {
-        event.opt().emitted(self.actions.handle(), |event| {
-            if let SelectStateEvent::Submit(index) = event {
-                // Close modal first so the parent can consume the emitted
-                // event
+        event.opt().emitted(self.actions.to_emitter(), |event| {
+            if let SelectStateEvent::Submit(_) = event {
                 self.close(true);
-                let action = self.actions.data()[index];
-                self.emit(action);
             }
         })
     }
@@ -82,11 +88,7 @@ where
     }
 }
 
-impl<T> Draw for ActionsModal<T>
-where
-    T: 'static + FixedSelect,
-    for<'a> &'a T: Generate<Output<'a> = Span<'a>>,
-{
+impl Draw for ActionsModal {
     fn draw(&self, frame: &mut Frame, _: (), metadata: DrawMetadata) {
         self.actions.draw(
             frame,
@@ -97,11 +99,44 @@ where
     }
 }
 
-impl<T: FixedSelect> Emitter for ActionsModal<T> {
-    /// Emit the action itself
-    type Emitted = T;
+/// One item in an action menu modal. The action menu is built dynamically, and
+/// each action is tied back to the component that supplied it via an [Emitter].
+#[derive(Debug, derive_more::Display)]
+#[display("{name}")]
+pub struct MenuAction {
+    name: String,
+    value: Box<dyn LocalEvent>,
+    /// Because actions are sourced from multiple components, we use a
+    /// type-erased emitter here. When the action is selected, we'll emit it on
+    /// behalf of the supplier, who will then downcast and consume it in its
+    /// update() handler.
+    emitter: Emitter<dyn LocalEvent>,
+    enabled: bool,
+}
 
-    fn id(&self) -> EmitterId {
-        self.emitter_id
+impl ToStringGenerate for MenuAction {}
+
+/// Trait for an enum that can be converted into a list of actions. Most
+/// components have a static list of actions available, so this trait makes it
+/// easy to implement [EventHandler::menu_actions].
+pub trait IntoMenuActions<Data>:
+    Display + IntoEnumIterator + LocalEvent
+{
+    /// Create a list of actions, one per variant in this enum
+    fn into_actions(data: &Data) -> Vec<MenuAction>
+    where
+        Data: ToEmitter<Self>,
+    {
+        Self::iter()
+            .map(|action| MenuAction {
+                name: action.to_string(),
+                enabled: action.enabled(data),
+                emitter: data.to_emitter().upcast(),
+                value: Box::new(action),
+            })
+            .collect()
     }
+
+    /// Should this action be enabled in the menu?
+    fn enabled(&self, data: &Data) -> bool;
 }

--- a/crates/tui/src/view/common/button.rs
+++ b/crates/tui/src/view/common/button.rs
@@ -5,7 +5,7 @@ use crate::{
     view::{
         context::UpdateContext,
         draw::{Draw, DrawMetadata, Generate},
-        event::{Emitter, EmitterId, Event, EventHandler, OptionEvent},
+        event::{Emitter, Event, EventHandler, OptionEvent, ToEmitter},
         state::fixed_select::{FixedSelect, FixedSelectState},
     },
 };
@@ -50,7 +50,9 @@ impl<'a> Generate for Button<'a> {
 /// type `T`.
 #[derive(Debug, Default)]
 pub struct ButtonGroup<T: FixedSelect> {
-    emitter_id: EmitterId,
+    /// The only type of event we can emit is a button being selected, so just
+    /// emit the button type
+    emitter: Emitter<T>,
     select: FixedSelectState<T>,
 }
 
@@ -61,7 +63,7 @@ impl<T: FixedSelect> EventHandler for ButtonGroup<T> {
             Action::Right => self.select.next(),
             Action::Submit => {
                 // Propagate the selected item as a dynamic event
-                self.emit(self.select.selected());
+                self.emitter.emit(self.select.selected());
             }
             _ => propagate.set(),
         })
@@ -99,12 +101,8 @@ impl<T: FixedSelect> Draw for ButtonGroup<T> {
     }
 }
 
-/// The only type of event we can emit is a button being selected, so just
-/// emit the button type
-impl<T: FixedSelect> Emitter for ButtonGroup<T> {
-    type Emitted = T;
-
-    fn id(&self) -> EmitterId {
-        self.emitter_id
+impl<T: FixedSelect> ToEmitter<T> for ButtonGroup<T> {
+    fn to_emitter(&self) -> Emitter<T> {
+        self.emitter
     }
 }

--- a/crates/tui/src/view/component/exchange_pane.rs
+++ b/crates/tui/src/view/component/exchange_pane.rs
@@ -10,7 +10,7 @@ use crate::{
         },
         context::UpdateContext,
         draw::{Draw, DrawMetadata, Generate},
-        event::{Child, Emitter, EmitterId, Event, EventHandler, OptionEvent},
+        event::{Child, Emitter, Event, EventHandler, OptionEvent, ToEmitter},
         util::persistence::PersistedLazy,
         RequestState,
     },
@@ -36,7 +36,7 @@ use strum::{EnumCount, EnumIter};
 /// new request is selected.
 #[derive(Debug)]
 pub struct ExchangePane {
-    emitter_id: EmitterId,
+    emitter: Emitter<ExchangePaneEvent>,
     tabs: Component<PersistedLazy<SingletonKey<Tab>, Tabs<Tab>>>,
     state: State,
 }
@@ -47,7 +47,7 @@ impl ExchangePane {
         selected_recipe_kind: Option<RecipeNodeType>,
     ) -> Self {
         Self {
-            emitter_id: Default::default(),
+            emitter: Default::default(),
             tabs: Default::default(),
             state: State::new(selected_request, selected_recipe_kind),
         }
@@ -57,7 +57,7 @@ impl ExchangePane {
 impl EventHandler for ExchangePane {
     fn update(&mut self, _: &mut UpdateContext, event: Event) -> Option<Event> {
         event.opt().action(|action, propagate| match action {
-            Action::LeftClick => self.emit(ExchangePaneEvent::Click),
+            Action::LeftClick => self.emitter.emit(ExchangePaneEvent::Click),
             _ => propagate.set(),
         })
     }
@@ -134,11 +134,9 @@ impl Draw for ExchangePane {
 }
 
 /// Notify parent when this pane is clicked
-impl Emitter for ExchangePane {
-    type Emitted = ExchangePaneEvent;
-
-    fn id(&self) -> EmitterId {
-        self.emitter_id
+impl ToEmitter<ExchangePaneEvent> for ExchangePane {
+    fn to_emitter(&self) -> Emitter<ExchangePaneEvent> {
+        self.emitter
     }
 }
 

--- a/crates/tui/src/view/component/history.rs
+++ b/crates/tui/src/view/component/history.rs
@@ -6,7 +6,7 @@ use crate::{
         common::{list::List, modal::Modal},
         component::Component,
         draw::{Draw, DrawMetadata, Generate},
-        event::{Child, Emitter, Event, EventHandler, OptionEvent},
+        event::{Child, Event, EventHandler, OptionEvent, ToEmitter},
         state::select::{SelectState, SelectStateEvent, SelectStateEventType},
         UpdateContext, ViewContext,
     },
@@ -73,7 +73,7 @@ impl Modal for History {
 
 impl EventHandler for History {
     fn update(&mut self, _: &mut UpdateContext, event: Event) -> Option<Event> {
-        event.opt().emitted(self.select.handle(), |event| {
+        event.opt().emitted(self.select.to_emitter(), |event| {
             if let SelectStateEvent::Select(index) = event {
                 ViewContext::push_event(Event::HttpSelectRequest(Some(
                     self.select.data()[index].id(),

--- a/crates/tui/src/view/component/recipe_pane/recipe.rs
+++ b/crates/tui/src/view/component/recipe_pane/recipe.rs
@@ -34,7 +34,7 @@ use slumber_core::{
 use std::ops::Deref;
 use strum::{EnumCount, EnumIter};
 
-/// Display a recipe. Note a recipe *node*, this is for genuine bonafide recipe.
+/// Display a recipe. Not a recipe *node*, this is for genuine bonafide recipe.
 /// This maintains internal state specific to a recipe, so it should be
 /// recreated every time the recipe/profile changes.
 #[derive(Debug)]

--- a/crates/tui/src/view/context.rs
+++ b/crates/tui/src/view/context.rs
@@ -5,7 +5,6 @@ use crate::{
         component::RecipeOverrideStore,
         event::{Event, EventQueue},
         state::Notification,
-        IntoModal,
     },
 };
 use slumber_core::{collection::Collection, db::CollectionDatabase};
@@ -125,11 +124,6 @@ impl ViewContext {
     /// Pop an event off the event queue
     pub fn pop_event() -> Option<Event> {
         Self::with_mut(|context| context.event_queue.pop())
-    }
-
-    /// Open a modal
-    pub fn open_modal(modal: impl 'static + IntoModal) {
-        Self::push_event(Event::OpenModal(Box::new(modal.into_modal())));
     }
 
     /// Queue an event to send an informational notification to the user

--- a/crates/tui/src/view/state/fixed_select.rs
+++ b/crates/tui/src/view/state/fixed_select.rs
@@ -1,7 +1,7 @@
 use crate::view::{
     context::UpdateContext,
     draw::{Draw, DrawMetadata},
-    event::{Emitter, EmitterId, Event, EventHandler},
+    event::{Emitter, Event, EventHandler, ToEmitter},
     state::select::{
         SelectItem, SelectState, SelectStateBuilder, SelectStateData,
         SelectStateEvent, SelectStateEventType,
@@ -235,11 +235,9 @@ where
     }
 }
 
-impl<T: FixedSelect> Emitter for FixedSelectState<T> {
-    type Emitted = SelectStateEvent;
-
-    fn id(&self) -> EmitterId {
-        self.inner.id()
+impl<T: FixedSelect> ToEmitter<SelectStateEvent> for FixedSelectState<T> {
+    fn to_emitter(&self) -> Emitter<SelectStateEvent> {
+        self.inner.to_emitter()
     }
 }
 


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

This cleans up and deduplicates the code used to generate action menus, and also opens the door for components to provide a dynamic number of actions. It will also make it easier to bind shortcuts to actions.

This also includes a medium-sized refactor of emitters. The Emitter trait has had most of its logic moved to the EmitterHandle struct. Accordingly, the Emitter trait is now called ToEmitter, and EmitterHandle is now just Emitter. This should cut down a bit on static code duplication during compilation, and also simplifies the emitter logic a bit. Components themselves are no longer emitters, instead they just hold emitters. Since components are no longer working directly with Emitter IDs, it's not possible to mix up IDs and emit the wrong type from one. An emitter is just an emitter ID bound to a particular type.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Big code change = big bug potential. Mitigated with good existing unit tests.

## QA

_How did you test this?_

Leaning on existing tests here

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
