### PR TITLE
Scroll text box to keep cursor in view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+- Text box now scrolls to the cursor when it's off screen
+
 ## [3.0.0] - 2025-02-15
 
 A major release! The main focus of this release is the introduction of shell commands for data querying and export. Previously, you could query response bodies within the TUI only using JSONPath. This limited querying only to JSON responses, and the limited amount of operators supported by JSON. Now, you can use whatever shell commands you want (such as `head`, `grep`, and `jq`) to filter your reponses bodies, right in the TUI! [Check out the docs](https://slumber.lucaspickering.me/book/user_guide/tui/filter_query.md) for more examples.

--- a/crates/tui/src/test_util.rs
+++ b/crates/tui/src/test_util.rs
@@ -129,6 +129,7 @@ impl TestTerminal {
 
     /// Alias for
     /// [TestBackend::assert_buffer_lines](ratatui::backend::TestBackend::assert_buffer_lines)
+    #[track_caller]
     pub fn assert_buffer_lines<'a>(
         &self,
         expected: impl IntoIterator<Item = impl Into<Line<'a>>>,

--- a/crates/tui/src/view/common/text_box.rs
+++ b/crates/tui/src/view/common/text_box.rs
@@ -414,6 +414,7 @@ mod tests {
 
     /// Assert that text state matches text/cursor location. Cursor location is
     /// a *character* offset, not byte offset
+    #[track_caller]
     fn assert_state(state: &TextState, text: &str, cursor: usize) {
         assert_eq!(state.text, text, "Text does not match");
         assert_eq!(

--- a/crates/tui/src/view/test_util.rs
+++ b/crates/tui/src/view/test_util.rs
@@ -312,6 +312,7 @@ where
 
     /// Assert that no events were propagated, i.e. the component handled all
     /// given and generated events.
+    #[track_caller]
     pub fn assert_empty(self) {
         assert!(
             self.propagated.is_empty(),
@@ -323,6 +324,7 @@ where
     /// Assert that only emitted events were propagated, and those events match
     /// a specific sequence. Requires `PartialEq` to be implemented for the
     /// emitted event type.
+    #[track_caller]
     pub fn assert_emitted<E>(self, expected: impl IntoIterator<Item = E>)
     where
         Component: ToEmitter<E>,


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

The text box component (for single-line text editing) will now scroll left and right to ensure the cursor stays visible

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Bugs could make the text box broken still. It's unlikely to be any worse than it was. 

## QA

_How did you test this?_

Added a unit test, tested manually too

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
