### PR TITLE
Allow directory to --file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,8 +101,8 @@ jobs:
 
       - name: Install toolchain
         run: rustup target add ${{ matrix.platform.target }}
-        env:
-          RUST_BACKTRACE: 1
 
       - name: Run tests
         run: cargo test --workspace --no-fail-fast
+        env:
+          RUST_BACKTRACE: 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Denote templates that have been edited during the current session with italics instead of a faint "(edited)" note
 - Header names in recipes are now lowercased in the UI
   - They have always been lowercased when the request is actually sent, so now the UI is just more representative of what will be sent
+- Accept a directory for the `--file`/`-f` CLI argument
+  - If a directory is given, the [standard rules for detecting a collection file](https://slumber.lucaspickering.me/book/api/request_collection/index.html#format--loading) will be applied from that directory
 
 ### Fixed
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -53,7 +53,9 @@ impl Args {
 pub struct GlobalArgs {
     /// Collection file, which defines profiles, recipes, etc. If omitted,
     /// check the current and all parent directories for the following files
-    /// (in this order): slumber.yml, slumber.yaml, .slumber.yml, .slumber.yaml
+    /// (in this order): slumber.yml, slumber.yaml, .slumber.yml,
+    /// .slumber.yaml. If a directory is passed, apply the same search
+    /// logic from the given directory rather than the current.
     #[clap(long, short)]
     pub file: Option<PathBuf>,
 }

--- a/crates/core/src/collection/models.rs
+++ b/crates/core/src/collection/models.rs
@@ -55,7 +55,7 @@ impl Collection {
         };
 
         load()
-            .context(format!("Error loading data from {path:?}"))
+            .context(format!("Error loading collection from {path:?}"))
             .traced()
     }
 }

--- a/docs/src/api/request_collection/index.md
+++ b/docs/src/api/request_collection/index.md
@@ -13,10 +13,11 @@ A collection is defined as a [YAML](https://yaml.org/) file. When you run `slumb
 - `.slumber.yml`
 - `.slumber.yaml`
 
-Whichever of those files is found _first_ will be used. For any given directory, if no collection file is found there, it will recursively go up the directory tree until we find a collection file or hit the root directory. If you want to use a different file for your collection (e.g. if you want to store multiple collections in the same directory), you can override the auto-search with the `--file` (or `-f`) command line argument. E.g.:
+Whichever of those files is found _first_ will be used. For any given directory, if no collection file is found there, it will recursively go up the directory tree until we find a collection file or hit the root directory. If you want to use a different file for your collection (e.g. if you want to store multiple collections in the same directory), you can override the auto-search with the `--file` (or `-f`) command line argument. You can also pass a directory to `--file` to have it search that directory instead of the current one. E.g.:
 
 ```sh
-slumber -f my-collection.yml
+slumber --file my-collection.yml
+slumber --file ../another-project/
 ```
 
 ## Fields


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

`--file` now accepts a directory. It will search that directory using the standard search logic.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

It could be confusing since it will search up from the given dir. This is consistent with existing behavior though.

## QA

_How did you test this?_

Unit tests!!!

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
