### PR TITLE
Attempt to fix panic cleanup issues

### DIFF
--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -87,7 +87,6 @@ impl Tui {
     /// Start the TUI. Any errors that occur during startup will be panics,
     /// because they prevent TUI execution.
     pub async fn start(collection_path: Option<PathBuf>) -> anyhow::Result<()> {
-        initialize_panic_handler();
         let collection_path = CollectionFile::try_path(None, collection_path)?;
 
         // ===== Initialize global state =====
@@ -710,13 +709,14 @@ impl Drop for Tui {
 fn initialize_panic_handler() {
     let original_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |panic_info| {
-        restore_terminal().unwrap();
+        let _ = restore_terminal();
         original_hook(panic_info);
     }));
 }
 
 /// Set up terminal for TUI
 fn initialize_terminal() -> anyhow::Result<Term> {
+    initialize_panic_handler();
     crossterm::terminal::enable_raw_mode()?;
     let mut stdout = io::stdout();
     crossterm::execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

I've noticed some issues with the app occasionally not cleaning up the terminal properly on exit. I've never been able to pin down why or reproduce it reliably, but this is a mild attempt at fixing it.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Still broken

## QA

_How did you test this?_

I tested manual quitting a panics still clean up like normal, as far as I can tell

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
