### PR TITLE
Lowercase headers during serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Changed
 
 - Denote templates that have been edited during the current session with italics instead of a faint "(edited)" note
+- Header names in recipes are now lowercased in the UI
+  - They have always been lowercased when the request is actually sent, so now the UI is just more representative of what will be sent
 
 ### Fixed
 

--- a/crates/core/src/collection.rs
+++ b/crates/core/src/collection.rs
@@ -472,7 +472,7 @@ mod tests {
                         ("fast".into(), "no_thanks".into()),
                     ],
                     headers: indexmap! {
-                        "Accept".into() => "application/json".into(),
+                        "accept".into() => "application/json".into(),
                     },
                 }),
                 RecipeNode::Folder(Folder {
@@ -507,7 +507,7 @@ mod tests {
                             )),
                             query: vec![],
                             headers: indexmap! {
-                                "Accept".into() => "application/json".into(),
+                                "accept".into() => "application/json".into(),
                             },
                         }),
                         RecipeNode::Recipe(Recipe {
@@ -527,7 +527,7 @@ mod tests {
                             }),
                             query: vec![],
                             headers: indexmap! {
-                                "Accept".into() => "application/json".into(),
+                                "accept".into() => "application/json".into(),
                             },
                         }),
                         RecipeNode::Recipe(Recipe {
@@ -542,7 +542,7 @@ mod tests {
                             authentication: None,
                             query: vec![],
                             headers: indexmap! {
-                                "Accept".into() => "application/json".into(),
+                                "accept".into() => "application/json".into(),
                             },
                         }),
                     ]),

--- a/crates/core/src/collection/cereal.rs
+++ b/crates/core/src/collection/cereal.rs
@@ -226,6 +226,26 @@ pub mod serde_query_parameters {
     }
 }
 
+/// Deserialize a header map, lowercasing all header names. Headers are
+/// case-insensitive (and must be lowercase in HTTP/2+), so forcing the case
+/// makes lookups on the map easier.
+pub fn deserialize_headers<'de, D>(
+    deserializer: D,
+) -> Result<IndexMap<String, Template>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    // This involves an extra allocation, but it makes the logic a lot easier.
+    // These maps should be small anyway
+    let headers: IndexMap<String, Template> =
+        IndexMap::deserialize(deserializer)?;
+    Ok(headers
+        .into_iter()
+        // TODO should be ascii only?
+        .map(|(k, v)| (k.to_lowercase(), v))
+        .collect())
+}
+
 impl RecipeBody {
     // Constants for serialize/deserialization. Typically these are generated
     // by macros, but we need custom implementation

--- a/test_data/rest_http_bin.http
+++ b/test_data/rest_http_bin.http
@@ -12,8 +12,8 @@ GET {{ HOST}}/get HTTP/1.1
 @FULL={{ FIRST }} {{LAST}}
 
 POST {{HOST}}/post?hello=123 HTTP/1.1
-Authorization: Basic Zm9vOmJhcg==
-Content-Type: application/json
+authorization: Basic Zm9vOmJhcg==
+content-type: application/json
 X-Http-Method-Override: PUT
 
 {
@@ -26,16 +26,16 @@ X-Http-Method-Override: PUT
 @ENDPOINT = post
 
 POST https://httpbin.org/{{ENDPOINT}} HTTP/1.1
-Authorization: Bearer efaxijasdfjasdfa
-Content-Type: application/x-www-form-urlencoded
-My-Header: hello
-Other-Header: goodbye
+authorization: Bearer efaxijasdfjasdfa
+content-type: application/x-www-form-urlencoded
+my-header: hello
+other-header: goodbye
 
 first={{ FIRST}}&last={{LAST}}&full={{FULL}}
 
 ### Pet.json
 
 POST {{HOST}}/post HTTP/1.1
-Content-Type: application/json
+content-type: application/json
 
 < ./test_data/rest_pets.json

--- a/test_data/rest_imported.yml
+++ b/test_data/rest_imported.yml
@@ -6,7 +6,7 @@ profiles:
       HOST: http://httpbin.org
       FIRST: Joe
       LAST: Smith
-      FULL: '{{FIRST}} {{LAST}}'
+      FULL: "{{FIRST}} {{LAST}}"
       ENDPOINT: post
 chains:
   Pet_json_3_body:
@@ -21,7 +21,7 @@ requests:
   SimpleGet_0: !request
     name: SimpleGet
     method: GET
-    url: '{{HOST}}/get'
+    url: "{{HOST}}/get"
     body: null
     authentication: null
     query: []
@@ -29,15 +29,15 @@ requests:
   JsonPost_1: !request
     name: JsonPost
     method: POST
-    url: '{{HOST}}/post'
+    url: "{{HOST}}/post"
     body: !json
       data: my data
-      name: '{{FULL}}'
+      name: "{{FULL}}"
     authentication: !basic
       username: foo
       password: bar
     query:
-    - hello=123
+      - hello=123
     headers:
       Content-Type: application/json
       X-Http-Method-Override: PUT
@@ -55,8 +55,8 @@ requests:
   Pet_json_3: !request
     name: Pet.json
     method: POST
-    url: '{{HOST}}/post'
-    body: '{{chains.Pet_json_3_body}}'
+    url: "{{HOST}}/post"
+    body: "{{chains.Pet_json_3_body}}"
     authentication: null
     query: []
     headers:


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

This makes lookups on the recipe header map easier. It also makes the header display in the UI match what will actually be sent, since reqwest forces lowercase anyway. It will *not* change the behavior of sent requests.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

This could potentially be confusing for users, who put `Content-Type` in the file and see `content-type` in the UI. The flip side is it's more representative of what will actually be sent.

## QA

_How did you test this?_

Unit tests

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
