### PR TITLE
Add `history clear` and `history delete` subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Add `slumber history delete` and `slumber history clear` for deleting request history
+
 ### Changed
 
 - Upgrade to Rust 1.85 (2024 edition!)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1977,9 +1977,9 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.21.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afd55a67069d6e434a95161415f5beeada95a01c7b815508a82dcb0e1593682"
+checksum = "03e905296805ab93e13c1ec3a03f4b6c4f35e9498a3d5fa96dc626d22c03cd89"
 dependencies = [
  "rstest_macros",
  "rustc_version",
@@ -1987,9 +1987,9 @@ dependencies = [
 
 [[package]]
 name = "rstest_macros"
-version = "0.21.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4165dfae59a39dd41d8dec720d3cbfbc71f69744efb480a3920f5d4e0cc6798d"
+checksum = "ef0053bbffce09062bee4bcc499b0fbe7a57b879f1efe088d6d8d4c7adcdef9b"
 dependencies = [
  "cfg-if",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ mime = "0.3.17"
 pretty_assertions = "1.4.0"
 ratatui = {version = "0.28.0", default-features = false}
 reqwest = {version = "0.12.5", default-features = false}
-rstest = {version = "0.21.0", default-features = false}
+rstest = {version = "0.24.0", default-features = false}
 serde = {version = "1.0.204", default-features = false}
 serde_json = {version = "1.0.120", default-features = false, features = ["preserve_order"]}
 serde_test = "1.0.176"

--- a/crates/cli/src/commands/request.rs
+++ b/crates/cli/src/commands/request.rs
@@ -10,7 +10,7 @@ use indexmap::IndexMap;
 use itertools::Itertools;
 use slumber_config::Config;
 use slumber_core::{
-    collection::{Collection, CollectionFile, ProfileId, RecipeId},
+    collection::{Collection, ProfileId, RecipeId},
     db::{CollectionDatabase, Database, DatabaseMode},
     http::{
         BuildOptions, HttpEngine, RequestRecord, RequestSeed, RequestTicket,
@@ -152,7 +152,7 @@ impl BuildRequestCommand {
         global: GlobalArgs,
         trigger_dependencies: bool,
     ) -> anyhow::Result<(CollectionDatabase, RequestTicket)> {
-        let collection_path = CollectionFile::try_path(None, global.file)?;
+        let collection_path = global.collection_path()?;
         let config = Config::load()?;
         let collection = Collection::load(&collection_path)?;
         // Open DB in readonly. Storing requests in history from the CLI isn't

--- a/crates/cli/src/commands/show.rs
+++ b/crates/cli/src/commands/show.rs
@@ -2,11 +2,7 @@ use crate::{GlobalArgs, Subcommand};
 use clap::Parser;
 use serde::Serialize;
 use slumber_config::Config;
-use slumber_core::{
-    collection::{Collection, CollectionFile},
-    db::Database,
-    util::paths,
-};
+use slumber_core::{collection::Collection, db::Database, util::paths};
 use std::{borrow::Cow, path::Path, process::ExitCode};
 
 /// Print meta information about Slumber (config, collections, etc.)
@@ -30,8 +26,7 @@ impl Subcommand for ShowCommand {
     async fn execute(self, global: GlobalArgs) -> anyhow::Result<ExitCode> {
         match self.target {
             ShowTarget::Paths => {
-                let collection_path =
-                    CollectionFile::try_path(None, global.file);
+                let collection_path = global.collection_path();
                 println!("Config: {}", Config::path().display());
                 println!("Database: {}", Database::path().display());
                 println!("Log file: {}", paths::log_file().display());
@@ -48,8 +43,7 @@ impl Subcommand for ShowCommand {
                 println!("{}", to_yaml(&config));
             }
             ShowTarget::Collection => {
-                let collection_path =
-                    CollectionFile::try_path(None, global.file)?;
+                let collection_path = global.collection_path()?;
                 let collection = Collection::load(&collection_path)?;
                 println!("{}", to_yaml(&collection));
             }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -17,6 +17,7 @@ use crate::commands::{
 };
 use clap::{CommandFactory, Parser};
 use clap_complete::CompleteEnv;
+use slumber_core::collection::CollectionFile;
 use std::{path::PathBuf, process::ExitCode};
 
 const COMMAND_NAME: &str = "slumber";
@@ -58,6 +59,14 @@ pub struct GlobalArgs {
     /// logic from the given directory rather than the current.
     #[clap(long, short)]
     pub file: Option<PathBuf>,
+}
+
+impl GlobalArgs {
+    /// Get the path to the active collection file. Return an error if there is
+    /// no collection file present, or if the user specified an invalid file.
+    fn collection_path(&self) -> anyhow::Result<PathBuf> {
+        CollectionFile::try_path(None, self.file.clone())
+    }
 }
 
 /// A CLI subcommand

--- a/crates/core/src/collection/models.rs
+++ b/crates/core/src/collection/models.rs
@@ -261,6 +261,16 @@ impl From<&str> for RecipeId {
     }
 }
 
+/// For rstest magic conversions
+#[cfg(any(test, feature = "test"))]
+impl FromStr for RecipeId {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok::<_, ()>(s.to_owned().into())
+    }
+}
+
 #[cfg(any(test, feature = "test"))]
 impl crate::test_util::Factory for RecipeId {
     fn factory(_: ()) -> Self {

--- a/crates/core/src/db/migrations.rs
+++ b/crates/core/src/db/migrations.rs
@@ -1,4 +1,4 @@
-use dialoguer::Confirm;
+use crate::util::confirm;
 use rusqlite::Transaction;
 use rusqlite_migration::{HookError, HookResult, M, Migrations};
 
@@ -127,19 +127,14 @@ fn migrate_requests_v2(transaction: &Transaction) -> HookResult {
             row.get::<_, u64>(0)
         })?;
     if old_requests_count > 0 {
-        let delete = Confirm::new()
-            .with_prompt(
-                "You are upgrading from Slumber <1.8.0 to Slumber >=3.0.0. \
+        let delete = confirm(
+            "You are upgrading from Slumber <1.8.0 to Slumber >=3.0.0. \
                 Your request history database contains old requests that \
                 cannot be migrated directly to a newer format. You can proceed \
                 with the upgrade by DELETING THE OLD REQUESTS now, or you can \
                 retain the requests by upgrading to an intermediate version \
                 first.\nWould you like to DELETE YOUR REQUEST HISTORY?",
-            )
-            .default(false)
-            .wait_for_newline(true)
-            .interact()
-            .unwrap_or(false);
+        );
         if delete {
             // We can just proceed and a future migration will drop the old
             // table

--- a/crates/core/src/db/tests.rs
+++ b/crates/core/src/db/tests.rs
@@ -1,0 +1,376 @@
+use super::*;
+use crate::{assert_err, test_util::Factory, util::paths::get_repo_root};
+use indexmap::IndexMap;
+use itertools::Itertools;
+use rstest::{fixture, rstest};
+use std::collections::HashMap;
+
+impl CollectionDatabase {
+    fn count_requests(&self) -> usize {
+        self.database
+            .connection()
+            .query_row(
+                "SELECT COUNT(*) FROM requests_v2
+                WHERE collection_id = :collection_id",
+                named_params! {
+                    ":collection_id": self.collection_id(),
+                },
+                |row| row.get(0),
+            )
+            .unwrap()
+    }
+}
+
+#[fixture]
+fn collection_path() -> PathBuf {
+    get_repo_root().join("slumber.yml")
+}
+
+#[fixture]
+fn other_collection_path() -> PathBuf {
+    get_repo_root().join("README.md") // Has to be a real file
+}
+
+/// Populate a DB with two collections, and a few exchanges in each one
+#[fixture]
+fn request_db(
+    collection_path: PathBuf,
+    other_collection_path: PathBuf,
+) -> RequestDb {
+    let database = Database::factory(());
+    let collection1 = database
+        .clone()
+        .into_collection(&collection_path, DatabaseMode::ReadWrite)
+        .unwrap();
+    let collection2 = database
+        .clone()
+        .into_collection(&other_collection_path, DatabaseMode::ReadWrite)
+        .unwrap();
+
+    // We separate requests by 3 columns. Create multiple of each column to
+    // make sure we filter by each column correctly
+    let collections = [collection1, collection2];
+
+    // Store the created request ID for each cell in the matrix, so we can
+    // compare to what the DB spits back later
+    let mut request_ids: IndexMap<
+        (CollectionId, Option<ProfileId>, RecipeId),
+        RequestId,
+    > = Default::default();
+
+    // Create and insert each request
+    for collection in &collections {
+        for profile_id in [None, Some("profile1"), Some("profile2")] {
+            for recipe_id in ["recipe1", "recipe2"] {
+                let recipe_id: RecipeId = recipe_id.into();
+                let profile_id = profile_id.map(ProfileId::from);
+                let exchange =
+                    Exchange::factory((profile_id.clone(), recipe_id.clone()));
+                collection.insert_exchange(&exchange).unwrap();
+                request_ids.insert(
+                    (collection.collection_id(), profile_id, recipe_id),
+                    exchange.id,
+                );
+            }
+        }
+    }
+
+    RequestDb {
+        database,
+        collections,
+        request_ids,
+    }
+}
+
+struct RequestDb {
+    database: Database,
+    collections: [CollectionDatabase; 2],
+    /// A map of the request IDs we inserted for each (collection, profile,
+    /// recipe) key. This makes it possible to do assertions on the inserted
+    /// IDs
+    request_ids:
+        IndexMap<(CollectionId, Option<ProfileId>, RecipeId), RequestId>,
+}
+
+#[rstest]
+fn test_merge(collection_path: PathBuf, other_collection_path: PathBuf) {
+    let database = Database::factory(());
+    let collection1 = database
+        .clone()
+        .into_collection(&collection_path, DatabaseMode::ReadWrite)
+        .unwrap();
+    let collection2 = database
+        .clone()
+        .into_collection(&other_collection_path, DatabaseMode::ReadWrite)
+        .unwrap();
+
+    let exchange1 =
+        Exchange::factory((Some("profile1".into()), "recipe1".into()));
+    let exchange2 =
+        Exchange::factory((Some("profile1".into()), "recipe1".into()));
+    let profile_id = exchange1.request.profile_id.as_ref();
+    let recipe_id = &exchange1.request.recipe_id;
+    let key_type = "MyKey";
+    let ui_key = "key1";
+    collection1.insert_exchange(&exchange1).unwrap();
+    collection1.set_ui(key_type, ui_key, "value1").unwrap();
+    collection2.insert_exchange(&exchange2).unwrap();
+    collection2.set_ui(key_type, ui_key, "value2").unwrap();
+
+    // Sanity checks
+    assert_eq!(
+        collection1
+            .get_latest_request(profile_id.into(), recipe_id)
+            .unwrap()
+            .unwrap()
+            .id,
+        exchange1.id
+    );
+    assert_eq!(
+        collection1.get_ui::<_, String>(key_type, ui_key).unwrap(),
+        Some("value1".into())
+    );
+    assert_eq!(
+        collection2
+            .get_latest_request(profile_id.into(), recipe_id)
+            .unwrap()
+            .unwrap()
+            .id,
+        exchange2.id
+    );
+    assert_eq!(
+        collection2.get_ui::<_, String>(key_type, ui_key).unwrap(),
+        Some("value2".into())
+    );
+
+    // Do the merge
+    database
+        .merge_collections(&other_collection_path, &collection_path)
+        .unwrap();
+
+    // Collection 2 values should've overwritten
+    assert_eq!(
+        collection1
+            .get_latest_request(profile_id.into(), recipe_id)
+            .unwrap()
+            .unwrap()
+            .id,
+        exchange2.id
+    );
+    assert_eq!(
+        collection1.get_ui::<_, String>(key_type, ui_key).unwrap(),
+        Some("value2".into())
+    );
+
+    // Make sure collection2 was deleted
+    assert_eq!(
+        database.collections().unwrap(),
+        vec![collection_path.canonicalize().unwrap()]
+    );
+}
+
+/// Test request storage and retrieval
+#[rstest]
+fn test_request(request_db: RequestDb) {
+    // Try to find each inserted recipe individually. Also try some
+    // expected non-matches
+    for collection in &request_db.collections {
+        for profile_id in [None, Some("profile1"), Some("extra_profile")] {
+            for recipe_id in ["recipe1", "extra_recipe"] {
+                let collection_id = collection.collection_id();
+                let profile_id = profile_id.map(ProfileId::from);
+                let recipe_id = recipe_id.into();
+
+                // Leave the Option here so a non-match will trigger a handy
+                // assertion error
+                let exchange_id = collection
+                    .get_latest_request(profile_id.as_ref().into(), &recipe_id)
+                    .unwrap()
+                    .map(|exchange| exchange.id);
+                let expected_id = request_db.request_ids.get(&(
+                    collection_id,
+                    profile_id.clone(),
+                    recipe_id.clone(),
+                ));
+
+                assert_eq!(
+                    exchange_id.as_ref(),
+                    expected_id,
+                    "Request mismatch for collection = {collection_id}, \
+                        profile = {profile_id:?}, recipe = {recipe_id}"
+                );
+            }
+        }
+    }
+}
+
+/// Test fetching all requests for a single recipe
+#[test]
+fn test_get_recipe_requests() {
+    let database = CollectionDatabase::factory(());
+
+    // Create and insert multiple requests per profile+recipe.
+    // Store the created request ID for each cell in the matrix, so we can
+    // compare to what the DB spits back later
+    let mut request_ids: HashMap<
+        (Option<ProfileId>, RecipeId),
+        Vec<RequestId>,
+    > = Default::default();
+    for profile_id in [None, Some("profile1"), Some("profile2")] {
+        for recipe_id in ["recipe1", "recipe2"] {
+            let recipe_id: RecipeId = recipe_id.into();
+            let profile_id = profile_id.map(ProfileId::from);
+            let mut ids = (0..3)
+                .map(|_| {
+                    let exchange = Exchange::factory((
+                        profile_id.clone(),
+                        recipe_id.clone(),
+                    ));
+                    database.insert_exchange(&exchange).unwrap();
+                    exchange.id
+                })
+                .collect_vec();
+            // Order newest->oldest, that's the response we expect
+            ids.reverse();
+            request_ids.insert((profile_id, recipe_id), ids);
+        }
+    }
+
+    // Try to find each inserted recipe individually. Also try some
+    // expected non-matches
+    for profile_id in [None, Some("profile1"), Some("extra_profile")] {
+        for recipe_id in ["recipe1", "extra_recipe"] {
+            let profile_id = profile_id.map(ProfileId::from);
+            let recipe_id = recipe_id.into();
+
+            // Leave the Option here so a non-match will trigger a handy
+            // assertion error
+            let ids = database
+                .get_recipe_requests(profile_id.as_ref().into(), &recipe_id)
+                .unwrap()
+                .into_iter()
+                .map(|exchange| exchange.id)
+                .collect_vec();
+            let expected_id = request_ids
+                .get(&(profile_id.clone(), recipe_id.clone()))
+                .cloned()
+                .unwrap_or_default();
+
+            assert_eq!(
+                ids, expected_id,
+                "Requests mismatch for \
+                    profile = {profile_id:?}, recipe = {recipe_id}"
+            );
+        }
+    }
+
+    // Load all requests for a recipe (across all profiles)
+    let recipe_id = "recipe1".into();
+    let ids = database
+        .get_recipe_requests(ProfileFilter::All, &recipe_id)
+        .unwrap()
+        .into_iter()
+        .map(|exchange| exchange.id)
+        .sorted()
+        .collect_vec();
+    let expected_ids = request_ids
+        .iter()
+        .filter(|((_, r), _)| r == &recipe_id)
+        .flat_map(|(_, request_ids)| request_ids)
+        .sorted()
+        .copied()
+        .collect_vec();
+    assert_eq!(ids, expected_ids)
+}
+
+/// Test deleting all requests for all collections
+#[rstest]
+fn test_database_delete_all_requests(request_db: RequestDb) {
+    let [collection1, collection2] = request_db.collections;
+    assert_eq!(request_db.database.delete_all_requests().unwrap(), 12);
+    assert_eq!(collection1.count_requests(), 0);
+    assert_eq!(collection2.count_requests(), 0);
+}
+
+/// Test deleting all requests for a collection
+#[rstest]
+fn test_collection_delete_all_requests(request_db: RequestDb) {
+    let [collection1, collection2] = request_db.collections;
+    assert_eq!(collection1.delete_all_requests().unwrap(), 6);
+    assert_eq!(collection1.count_requests(), 0);
+    assert_eq!(collection2.count_requests(), 6);
+}
+
+/// Test deleting all requests for a recipe/profile combo
+#[rstest]
+#[case(ProfileFilter::All, "recipe1", 3)]
+#[case(ProfileFilter::Some(Cow::Owned("profile1".into())), "recipe1", 1)]
+#[case(ProfileFilter::None, "recipe1", 1)]
+fn test_delete_recipe_requests(
+    request_db: RequestDb,
+    #[case] profile_filter: ProfileFilter<'static>,
+    #[case] recipe_id: RecipeId,
+    #[case] expected_deleted: usize,
+) {
+    let [collection1, collection2] = request_db.collections;
+    assert_eq!(
+        collection1
+            .delete_recipe_requests(profile_filter, &recipe_id)
+            .unwrap(),
+        expected_deleted
+    );
+    assert_eq!(collection1.count_requests(), 6 - expected_deleted);
+    assert_eq!(collection2.count_requests(), 6);
+}
+
+/// Test deleting a specific request
+#[rstest]
+fn test_delete_request(request_db: RequestDb) {
+    let [collection1, collection2] = request_db.collections;
+    let request_id = *request_db.request_ids.first().unwrap().1;
+
+    assert_eq!(collection1.delete_request(request_id).unwrap(), 1);
+    assert_eq!(collection1.count_requests(), 5);
+    assert_eq!(collection2.count_requests(), 6);
+}
+
+/// Test UI state storage and retrieval
+#[rstest]
+fn test_ui_state(collection_path: PathBuf) {
+    let database = Database::factory(());
+    let collection1 = database
+        .clone()
+        .into_collection(&collection_path, DatabaseMode::ReadWrite)
+        .unwrap();
+    let collection2 = database
+        .clone()
+        .into_collection(Path::new("Cargo.toml"), DatabaseMode::ReadWrite)
+        .unwrap();
+
+    let key_type = "MyKey";
+    let ui_key = "key1";
+    collection1.set_ui(key_type, ui_key, "value1").unwrap();
+    collection2.set_ui(key_type, ui_key, "value2").unwrap();
+
+    assert_eq!(
+        collection1.get_ui::<_, String>(key_type, ui_key).unwrap(),
+        Some("value1".into())
+    );
+    assert_eq!(
+        collection2.get_ui::<_, String>(key_type, ui_key).unwrap(),
+        Some("value2".into())
+    );
+}
+
+#[test]
+fn test_readonly_mode() {
+    let database = CollectionDatabase::factory(DatabaseMode::ReadOnly);
+    assert_err!(
+        database.insert_exchange(&Exchange::factory(())),
+        "Database in read-only mode"
+    );
+    assert_err!(
+        database.set_ui("MyKey", "key1", "value1"),
+        "Database in read-only mode"
+    );
+}

--- a/crates/core/src/util.rs
+++ b/crates/core/src/util.rs
@@ -8,6 +8,7 @@ use chrono::{
     format::{DelayedFormat, StrftimeItems},
 };
 use derive_more::{DerefMut, Display};
+use dialoguer::Confirm;
 use serde::de::DeserializeOwned;
 use std::{
     collections::{HashMap, hash_map::Entry},
@@ -89,6 +90,16 @@ pub fn format_byte_size(size: usize) -> String {
     };
     let size = size as f64 / denom as f64;
     format!("{size:.1} {suffix}B")
+}
+
+/// Show the user a confirmation prompt
+pub fn confirm(prompt: impl Into<String>) -> bool {
+    Confirm::new()
+        .with_prompt(prompt)
+        .default(false)
+        .wait_for_newline(true)
+        .interact()
+        .unwrap_or(false)
 }
 
 /// Extension trait for [Result]

--- a/crates/tui/src/http.rs
+++ b/crates/tui/src/http.rs
@@ -268,7 +268,7 @@ impl RequestStore {
         // store, because they don't include request/response data
         let loaded = self
             .database
-            .get_all_requests(profile_id.into(), recipe_id)?;
+            .get_recipe_requests(profile_id.into(), recipe_id)?;
 
         // Find what we have in memory already
         let iter = self


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Add two new subcommands for deleting old history:

- `slumber history delete <recipe/request>` - delete a single request, or all requests for a recipe
- `slumber history clear [--all]` - delete all requests for a collection, or ALL collections

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

This command is dangerous. Mitigated with confirmation dialogues for the more destructive ones

## QA

_How did you test this?_

Added unit tests on the DB. Still need to add CLI tests

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
