### PR TITLE
Add shortcuts to menu actions

### DIFF
--- a/crates/tui/src/view/component/primary.rs
+++ b/crates/tui/src/view/component/primary.rs
@@ -539,8 +539,7 @@ mod tests {
 
         harness.clear_messages(); // Clear init junk
 
-        // Open action menu
-        component.send_key(KeyCode::Char('x')).assert_empty();
+        component.open_actions().assert_empty();
         // Select first action - Edit Collection
         component.send_key(KeyCode::Enter).assert_empty();
         // Event should be converted into a message appropriately

--- a/crates/tui/src/view/component/recipe_pane/authentication.rs
+++ b/crates/tui/src/view/component/recipe_pane/authentication.rs
@@ -220,7 +220,14 @@ enum AuthenticationMenuAction {
     Reset,
 }
 
-impl IntoMenuAction<AuthenticationDisplay> for AuthenticationMenuAction {}
+impl IntoMenuAction<AuthenticationDisplay> for AuthenticationMenuAction {
+    fn shortcut(&self, _: &AuthenticationDisplay) -> Option<Action> {
+        match self {
+            Self::Edit => Some(Action::Edit),
+            Self::Reset => Some(Action::Reset),
+        }
+    }
+}
 
 /// Private to hide enum variants
 #[derive(Debug)]
@@ -480,13 +487,9 @@ mod tests {
             AuthenticationDisplay::new(RecipeId::factory(()), authentication),
         );
 
+        component.open_actions().assert_empty();
         component
-            .send_keys([
-                KeyCode::Char('x'),
-                KeyCode::Enter,
-                KeyCode::Char('!'),
-                KeyCode::Enter,
-            ])
+            .send_keys([KeyCode::Enter, KeyCode::Char('!'), KeyCode::Enter])
             .assert_empty();
         assert_eq!(
             component.data().override_value(),

--- a/crates/tui/src/view/component/recipe_pane/body.rs
+++ b/crates/tui/src/view/component/recipe_pane/body.rs
@@ -308,7 +308,14 @@ enum RawBodyMenuAction {
     Reset,
 }
 
-impl IntoMenuAction<RawBody> for RawBodyMenuAction {}
+impl IntoMenuAction<RawBody> for RawBodyMenuAction {
+    fn shortcut(&self, _: &RawBody) -> Option<Action> {
+        match self {
+            Self::Edit => Some(Action::Edit),
+            Self::Reset => Some(Action::Reset),
+        }
+    }
+}
 
 /// Local event to save a user's override body. Triggered from the on_complete
 /// callback when the user closes the editor.

--- a/crates/tui/src/view/component/recipe_pane/table.rs
+++ b/crates/tui/src/view/component/recipe_pane/table.rs
@@ -280,6 +280,16 @@ where
             }
         }
     }
+
+    fn shortcut(
+        &self,
+        _: &RecipeFieldTable<RowSelectKey, RowToggleKey>,
+    ) -> Option<Action> {
+        match self {
+            Self::Edit { .. } => Some(Action::Edit),
+            Self::Reset { .. } => Some(Action::Reset),
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -582,13 +592,9 @@ mod tests {
             },
         );
 
+        component.open_actions().assert_empty();
         component
-            .send_keys([
-                KeyCode::Char('x'),
-                KeyCode::Enter,
-                KeyCode::Char('!'),
-                KeyCode::Enter,
-            ])
+            .send_keys([KeyCode::Enter, KeyCode::Char('!'), KeyCode::Enter])
             .assert_empty();
 
         let selected_row = component.data().select.data().selected().unwrap();

--- a/crates/tui/src/view/component/response_view.rs
+++ b/crates/tui/src/view/component/response_view.rs
@@ -213,9 +213,10 @@ mod tests {
         );
 
         // Open actions modal and select the copy action
+        component.open_actions().assert_empty();
+        // Note: Edit Collections action isn't visible here
         component
-            // Note: Edit Collections action isn't visible here
-            .send_keys([KeyCode::Char('x'), KeyCode::Down, KeyCode::Enter])
+            .send_keys([KeyCode::Down, KeyCode::Enter])
             .assert_empty();
 
         let body = assert_matches!(
@@ -302,14 +303,10 @@ mod tests {
         }
 
         // Open actions modal and select the save action
+        component.open_actions().assert_empty();
         component
-            .send_keys([
-                KeyCode::Char('x'),
-                // Note: Edit Collections action isn't visible here
-                KeyCode::Down,
-                KeyCode::Down,
-                KeyCode::Enter,
-            ])
+            // Note: Edit Collections action isn't visible here
+            .send_keys([KeyCode::Down, KeyCode::Down, KeyCode::Enter])
             .assert_empty();
 
         let (request_id, data) = assert_matches!(

--- a/crates/tui/src/view/state/select.rs
+++ b/crates/tui/src/view/state/select.rs
@@ -234,18 +234,8 @@ impl<Item, State: SelectStateData> SelectState<Item, State> {
         }
     }
 
-    /// Select the previous item in the list
-    pub fn previous(&mut self) {
-        self.select_delta(-1);
-    }
-
-    /// Select the next item in the list
-    pub fn next(&mut self) {
-        self.select_delta(1);
-    }
-
     /// Select an item by index
-    fn select_index(&mut self, index: usize) {
+    pub fn select_index(&mut self, index: usize) {
         let state = self.state.get_mut();
         let current = state.selected();
         state.select(index);
@@ -255,6 +245,16 @@ impl<Item, State: SelectStateData> SelectState<Item, State> {
         if current != new {
             self.emit_for_selected(SelectStateEvent::Select);
         }
+    }
+
+    /// Select the previous item in the list
+    pub fn previous(&mut self) {
+        self.select_delta(-1);
+    }
+
+    /// Select the next item in the list
+    pub fn next(&mut self) {
+        self.select_delta(1);
     }
 
     /// Move some number of items up or down the list. Selection will wrap if

--- a/crates/tui/src/view/test_util.rs
+++ b/crates/tui/src/view/test_util.rs
@@ -296,6 +296,11 @@ where
             events,
         }
     }
+
+    /// Open the actions menu
+    pub fn open_actions(&mut self) -> PropagatedEvents<'_, T> {
+        self.send_key(KeyCode::Char('x'))
+    }
 }
 
 /// A collection of events that were propagated out from a particular


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Add shortcuts to menu actions, so that actions that are available both by keybinding and menu action get the keybinding shown in the menu.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

- Code dupe
- Potential overlap between bindings

## QA

_How did you test this?_

Unit tests

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
