### PR TITLE
Fix panics when the screen gets small

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - Text box now scrolls to the cursor when it's off screen
+- Fix panics when the screen gets very small [#469](https://github.com/LucasPickering/slumber/issues/469)
 
 ## [3.0.0] - 2025-02-15
 

--- a/crates/tui/src/view.rs
+++ b/crates/tui/src/view.rs
@@ -90,6 +90,13 @@ impl View {
             root.draw(frame, (), chunk, true);
         }
 
+        // If the screen is too small to render anything, don't try. This avoids
+        // panics within ratatui from trying to render borders and margins
+        // outside the buffer area
+        if frame.area().width <= 1 || frame.area().height <= 1 {
+            return;
+        }
+
         // If debug monitor is enabled, use it to capture the view duration
         if let Some(debug_monitor) = &self.debug_monitor {
             debug_monitor.draw(frame, |frame| draw_impl(&self.root, frame));

--- a/crates/tui/src/view/common/scrollbar.rs
+++ b/crates/tui/src/view/common/scrollbar.rs
@@ -97,12 +97,12 @@ impl Widget for Scrollbar {
                 .thumb_symbol(thumb_symbol)
                 .end_symbol(Some(end_symbol));
 
-        StatefulWidget::render(
-            scrollbar,
-            area.offset(offset),
-            buf,
-            &mut self.state(area),
-        );
+        let area = area.offset(offset);
+        // Avoid panic if there's nowhere to render the scroll bar. This can
+        // occur if the screen gets really small
+        if !area.is_empty() {
+            StatefulWidget::render(scrollbar, area, buf, &mut self.state(area));
+        }
     }
 }
 


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

There were a few different situations where the screen getting very small would cause a panic within ratatui. Fixed these in two different ways:

- Don't attempt to render _anything_ when the width or height is <= 1
- Don't attempt to render a scrollbar if its area is empty

Closes #469 

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

- Panics may still exist in other scenarios that I missed
- Disabling rendering when the screen is very small could lead to some odd state bugs

## QA

_How did you test this?_

Manually, by shrinking the screen way down and confirming it doesn't panic

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
