### PR TITLE
Fixes related to queries

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+[build]
+# Unstable: we use the task builder
+# https://docs.rs/tokio/latest/tokio/index.html#unstable-features
+rustflags = ["--cfg", "tokio_unstable"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.92",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +173,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,6 +233,12 @@ dependencies = [
  "rustc-demangle",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -389,6 +464,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "console-api"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8030735ecb0d128428b64cd379809817e620a40e5001c54465b99ec5feec2857"
+dependencies = [
+ "futures-core",
+ "prost",
+ "prost-types",
+ "tonic",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6539aa9c6a4cd31f4b1c040f860a1eac9aa80e7df6b05d506a6e7179936d6a01"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures-task",
+ "hdrhistogram",
+ "humantime",
+ "hyper-util",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,6 +517,30 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -661,6 +799,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "flate2"
+version = "1.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,12 +974,18 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.7.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -860,6 +1014,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "hdrhistogram"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+dependencies = [
+ "base64 0.21.7",
+ "byteorder",
+ "flate2",
+ "nom",
+ "num-traits",
 ]
 
 [[package]]
@@ -921,6 +1088,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,6 +1131,19 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1145,6 +1331,16 @@ checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1354,6 +1550,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1542,7 +1753,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc02deea53ffe807708244e5914f6b099ad7015a207ee24317c22112e17d9c5c"
 dependencies = [
- "indexmap",
+ "indexmap 2.7.0",
  "serde",
  "serde_json",
 ]
@@ -1638,7 +1849,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 2.7.0",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.92",
 ]
 
 [[package]]
@@ -1701,7 +1932,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax",
+ "regex-syntax 0.8.5",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -1716,6 +1947,38 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.92",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.92",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2f1e56baa61e93533aebc21af4d2134b70f66275e0fcdf3cbe43d77ff7e8fc"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -1874,8 +2137,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -1886,8 +2158,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -1907,7 +2185,7 @@ version = "0.12.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fe060fe50f524be480214aba758c71f99f90ee8c83c5a36b5e9e1d568eb4eb3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -1936,7 +2214,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tower",
+ "tower 0.5.2",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -1953,9 +2231,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "575c220d2c01ec29da1d36c6fbd1deb7fe001597336f54f22f5f1a35cbeaa5c8"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "httparse",
- "indexmap",
+ "indexmap 2.7.0",
  "nom",
  "url",
 ]
@@ -2220,7 +2498,7 @@ version = "1.0.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
 dependencies = [
- "indexmap",
+ "indexmap 2.7.0",
  "itoa",
  "memchr",
  "ryu",
@@ -2314,7 +2592,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.7.0",
  "itoa",
  "ryu",
  "serde",
@@ -2386,6 +2664,7 @@ name = "slumber"
 version = "2.5.0"
 dependencies = [
  "anyhow",
+ "console-subscriber",
  "slumber_cli",
  "slumber_core",
  "slumber_tui",
@@ -2403,7 +2682,7 @@ dependencies = [
  "clap_complete",
  "dialoguer",
  "env-lock",
- "indexmap",
+ "indexmap 2.7.0",
  "itertools",
  "pretty_assertions",
  "reqwest",
@@ -2427,7 +2706,7 @@ dependencies = [
  "dirs",
  "env-lock",
  "glob",
- "indexmap",
+ "indexmap 2.7.0",
  "itertools",
  "mime",
  "ratatui",
@@ -2451,7 +2730,7 @@ dependencies = [
  "dirs",
  "env-lock",
  "futures",
- "indexmap",
+ "indexmap 2.7.0",
  "itertools",
  "mime",
  "pretty_assertions",
@@ -2483,7 +2762,7 @@ name = "slumber_import"
 version = "2.5.0"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.7.0",
  "itertools",
  "mime",
  "openapiv3",
@@ -2514,7 +2793,7 @@ dependencies = [
  "derive_more",
  "editor-command",
  "futures",
- "indexmap",
+ "indexmap 2.7.0",
  "itertools",
  "mime",
  "notify",
@@ -2530,6 +2809,7 @@ dependencies = [
  "slumber_core",
  "strum",
  "tokio",
+ "tokio-util",
  "tracing",
  "tree-sitter-highlight",
  "tree-sitter-json",
@@ -2743,9 +3023,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.42.0"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2755,14 +3035,15 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2780,6 +3061,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2790,6 +3082,56 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "socket2",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2848,6 +3190,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
 ]
 
 [[package]]
@@ -2856,9 +3199,13 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "thread_local",
+ "tracing",
  "tracing-core",
 ]
 
@@ -3017,6 +3364,12 @@ dependencies = [
  "getrandom",
  "serde",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -3463,7 +3816,7 @@ checksum = "7fff469918e7ca034884c7fd8f93fe27bacb7fcb599fd879df6c7b429a29b646"
 dependencies = [
  "assert-json-diff",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "deadpool",
  "futures",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ winnow = "0.6.16"
 
 [dependencies]
 anyhow = {workspace = true, features = ["backtrace"]}
+console-subscriber = {version = "0.4.1", optional = true}
 slumber_cli = {workspace = true}
 slumber_core = {workspace = true}
 slumber_tui = {workspace = true, optional = true}
@@ -71,6 +72,8 @@ tracing-subscriber = {version = "0.3.17", default-features = false, features = [
 default = ["tui"]
 # TUI can be disabled in dev to speed compilation while testing CLI
 tui = ["dep:slumber_tui"]
+# Enable tokio tracing, for use with tokio-console
+tokio_tracing = ["tokio/tracing", "dep:console-subscriber"]
 
 # The profile that 'cargo dist' will build with
 [profile.dist]

--- a/crates/core/src/collection.rs
+++ b/crates/core/src/collection.rs
@@ -174,7 +174,10 @@ fn detect_path(dir: &Path) -> Option<PathBuf> {
 async fn load_collection(path: PathBuf) -> anyhow::Result<Collection> {
     // YAML parsing is blocking so do it in a different thread. We could use
     // tokio::fs for this but that just uses std::fs underneath anyway.
-    task::spawn_blocking(move || Collection::load(&path))
+    task::Builder::new()
+        .name("Load collection")
+        .spawn_blocking(move || Collection::load(&path))
+        .unwrap()
         .await
         // This error only occurs if the task panics
         .context("Error parsing collection")?

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -32,7 +32,8 @@ shell-words = "1.1.0"
 slumber_config = {workspace = true}
 slumber_core = {workspace = true}
 strum = {workspace = true}
-tokio = {workspace = true, features = ["macros", "signal"]}
+tokio = {workspace = true, features = ["macros", "signal", "tracing"]}
+tokio-util = "0.7.13"
 tracing = {workspace = true}
 tree-sitter-highlight = "0.22.6"
 tree-sitter-json = "0.21.0"

--- a/crates/tui/src/util.rs
+++ b/crates/tui/src/util.rs
@@ -307,12 +307,15 @@ pub async fn run_command(
         .spawn()?;
 
     if let Some(stdin) = stdin {
-        process
+        // If writing to stdin fails, it's probably because the process exited
+        // immediately. This typically indicates some other error. We _don't_
+        // want to show the stdin error, because it will mask the actual error.
+        let _ = process
             .stdin
             .as_mut()
             .expect("Process missing stdin")
             .write_all(stdin)
-            .await?;
+            .await;
     }
     let output = process.wait_with_output().await?;
     debug!(

--- a/crates/tui/src/view/component/queryable_body.rs
+++ b/crates/tui/src/view/component/queryable_body.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     context::TuiContext,
-    util::{run_command, spawn_local},
+    util::{run_command, spawn},
     view::{
         common::{
             modal::Modal,
@@ -207,7 +207,7 @@ impl QueryableBody {
         body: Bytes,
         on_complete: impl 'static + FnOnce(String, anyhow::Result<Vec<u8>>),
     ) -> AbortHandle {
-        spawn_local(async move {
+        spawn("Command", async move {
             let shell = &TuiContext::get().config.commands.shell;
             let result = run_command(shell, &command, Some(&body))
                 .await

--- a/crates/tui/src/view/component/queryable_body.rs
+++ b/crates/tui/src/view/component/queryable_body.rs
@@ -239,20 +239,8 @@ impl EventHandler for QueryableBody {
                         false,
                     );
                 }
-                // Trigger error state. We DON'T want to show a modal here by
-                // default because it's incredibly annoying. Instead the user
-                // can open the modal by hitting  a key
-                Err(error) => {
-                    // It'd be nice to get the owned error here, but it makes
-                    // the downcasting for the emitted event more complicated
-                    self.query_state = QueryState::Error(error);
-                    let binding = TuiContext::get()
-                        .input_engine
-                        .binding_display(Action::OpenHelp);
-                    ViewContext::notify(format!(
-                        "Error query response; {binding} for detail"
-                    ));
-                }
+                // Trigger error state. Error will be shown in the pane
+                Err(error) => self.query_state = QueryState::Error(error),
             })
             .emitted(self.query_text_box.to_emitter(), |event| match event {
                 TextBoxEvent::Focus => self.focus(CommandFocus::Query),

--- a/crates/tui/src/view/component/recipe_pane/recipe.rs
+++ b/crates/tui/src/view/component/recipe_pane/recipe.rs
@@ -14,7 +14,6 @@ use crate::view::{
 use derive_more::Display;
 use persisted::SingletonKey;
 use ratatui::{layout::Layout, prelude::Constraint, widgets::Paragraph, Frame};
-use reqwest::header::HeaderName;
 use serde::{Deserialize, Serialize};
 use slumber_core::{
     collection::{Recipe, RecipeId},
@@ -128,22 +127,6 @@ impl RecipeDisplay {
             form_fields,
             body,
         }
-    }
-
-    /// Get the *preview* value of an HTTP header. This only includes headers
-    /// that are visible in the table, so no implied headers such as
-    /// `Authorization`
-    pub fn header(&self, name: HeaderName) -> Option<String> {
-        self.headers
-            .data()
-            .rows()
-            .find(|(k, _)| *k == name)
-            .map(|(_, value)| value.preview().text().to_string())
-    }
-
-    /// Does the recipe have a body defined?
-    pub fn has_body(&self) -> bool {
-        self.body.data().is_some()
     }
 }
 

--- a/crates/tui/src/view/component/recipe_pane/table.rs
+++ b/crates/tui/src/view/component/recipe_pane/table.rs
@@ -98,13 +98,6 @@ where
         }
     }
 
-    pub fn rows(&self) -> impl Iterator<Item = (&str, &RecipeTemplate)> {
-        self.select
-            .data()
-            .items()
-            .map(|row| (row.key.as_str(), &row.value))
-    }
-
     /// Get the set of disabled/overridden rows for this table
     pub fn to_build_overrides(&self) -> BuildFieldOverrides {
         self.select

--- a/crates/tui/src/view/state/fixed_select.rs
+++ b/crates/tui/src/view/state/fixed_select.rs
@@ -42,19 +42,6 @@ pub struct FixedSelectStateBuilder<Item, State> {
 }
 
 impl<Item, State> FixedSelectStateBuilder<Item, State> {
-    /// Disable certain items in the list by value. Disabled items can still be
-    /// selected, but do not trigger callbacks.
-    pub fn disabled_items<'a, T>(
-        mut self,
-        disabled_items: impl IntoIterator<Item = &'a T>,
-    ) -> Self
-    where
-        T: 'a + PartialEq<Item>,
-    {
-        self.inner = self.inner.disabled_items(disabled_items);
-        self
-    }
-
     /// Which types of events should this emit?
     pub fn subscribe(
         mut self,

--- a/crates/tui/src/view/state/select.rs
+++ b/crates/tui/src/view/state/select.rs
@@ -65,26 +65,6 @@ pub struct SelectStateBuilder<Item, State> {
 }
 
 impl<Item, State> SelectStateBuilder<Item, State> {
-    /// Disable certain items in the list by value. Disabled items can still be
-    /// selected, but do not emit events.
-    pub fn disabled_items<'a, T>(
-        mut self,
-        disabled_items: impl IntoIterator<Item = &'a T>,
-    ) -> Self
-    where
-        T: 'a + PartialEq<Item>,
-    {
-        // O(n^2)! We expect both lists to be very small so it's not an issue
-        for disabled in disabled_items {
-            for item in &mut self.items {
-                if disabled == &item.value {
-                    item.disabled = true;
-                }
-            }
-        }
-        self
-    }
-
     /// Disable certain items in the list by index. Disabled items can still be
     /// selected, but do not emit events.
     pub fn disabled_indexes(
@@ -514,7 +494,7 @@ mod tests {
         items: (Vec<&'static str>, List<'static>),
     ) {
         let select = SelectState::builder(items.0)
-            .disabled_items(&["c"])
+            .disabled_indexes([2])
             .subscribe([SelectStateEventType::Select])
             .build();
         let mut component =
@@ -544,7 +524,7 @@ mod tests {
         items: (Vec<&'static str>, List<'static>),
     ) {
         let select = SelectState::builder(items.0)
-            .disabled_items(&["c"])
+            .disabled_indexes([2])
             .subscribe([SelectStateEventType::Submit])
             .build();
         let mut component =

--- a/crates/tui/src/view/util.rs
+++ b/crates/tui/src/view/util.rs
@@ -5,7 +5,7 @@ pub mod persistence;
 
 use crate::{
     message::Message,
-    util::{spawn_local, temp_file},
+    util::{spawn, temp_file},
     view::ViewContext,
 };
 use anyhow::Context;
@@ -72,7 +72,7 @@ impl Debounce {
         // Run debounce in a local task so component behavior can access the
         // view context, e.g. to push events
         let duration = self.duration;
-        let handle = spawn_local(async move {
+        let handle = spawn("Debounce", async move {
             time::sleep(duration).await;
             on_complete();
         });

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,9 +96,18 @@ fn initialize_tracing(console_output: bool) {
         None
     };
 
+    // Spawn tokio subscriber server for tokio-console usage
+    #[cfg(feature = "tokio_tracing")]
+    let tokio_console_subscriber = Some(console_subscriber::spawn());
+    // console_subscriber crate isn't available - use an empty layer to fill
+    // its place
+    #[cfg(not(feature = "tokio_tracing"))]
+    let tokio_console_subscriber = None::<tracing_subscriber::fmt::Layer<_>>;
+
     tracing_subscriber::registry()
         .with(file_subscriber)
         .with(console_subscriber)
+        .with(tokio_console_subscriber)
         .init();
 }
 


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

- Fix showing incorrect error if a query fails immediately
- Fix process hanging on exit
  - This also included a lot of changes to make it easier to debug tokio tasks
- Remove some unused code that started getting reported in Rust 1.82
- Remove incorrect notification when a query command fails

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

The tokio tracing change could have a perf impact, so I hid it behind a feature flag.

## QA

_How did you test this?_

Manually

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
