### PR TITLE
Include recipe edit and reset actions in menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   - `slumber history get` prints a specific request/response
 - Add `--output` flag to `slumber request` to control where the response body is written to
 - Support MIME type mapping for `pager` config field, so you can set different pagers based on media type. [See docs](https://slumber.lucaspickering.me/book/api/configuration/mime.html)
+- Add "Edit" and "Reset" actions to menus on the recipe pane
+  - These don't provide any new functionality, as the `e` and `z` keys are already bound to those actions, but it should make them more discoverable
 
 ### Fixed
 

--- a/crates/tui/src/view/component/primary.rs
+++ b/crates/tui/src/view/component/primary.rs
@@ -6,7 +6,7 @@ use crate::{
     util::ResultReported,
     view::{
         common::{
-            actions::{IntoMenuActions, MenuAction},
+            actions::{IntoMenuAction, MenuAction},
             modal::Modal,
         },
         component::{
@@ -44,7 +44,7 @@ use slumber_config::Action;
 use slumber_core::collection::{
     Collection, ProfileId, RecipeId, RecipeNodeType,
 };
-use strum::{EnumCount, EnumIter};
+use strum::{EnumCount, EnumIter, IntoEnumIterator};
 
 /// Primary TUI view, which shows request/response panes
 #[derive(Debug)]
@@ -346,7 +346,9 @@ impl EventHandler for PrimaryView {
     }
 
     fn menu_actions(&self) -> Vec<MenuAction> {
-        GlobalMenuAction::into_actions(self)
+        GlobalMenuAction::iter()
+            .map(MenuAction::with_data(self))
+            .collect()
     }
 
     fn children(&mut self) -> Vec<Component<Child<'_>>> {
@@ -457,13 +459,7 @@ enum GlobalMenuAction {
     EditCollection,
 }
 
-impl IntoMenuActions<PrimaryView> for GlobalMenuAction {
-    fn enabled(&self, _: &PrimaryView) -> bool {
-        match self {
-            Self::EditCollection => true,
-        }
-    }
-}
+impl IntoMenuAction<PrimaryView> for GlobalMenuAction {}
 
 /// Helper for adjusting pane behavior according to state
 struct Panes {

--- a/crates/tui/src/view/component/queryable_body.rs
+++ b/crates/tui/src/view/component/queryable_body.rs
@@ -454,7 +454,7 @@ enum CommandFocus {
 /// Emitted event to notify when a query subprocess has completed. Contains the
 /// stdout of the process if successful.
 #[derive(Debug)]
-pub struct QueryComplete(Result<Vec<u8>, anyhow::Error>);
+struct QueryComplete(Result<Vec<u8>, anyhow::Error>);
 
 #[derive(Debug, Default)]
 enum QueryState {

--- a/crates/tui/src/view/component/recipe_list.rs
+++ b/crates/tui/src/view/component/recipe_list.rs
@@ -2,7 +2,7 @@ use crate::{
     context::TuiContext,
     view::{
         common::{
-            actions::{IntoMenuActions, MenuAction},
+            actions::{IntoMenuAction, MenuAction},
             list::List,
             text_box::{TextBox, TextBoxEvent, TextBoxProps},
             Pane,
@@ -29,6 +29,7 @@ use slumber_core::collection::{
     HasId, RecipeId, RecipeLookupKey, RecipeNode, RecipeNodeType, RecipeTree,
 };
 use std::collections::HashSet;
+use strum::IntoEnumIterator;
 
 /// List/tree of recipes and folders. This is mostly just a list, but with some
 /// extra logic to allow expanding/collapsing nodes. This could be made into a
@@ -193,7 +194,9 @@ impl EventHandler for RecipeListPane {
     }
 
     fn menu_actions(&self) -> Vec<MenuAction> {
-        RecipeMenuAction::into_actions(self)
+        RecipeMenuAction::iter()
+            .map(MenuAction::with_data(self))
+            .collect()
     }
 
     fn children(&mut self) -> Vec<Component<Child<'_>>> {
@@ -252,7 +255,7 @@ impl ToEmitter<RecipeMenuAction> for RecipeListPane {
     }
 }
 
-impl IntoMenuActions<RecipeListPane> for RecipeMenuAction {
+impl IntoMenuAction<RecipeListPane> for RecipeMenuAction {
     fn enabled(&self, data: &RecipeListPane) -> bool {
         let recipe = data
             .select

--- a/crates/tui/src/view/component/recipe_pane.rs
+++ b/crates/tui/src/view/component/recipe_pane.rs
@@ -11,7 +11,7 @@ use crate::{
     message::RequestConfig,
     view::{
         common::{
-            actions::{IntoMenuActions, MenuAction},
+            actions::{IntoMenuAction, MenuAction},
             Pane,
         },
         component::recipe_pane::recipe::RecipeDisplay,
@@ -36,7 +36,7 @@ use slumber_core::{
     util::doc_link,
 };
 use std::cell::Ref;
-use strum::EnumIter;
+use strum::{EnumIter, IntoEnumIterator};
 
 /// Display for the current recipe node, which could be a recipe, a folder, or
 /// empty
@@ -124,7 +124,9 @@ impl EventHandler for RecipePane {
     }
 
     fn menu_actions(&self) -> Vec<MenuAction> {
-        RecipeMenuAction::into_actions(self)
+        RecipeMenuAction::iter()
+            .map(MenuAction::with_data(self))
+            .collect()
     }
 
     fn children(&mut self) -> Vec<Component<Child<'_>>> {
@@ -242,7 +244,7 @@ pub enum RecipeMenuAction {
     CopyBody,
 }
 
-impl IntoMenuActions<RecipePane> for RecipeMenuAction {
+impl IntoMenuAction<RecipePane> for RecipeMenuAction {
     fn enabled(&self, data: &RecipePane) -> bool {
         let recipe = data.recipe_state.get().and_then(|state| {
             Ref::filter_map(state, |state| state.data().as_ref()).ok()

--- a/crates/tui/src/view/component/recipe_pane/recipe.rs
+++ b/crates/tui/src/view/component/recipe_pane/recipe.rs
@@ -57,6 +57,7 @@ impl RecipeDisplay {
             method: recipe.method,
             url: TemplatePreview::new(recipe.url.clone(), None),
             query: RecipeFieldTable::new(
+                "Parameter",
                 QueryRowKey(recipe.id.clone()),
                 recipe.query.iter().enumerate().map(|(i, (param, value))| {
                     (
@@ -72,6 +73,7 @@ impl RecipeDisplay {
             )
             .into(),
             headers: RecipeFieldTable::new(
+                "Header",
                 HeaderRowKey(recipe.id.clone()),
                 recipe.headers.iter().enumerate().map(
                     |(i, (header, value))| {

--- a/crates/tui/src/view/component/request_view.rs
+++ b/crates/tui/src/view/component/request_view.rs
@@ -3,7 +3,7 @@ use crate::{
     message::Message,
     view::{
         common::{
-            actions::{IntoMenuActions, MenuAction},
+            actions::{IntoMenuAction, MenuAction},
             header_table::HeaderTable,
             text_window::{TextWindow, TextWindowProps},
         },
@@ -22,7 +22,7 @@ use slumber_core::{
     util::{format_byte_size, MaybeStr},
 };
 use std::sync::Arc;
-use strum::EnumIter;
+use strum::{EnumIter, IntoEnumIterator};
 
 /// Display rendered HTTP request state. The request could still be in flight,
 /// it just needs to have been built successfully.
@@ -75,7 +75,9 @@ impl EventHandler for RequestView {
     }
 
     fn menu_actions(&self) -> Vec<MenuAction> {
-        RequestMenuAction::into_actions(self)
+        RequestMenuAction::iter()
+            .map(MenuAction::with_data(self))
+            .collect()
     }
 
     fn children(&mut self) -> Vec<Component<Child<'_>>> {
@@ -132,7 +134,7 @@ impl ToEmitter<RequestMenuAction> for RequestView {
 
 /// Items in the actions popup menu
 #[derive(Copy, Clone, Debug, Display, EnumIter)]
-pub enum RequestMenuAction {
+enum RequestMenuAction {
     #[display("Copy URL")]
     CopyUrl,
     #[display("Copy Body")]
@@ -141,7 +143,7 @@ pub enum RequestMenuAction {
     ViewBody,
 }
 
-impl IntoMenuActions<RequestView> for RequestMenuAction {
+impl IntoMenuAction<RequestView> for RequestMenuAction {
     fn enabled(&self, data: &RequestView) -> bool {
         match self {
             Self::CopyUrl => true,

--- a/crates/tui/src/view/component/response_view.rs
+++ b/crates/tui/src/view/component/response_view.rs
@@ -5,7 +5,7 @@ use crate::{
     message::Message,
     view::{
         common::{
-            actions::{IntoMenuActions, MenuAction},
+            actions::{IntoMenuAction, MenuAction},
             header_table::HeaderTable,
         },
         component::queryable_body::QueryableBody,
@@ -22,7 +22,7 @@ use ratatui::Frame;
 use serde::Serialize;
 use slumber_core::{collection::RecipeId, http::ResponseRecord};
 use std::sync::Arc;
-use strum::EnumIter;
+use strum::{EnumIter, IntoEnumIterator};
 
 /// Display response body
 #[derive(Debug)]
@@ -67,13 +67,7 @@ enum ResponseBodyMenuAction {
     SaveBody,
 }
 
-impl IntoMenuActions<ResponseBodyView> for ResponseBodyMenuAction {
-    fn enabled(&self, _: &ResponseBodyView) -> bool {
-        match self {
-            Self::ViewBody | Self::CopyBody | Self::SaveBody => true,
-        }
-    }
-}
+impl IntoMenuAction<ResponseBodyView> for ResponseBodyMenuAction {}
 
 /// Persisted key for response body JSONPath query text box
 #[derive(Debug, Serialize, PersistedKey)]
@@ -111,7 +105,9 @@ impl EventHandler for ResponseBodyView {
     }
 
     fn menu_actions(&self) -> Vec<MenuAction> {
-        ResponseBodyMenuAction::into_actions(self)
+        ResponseBodyMenuAction::iter()
+            .map(MenuAction::with_data(self))
+            .collect()
     }
 
     fn children(&mut self) -> Vec<Component<Child<'_>>> {


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

<img width="248" alt="image" src="https://github.com/user-attachments/assets/5e45280a-e855-4401-a7f7-fb332383cd3b" />


## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Menu is getting mighty big. Should get easier to navigate with shortcuts though

## QA

_How did you test this?_

Unit tests, manual testing

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
