### PR TITLE
Remove debounce on query box

### DIFF
--- a/crates/tui/src/view/component/queryable_body.rs
+++ b/crates/tui/src/view/component/queryable_body.rs
@@ -81,8 +81,7 @@ impl QueryableBody {
                 "{query_bind} to query, {export_bind} to export"
             ))
             .placeholder_focused("Enter query command (ex: `jq .results`)")
-            .default_value(default_query.clone().unwrap_or_default())
-            .debounce();
+            .default_value(default_query.clone().unwrap_or_default());
         // Don't use a debounce on this one, because we don't want to
         // auto-execute commands that will have a side effect
         let export_text_box = TextBox::default().placeholder_focused(
@@ -244,7 +243,7 @@ impl EventHandler for QueryableBody {
             })
             .emitted(self.query_text_box.to_emitter(), |event| match event {
                 TextBoxEvent::Focus => self.focus(CommandFocus::Query),
-                TextBoxEvent::Change => self.update_query(),
+                TextBoxEvent::Change => {}
                 TextBoxEvent::Cancel => {
                     // Reset text to whatever was submitted last
                     self.query_text_box.data_mut().set_text(


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

It's convenient in some scenarios, but with command-based filtering it ends up just being really annoying.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

This does bring us back to it being more cumbersome to do repeated filters, since you have to keep hitting `/` to get back into the search box. We could mitigate this by adding a keybind to mean "submit but stay in focus", e.g. shift+enter.

## QA

_How did you test this?_

Existing tests

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
