### PR TITLE
Use italics to mark templates that have been edited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Add "Edit" and "Reset" actions to menus on the recipe pane
   - These don't provide any new functionality, as the `e` and `z` keys are already bound to those actions, but it should make them more discoverable
 
+### Changed
+
+- Denote templates that have been edited during the current session with italics instead of a faint "(edited)" note
+
 ### Fixed
 
 - Fix certain recipe-related menu actions being enabled when they shouldn't be

--- a/crates/tui/src/view/common/text_window.rs
+++ b/crates/tui/src/view/common/text_window.rs
@@ -12,7 +12,6 @@ use ratatui::{
     buffer::Buffer,
     layout::{Layout, Rect},
     prelude::{Alignment, Constraint},
-    style::Style,
     text::{Line, StyledGrapheme, Text},
     widgets::{Paragraph, ScrollbarOrientation},
     Frame,
@@ -47,8 +46,6 @@ pub struct TextWindowProps<'a> {
     /// Text to render. We take a reference because this component tends to
     /// contain a lot of text, and we don't want to force a clone on render
     pub text: &'a Identified<Text<'a>>,
-    /// Extra text to render below the text window
-    pub footer: Option<Text<'a>>,
     pub margins: ScrollbarMargins,
 }
 
@@ -158,7 +155,7 @@ impl TextWindow {
             // have to map grapheme number -> byte offset and cache that,
             // because skipping bytes is O(1) instead of O(n)
             let graphemes = line
-                .styled_graphemes(Style::default())
+                .styled_graphemes(text.style)
                 .skip(self.offset_x.get())
                 .take(self.window_width.get());
             let mut x = 0;
@@ -260,25 +257,6 @@ impl<'a> Draw<TextWindowProps<'a>> for TextWindow {
         // Draw the text content
         self.render_chars(props.text, frame.buffer_mut(), text_area);
 
-        // Render the footer just below the text. If the text has maxed out the
-        // possible area, this will render beyond that. A bit hacky but in
-        // practice it works
-        if let Some(footer) = props.footer {
-            frame.render_widget(
-                footer,
-                Rect {
-                    x: text_area.x,
-                    y: text_area.y
-                        + (cmp::min(
-                            text_state.height,
-                            self.window_height.get(),
-                        )) as u16,
-                    width: text_area.width,
-                    height: 1,
-                },
-            );
-        }
-
         // Scrollbars
         if has_vertical_scroll {
             frame.render_widget(
@@ -338,7 +316,6 @@ mod tests {
                     right: 0,
                     bottom: 0,
                 },
-                footer: None,
             },
         );
         terminal.assert_buffer_lines([
@@ -419,7 +396,6 @@ mod tests {
                     right: 0,
                     bottom: 0,
                 },
-                footer: None,
             },
         );
         terminal.assert_buffer_lines([
@@ -446,7 +422,6 @@ mod tests {
                     right: 0,
                     bottom: 0,
                 },
-                footer: None,
             },
         );
         terminal.assert_buffer_lines([
@@ -476,7 +451,6 @@ mod tests {
                     right: 0,
                     bottom: 0,
                 },
-                footer: None,
             },
         );
 
@@ -493,7 +467,6 @@ mod tests {
                 right: 0,
                 bottom: 0,
             },
-            footer: None,
         });
         component.int().drain_draw().assert_empty();
 
@@ -519,7 +492,6 @@ mod tests {
                     right: 0,
                     bottom: 0,
                 },
-                footer: None,
             },
         );
 

--- a/crates/tui/src/view/component/profile_select.rs
+++ b/crates/tui/src/view/component/profile_select.rs
@@ -332,7 +332,10 @@ impl<'a> Draw<ProfileDetailProps<'a>> for ProfileDetail {
             profile_data
                 .iter()
                 .map(|(key, template)| {
-                    (key.clone(), TemplatePreview::new(template.clone(), None))
+                    (
+                        key.clone(),
+                        TemplatePreview::new(template.clone(), None, false),
+                    )
                 })
                 .collect_vec()
         });

--- a/crates/tui/src/view/component/queryable_body.rs
+++ b/crates/tui/src/view/component/queryable_body.rs
@@ -309,7 +309,6 @@ impl Draw for QueryableBody {
                         bottom: 2, // Extra margin to jump over the search box
                         ..Default::default()
                     },
-                    footer: None,
                 },
                 body_area,
                 true,

--- a/crates/tui/src/view/component/recipe_pane/authentication.rs
+++ b/crates/tui/src/view/component/recipe_pane/authentication.rs
@@ -22,11 +22,7 @@ use crate::{
 };
 use derive_more::derive::Display;
 use ratatui::{
-    layout::Layout,
-    prelude::Constraint,
-    text::{Line, Span},
-    widgets::TableState,
-    Frame,
+    layout::Layout, prelude::Constraint, text::Span, widgets::TableState, Frame,
 };
 use slumber_config::Action;
 use slumber_core::{
@@ -147,11 +143,23 @@ impl EventHandler for AuthenticationDisplay {
 impl Draw for AuthenticationDisplay {
     fn draw(&self, frame: &mut Frame, _: (), metadata: DrawMetadata) {
         let styles = &TuiContext::get().styles;
-
         let [label_area, content_area] =
             Layout::vertical([Constraint::Length(1), Constraint::Min(0)])
                 .areas(metadata.area());
+
         let label = match &self.state {
+            State::Basic { .. } => "Basic",
+            State::Bearer { .. } => "Bearer",
+        };
+        frame.render_widget(
+            Span::styled(
+                format!("Authentication Type: {label}"),
+                styles.text.title,
+            ),
+            label_area,
+        );
+
+        match &self.state {
             State::Basic {
                 username,
                 password,
@@ -171,23 +179,11 @@ impl Draw for AuthenticationDisplay {
                     content_area,
                     true,
                 );
-                "Basic"
             }
             State::Bearer { token } => {
                 frame.render_widget(token.preview().generate(), content_area);
-                "Bearer"
             }
-        };
-
-        let mut title: Line = Span::styled(
-            format!("Authentication Type: {label}"),
-            styles.text.title,
-        )
-        .into();
-        if self.state.is_overridden() {
-            title.push_span(Span::styled(" (edited)", styles.text.hint));
         }
-        frame.render_widget(title, label_area);
     }
 }
 

--- a/crates/tui/src/view/component/recipe_pane/persistence.rs
+++ b/crates/tui/src/view/component/recipe_pane/persistence.rs
@@ -76,7 +76,7 @@ impl RecipeTemplate {
             RecipeTemplateInner {
                 original_template: template.clone(),
                 override_template: None,
-                preview: TemplatePreview::new(template, content_type),
+                preview: TemplatePreview::new(template, content_type, false),
                 content_type,
             },
         ))
@@ -140,8 +140,11 @@ impl RecipeTemplateInner {
     }
 
     fn render_preview(&mut self) {
-        self.preview =
-            TemplatePreview::new(self.template().clone(), self.content_type);
+        self.preview = TemplatePreview::new(
+            self.template().clone(),
+            self.content_type,
+            self.override_template.is_some(),
+        );
     }
 }
 

--- a/crates/tui/src/view/component/recipe_pane/table.rs
+++ b/crates/tui/src/view/component/recipe_pane/table.rs
@@ -1,5 +1,4 @@
 use crate::{
-    context::TuiContext,
     util::ResultReported,
     view::{
         common::{
@@ -24,7 +23,6 @@ use crate::{
 use itertools::Itertools;
 use ratatui::{
     layout::Constraint,
-    text::Span,
     widgets::{Row, TableState},
     Frame,
 };
@@ -311,13 +309,11 @@ impl<K: PersistedKey<Value = bool>> Generate for &RowState<K> {
     where
         Self: 'this,
     {
-        let styles = &TuiContext::get().styles;
-        let mut preview_text = self.value.preview().generate();
-        if self.value.is_overridden() {
-            preview_text.push_span(Span::styled(" (edited)", styles.text.hint));
-        }
-        ToggleRow::new([self.key.as_str().into(), preview_text], *self.enabled)
-            .generate()
+        ToggleRow::new(
+            [self.key.as_str().into(), self.value.preview().generate()],
+            *self.enabled,
+        )
+        .generate()
     }
 }
 

--- a/crates/tui/src/view/component/request_view.rs
+++ b/crates/tui/src/view/component/request_view.rs
@@ -117,7 +117,6 @@ impl Draw for RequestView {
                 TextWindowProps {
                     text: body,
                     margins: Default::default(),
-                    footer: None,
                 },
                 body_area,
                 true,

--- a/crates/tui/src/view/styles.rs
+++ b/crates/tui/src/view/styles.rs
@@ -102,10 +102,10 @@ pub struct TextStyle {
     pub highlight: Style,
     /// Text in the primary color
     pub primary: Style,
+    /// Templates that have been overridden in this session
+    pub edited: Style,
     /// Text that means BAD BUSINESS
     pub error: Style,
-    /// Subtle text to provide a hint to the user
-    pub hint: Style,
     /// Text at the top of something
     pub title: Style,
 }
@@ -187,8 +187,8 @@ impl Styles {
                     .fg(theme.primary_text_color)
                     .bg(theme.primary_color),
                 primary: Style::default().fg(theme.primary_color),
+                edited: Style::default().add_modifier(Modifier::ITALIC),
                 error: Style::default().bg(theme.error_color),
-                hint: Style::default().fg(Color::DarkGray),
                 title: Style::default().add_modifier(Modifier::BOLD),
             },
             text_box: TextBoxStyle {


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Also remove the footer on the recipe pane showing how to edit/reset values. Those are discoverable in the help modal as well as the actions menu now.

![image](https://github.com/user-attachments/assets/d5f2ac3e-3e26-422c-b2fe-b468dff862ac)

![image](https://github.com/user-attachments/assets/86c687d7-d0ab-4451-b03d-33f6f72a4950)



## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

There's no explicit description of what the italics means now. I think it should be intuitive enough. This information isn't necessary to understand what the request will look like anyway, it's just a bonus note.

## QA

_How did you test this?_

Manual testing, updated some unit tests.

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
