### PR TITLE
Add `slumber history delete` subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Add `slumber history delete` subcommand for deleting request history
+
 ### Changed
 
 - Upgrade to Rust 1.85 (2024 edition!)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1977,9 +1977,9 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.21.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afd55a67069d6e434a95161415f5beeada95a01c7b815508a82dcb0e1593682"
+checksum = "03e905296805ab93e13c1ec3a03f4b6c4f35e9498a3d5fa96dc626d22c03cd89"
 dependencies = [
  "rstest_macros",
  "rustc_version",
@@ -1987,9 +1987,9 @@ dependencies = [
 
 [[package]]
 name = "rstest_macros"
-version = "0.21.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4165dfae59a39dd41d8dec720d3cbfbc71f69744efb480a3920f5d4e0cc6798d"
+checksum = "ef0053bbffce09062bee4bcc499b0fbe7a57b879f1efe088d6d8d4c7adcdef9b"
 dependencies = [
  "cfg-if",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ mime = "0.3.17"
 pretty_assertions = "1.4.0"
 ratatui = {version = "0.28.0", default-features = false}
 reqwest = {version = "0.12.5", default-features = false}
-rstest = {version = "0.21.0", default-features = false}
+rstest = {version = "0.24.0", default-features = false}
 serde = {version = "1.0.204", default-features = false}
 serde_json = {version = "1.0.120", default-features = false, features = ["preserve_order"]}
 serde_test = "1.0.176"

--- a/crates/cli/src/commands/collections.rs
+++ b/crates/cli/src/commands/collections.rs
@@ -1,6 +1,6 @@
 use crate::{GlobalArgs, Subcommand};
 use clap::Parser;
-use slumber_core::db::Database;
+use slumber_core::db::{Database, DatabaseMode};
 use std::{path::PathBuf, process::ExitCode};
 
 /// View and modify request collection metadata
@@ -29,14 +29,15 @@ enum CollectionsSubcommand {
 
 impl Subcommand for CollectionsCommand {
     async fn execute(self, _global: GlobalArgs) -> anyhow::Result<ExitCode> {
-        let database = Database::load()?;
         match self.subcommand {
             CollectionsSubcommand::List => {
+                let database = Database::load(DatabaseMode::ReadOnly)?;
                 for path in database.collections()? {
                     println!("{}", path.display());
                 }
             }
             CollectionsSubcommand::Migrate { from, to } => {
+                let database = Database::load(DatabaseMode::ReadWrite)?;
                 database.merge_collections(&from, &to)?;
                 println!("Migrated {} into {}", from.display(), to.display());
             }

--- a/crates/cli/src/commands/history.rs
+++ b/crates/cli/src/commands/history.rs
@@ -1,20 +1,24 @@
 use crate::{
     GlobalArgs, Subcommand,
     commands::request::DisplayExchangeCommand,
-    completions::{complete_profile, complete_recipe},
+    completions::{complete_profile, complete_recipe, complete_request_id},
 };
-use anyhow::anyhow;
+use anyhow::{anyhow, bail};
 use clap::Parser;
 use clap_complete::ArgValueCompleter;
 use slumber_core::{
-    collection::{CollectionFile, ProfileId, RecipeId},
+    collection::{ProfileId, RecipeId},
     db::{Database, DatabaseMode, ProfileFilter},
     http::{ExchangeSummary, RequestId},
-    util::format_time_iso,
+    util::{confirm, format_time_iso},
 };
 use std::{process::ExitCode, str::FromStr};
 
-/// View request history
+/// View and modify request history
+///
+/// Requests made in the Slumber TUI are stored in a local database so past
+/// requests can be viewed in the TUI. This subcommand allows you to browse and
+/// prune that history.
 #[derive(Clone, Debug, Parser)]
 pub struct HistoryCommand {
     #[command(subcommand)]
@@ -43,17 +47,32 @@ enum HistorySubcommand {
         profile: Option<Option<ProfileId>>,
     },
 
-    /// Print an entire request/response
+    /// Get a single request/response
     Get {
         /// ID of the request to print. Pass a recipe ID to get the most recent
         /// request for that recipe
-        // Autocomplete recipe IDs, because users won't ever be typing request
-        // IDs by hand
-        #[clap(add = ArgValueCompleter::new(complete_recipe))]
+        #[clap(
+            // Autocomplete recipe IDs, because users won't ever be typing request
+            // IDs by hand
+            add = ArgValueCompleter::new(complete_recipe),
+        )]
         request: RecipeOrRequest,
 
         #[clap(flatten)]
         display: DisplayExchangeCommand,
+    },
+
+    /// Delete requests from history
+    ///
+    /// The subcommand selects which request(s) to delete. This operation is
+    /// irreversible!
+    Delete {
+        #[clap(subcommand)]
+        selection: RequestSelection,
+
+        /// Skip the confirmation prompt
+        #[clap(long, short)]
+        yes: bool,
     },
 }
 
@@ -65,22 +84,22 @@ enum RecipeOrRequest {
 
 impl Subcommand for HistoryCommand {
     async fn execute(self, global: GlobalArgs) -> anyhow::Result<ExitCode> {
-        let collection_path = CollectionFile::try_path(None, global.file)?;
-        let database = Database::load()?
-            .into_collection(&collection_path, DatabaseMode::ReadOnly)?;
-
         match self.subcommand {
             HistorySubcommand::List { recipe, profile } => {
-                let profile_filter = match &profile {
-                    None => ProfileFilter::All,
-                    Some(None) => ProfileFilter::None,
-                    Some(Some(profile_id)) => ProfileFilter::Some(profile_id),
-                };
+                let database = Database::load()?.into_collection(
+                    &global.collection_path()?,
+                    DatabaseMode::ReadOnly,
+                )?;
                 let exchanges =
-                    database.get_all_requests(profile_filter, &recipe)?;
-                Self::print_list(exchanges);
+                    database.get_recipe_requests(profile.into(), &recipe)?;
+                print_list(exchanges);
             }
+
             HistorySubcommand::Get { request, display } => {
+                let database = Database::load()?.into_collection(
+                    &global.collection_path()?,
+                    DatabaseMode::ReadOnly,
+                )?;
                 let exchange = match request {
                     RecipeOrRequest::Recipe(recipe_id) => database
                         .get_latest_request(ProfileFilter::All, &recipe_id)?
@@ -96,22 +115,71 @@ impl Subcommand for HistoryCommand {
                 display.write_request(&exchange.request);
                 display.write_response(&exchange.response)?;
             }
+
+            HistorySubcommand::Delete { selection, yes } => {
+                if !yes {
+                    // Confirmation prompt
+                    let prompt = match &selection {
+                        RequestSelection::All => {
+                            "Delete ALL requests?".to_owned()
+                        }
+                        RequestSelection::Collection => {
+                            let collection_path = global.collection_path()?;
+                            format!(
+                                "Delete requests for {}?",
+                                collection_path.display()
+                            )
+                        }
+                        RequestSelection::Recipe { recipe, profile } => {
+                            let profile_label = match profile {
+                                None => "all profiles",
+                                Some(None) => "no profile",
+                                Some(Some(profile_id)) => profile_id,
+                            };
+                            format!(
+                                "Delete requests for recipe `{recipe}` \
+                                ({profile_label})?"
+                            )
+                        }
+                        RequestSelection::Request { request } => {
+                            format!("Delete request `{}`?", request)
+                        }
+                    };
+                    if !confirm(prompt) {
+                        bail!("Cancelled");
+                    }
+                }
+
+                // Do the deletion
+                let deleted = match selection {
+                    RequestSelection::All => {
+                        let database = Database::load()?;
+                        database.delete_all_requests()?
+                    }
+                    RequestSelection::Collection => {
+                        let database = Database::load()?.into_collection(
+                            &global.collection_path()?,
+                            DatabaseMode::ReadWrite,
+                        )?;
+                        database.delete_all_requests()?
+                    }
+                    RequestSelection::Recipe { recipe, profile } => {
+                        let database = Database::load()?.into_collection(
+                            &global.collection_path()?,
+                            DatabaseMode::ReadWrite,
+                        )?;
+                        database
+                            .delete_recipe_requests(profile.into(), &recipe)?
+                    }
+                    RequestSelection::Request { request } => {
+                        let database = Database::load()?;
+                        database.delete_request(request)?
+                    }
+                };
+                println!("Deleted {deleted} request(s)");
+            }
         }
         Ok(ExitCode::SUCCESS)
-    }
-}
-
-impl HistoryCommand {
-    fn print_list(exchanges: Vec<ExchangeSummary>) {
-        for exchange in exchanges {
-            println!(
-                "{}\t{}\t{}\t{}",
-                exchange.profile_id.as_deref().unwrap_or_default(),
-                exchange.id,
-                exchange.status.as_str(),
-                format_time_iso(&exchange.start_time),
-            );
-        }
     }
 }
 
@@ -124,5 +192,55 @@ impl FromStr for RecipeOrRequest {
             .unwrap_or_else(|_| {
                 RecipeOrRequest::Recipe(RecipeId::from(s.to_owned()))
             }))
+    }
+}
+
+/// An abstraction for a subcommand that supports selecting multiple requests
+/// at once.
+#[derive(Clone, Debug, Parser)]
+enum RequestSelection {
+    /// Select all requests across all collections
+    All,
+    /// Select all requests for the current collection
+    Collection,
+    /// Select all requests for a recipe in the current collection
+    ///
+    /// Note: The recipe does not have to currently be in the collection file.
+    /// You can view and modify history for recipes that have since been removed
+    /// from the collection file.
+    Recipe {
+        /// Recipe to select requests for
+        #[clap(add = ArgValueCompleter::new(complete_recipe))]
+        recipe: RecipeId,
+        /// Optional filter to select requests for only a single profile. To
+        /// select requests that were run under _no_ profile, pass `--profile`
+        /// with no value.
+        #[clap(
+            long = "profile",
+            short,
+            add = ArgValueCompleter::new(complete_profile),
+        )]
+        // None -> All profiles
+        // Some(None) -> No profile
+        // Some(Some("profile1")) -> profile1
+        profile: Option<Option<ProfileId>>,
+    },
+    /// Select a single request by ID
+    Request {
+        #[clap(add = ArgValueCompleter::new(complete_request_id))]
+        request: RequestId,
+    },
+}
+
+/// Print request history as a table
+fn print_list(exchanges: Vec<ExchangeSummary>) {
+    for exchange in exchanges {
+        println!(
+            "{}\t{}\t{}\t{}",
+            exchange.profile_id.as_deref().unwrap_or_default(),
+            exchange.id,
+            exchange.status.as_str(),
+            format_time_iso(&exchange.start_time),
+        );
     }
 }

--- a/crates/cli/src/commands/request.rs
+++ b/crates/cli/src/commands/request.rs
@@ -10,7 +10,7 @@ use indexmap::IndexMap;
 use itertools::Itertools;
 use slumber_config::Config;
 use slumber_core::{
-    collection::{Collection, CollectionFile, ProfileId, RecipeId},
+    collection::{Collection, ProfileId, RecipeId},
     db::{CollectionDatabase, Database, DatabaseMode},
     http::{
         BuildOptions, HttpEngine, RequestRecord, RequestSeed, RequestTicket,
@@ -152,7 +152,7 @@ impl BuildRequestCommand {
         global: GlobalArgs,
         trigger_dependencies: bool,
     ) -> anyhow::Result<(CollectionDatabase, RequestTicket)> {
-        let collection_path = CollectionFile::try_path(None, global.file)?;
+        let collection_path = global.collection_path()?;
         let config = Config::load()?;
         let collection = Collection::load(&collection_path)?;
         // Open DB in readonly. Storing requests in history from the CLI isn't

--- a/crates/cli/src/commands/request.rs
+++ b/crates/cli/src/commands/request.rs
@@ -158,8 +158,8 @@ impl BuildRequestCommand {
         // Open DB in readonly. Storing requests in history from the CLI isn't
         // really intuitive, and could have a large perf impact for scripting
         // and large responses
-        let database = Database::load()?
-            .into_collection(&collection_path, DatabaseMode::ReadOnly)?;
+        let database = Database::load(DatabaseMode::ReadOnly)?
+            .into_collection(&collection_path)?;
         let http_engine = HttpEngine::new(&config.http);
 
         // Validate profile ID, so we can provide a good error if it's invalid

--- a/crates/cli/src/commands/show.rs
+++ b/crates/cli/src/commands/show.rs
@@ -2,11 +2,7 @@ use crate::{GlobalArgs, Subcommand};
 use clap::Parser;
 use serde::Serialize;
 use slumber_config::Config;
-use slumber_core::{
-    collection::{Collection, CollectionFile},
-    db::Database,
-    util::paths,
-};
+use slumber_core::{collection::Collection, db::Database, util::paths};
 use std::{borrow::Cow, path::Path, process::ExitCode};
 
 /// Print meta information about Slumber (config, collections, etc.)
@@ -30,8 +26,7 @@ impl Subcommand for ShowCommand {
     async fn execute(self, global: GlobalArgs) -> anyhow::Result<ExitCode> {
         match self.target {
             ShowTarget::Paths => {
-                let collection_path =
-                    CollectionFile::try_path(None, global.file);
+                let collection_path = global.collection_path();
                 println!("Config: {}", Config::path().display());
                 println!("Database: {}", Database::path().display());
                 println!("Log file: {}", paths::log_file().display());
@@ -48,8 +43,7 @@ impl Subcommand for ShowCommand {
                 println!("{}", to_yaml(&config));
             }
             ShowTarget::Collection => {
-                let collection_path =
-                    CollectionFile::try_path(None, global.file)?;
+                let collection_path = global.collection_path()?;
                 let collection = Collection::load(&collection_path)?;
                 println!("{}", to_yaml(&collection));
             }

--- a/crates/cli/src/completions.rs
+++ b/crates/cli/src/completions.rs
@@ -1,7 +1,16 @@
 //! Shell completion utilities
+//!
+//! To test this locally:
+//! - `cargo install --path .` (current version of Slumber must be in $PATH)
+//! - `COMPLETE=<shell> slumber` and pipe that to `source`
+//!
+//! That will enable completions for the current shell
 
 use clap_complete::CompletionCandidate;
-use slumber_core::collection::{Collection, CollectionFile};
+use slumber_core::{
+    collection::{Collection, CollectionFile, ProfileId},
+    db::Database,
+};
 use std::{ffi::OsStr, ops::Deref};
 
 /// Provide completions for profile IDs
@@ -10,7 +19,10 @@ pub fn complete_profile(current: &OsStr) -> Vec<CompletionCandidate> {
         return Vec::new();
     };
 
-    get_candidates(collection.profiles.keys(), current)
+    get_candidates(
+        collection.profiles.keys().map(ProfileId::to_string),
+        current,
+    )
 }
 
 /// Provide completions for recipe IDs
@@ -24,7 +36,23 @@ pub fn complete_recipe(current: &OsStr) -> Vec<CompletionCandidate> {
             .recipes
             .iter()
             // Include recipe IDs only. Folder IDs are never passed to the CLI
-            .filter_map(|(_, node)| Some(&node.recipe()?.id)),
+            .filter_map(|(_, node)| Some(node.recipe()?.id.to_string())),
+        current,
+    )
+}
+
+/// Provide completions for request IDs
+pub fn complete_request_id(current: &OsStr) -> Vec<CompletionCandidate> {
+    let Ok(database) = Database::load() else {
+        return Vec::new();
+    };
+    let Ok(exchanges) = database.get_all_requests() else {
+        return Vec::new();
+    };
+    get_candidates(
+        exchanges
+            .into_iter()
+            .map(|exchange| exchange.id.to_string()),
         current,
     )
 }
@@ -36,15 +64,16 @@ fn load_collection() -> anyhow::Result<Collection> {
     Collection::load(&path)
 }
 
-fn get_candidates<'a, T: 'a + Deref<Target = str>>(
-    iter: impl Iterator<Item = &'a T>,
+fn get_candidates<T: Into<String>>(
+    iter: impl Iterator<Item = T>,
     current: &OsStr,
 ) -> Vec<CompletionCandidate> {
     let Some(current) = current.to_str() else {
         return Vec::new();
     };
     // Only include IDs prefixed by the input we've gotten so far
-    iter.filter(|value| value.starts_with(current))
+    iter.map(T::into)
+        .filter(|value| value.starts_with(current))
         .map(|value| CompletionCandidate::new(value.deref()))
         .collect()
 }

--- a/crates/cli/src/completions.rs
+++ b/crates/cli/src/completions.rs
@@ -9,7 +9,7 @@
 use clap_complete::CompletionCandidate;
 use slumber_core::{
     collection::{Collection, CollectionFile, ProfileId},
-    db::Database,
+    db::{Database, DatabaseMode},
 };
 use std::{ffi::OsStr, ops::Deref};
 
@@ -43,7 +43,7 @@ pub fn complete_recipe(current: &OsStr) -> Vec<CompletionCandidate> {
 
 /// Provide completions for request IDs
 pub fn complete_request_id(current: &OsStr) -> Vec<CompletionCandidate> {
-    let Ok(database) = Database::load() else {
+    let Ok(database) = Database::load(DatabaseMode::ReadOnly) else {
         return Vec::new();
     };
     let Ok(exchanges) = database.get_all_requests() else {

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -17,6 +17,7 @@ use crate::commands::{
 };
 use clap::{CommandFactory, Parser};
 use clap_complete::CompleteEnv;
+use slumber_core::collection::CollectionFile;
 use std::{path::PathBuf, process::ExitCode};
 
 const COMMAND_NAME: &str = "slumber";
@@ -58,6 +59,14 @@ pub struct GlobalArgs {
     /// logic from the given directory rather than the current.
     #[clap(long, short)]
     pub file: Option<PathBuf>,
+}
+
+impl GlobalArgs {
+    /// Get the path to the active collection file. Return an error if there is
+    /// no collection file present, or if the user specified an invalid file.
+    fn collection_path(&self) -> anyhow::Result<PathBuf> {
+        CollectionFile::try_path(None, self.file.clone())
+    }
 }
 
 /// A CLI subcommand

--- a/crates/core/src/collection/models.rs
+++ b/crates/core/src/collection/models.rs
@@ -261,6 +261,16 @@ impl From<&str> for RecipeId {
     }
 }
 
+/// For rstest magic conversions
+#[cfg(any(test, feature = "test"))]
+impl FromStr for RecipeId {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok::<_, ()>(s.to_owned().into())
+    }
+}
+
 #[cfg(any(test, feature = "test"))]
 impl crate::test_util::Factory for RecipeId {
     fn factory(_: ()) -> Self {

--- a/crates/core/src/db.rs
+++ b/crates/core/src/db.rs
@@ -3,6 +3,8 @@
 
 mod convert;
 mod migrations;
+#[cfg(test)]
+mod tests;
 
 use crate::{
     collection::{ProfileId, RecipeId},
@@ -15,6 +17,7 @@ use derive_more::Display;
 use rusqlite::{Connection, DatabaseName, OptionalExtension, named_params};
 use serde::{Serialize, de::DeserializeOwned};
 use std::{
+    borrow::Cow,
     fmt::Debug,
     ops::{Deref, DerefMut},
     path::{Path, PathBuf},
@@ -44,6 +47,7 @@ pub struct Database {
     /// one connection per thread, but the code would be a bit more
     /// complicated.
     connection: Arc<Mutex<Connection>>,
+    // TODO set mode here?
 }
 
 impl Database {
@@ -167,6 +171,46 @@ impl Database {
             .context("Error deleting source collection")
             .traced()?;
         Ok(())
+    }
+
+    /// Get all requests for all collections
+    pub fn get_all_requests(&self) -> anyhow::Result<Vec<ExchangeSummary>> {
+        trace!("Fetching requests for all collections");
+        self.connection()
+            .prepare(
+                "SELECT id, profile_id, start_time, end_time, status_code
+                FROM requests_v2 ORDER BY start_time DESC",
+            )?
+            .query_map((), |row| row.try_into())
+            .context("Error fetching request history from database")
+            .traced()?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .context("Error extracting request history")
+    }
+
+    /// Delete ALL requests for ALL collections. Be careful with this! Return
+    /// the number of deleted requests
+    pub fn delete_all_requests(&self) -> anyhow::Result<usize> {
+        info!("Deleting all requests for ALL collections");
+        self.connection()
+            .execute("DELETE FROM requests_v2", ())
+            .context("Error deleting request history")
+            .traced()
+    }
+
+    /// Delete a single exchange by ID. Return the number of deleted requests
+    pub fn delete_request(
+        &self,
+        request_id: RequestId,
+    ) -> anyhow::Result<usize> {
+        info!(%request_id, "Deleting request");
+        self.connection()
+            .execute(
+                "DELETE FROM requests_v2 WHERE id = :request_id",
+                named_params! {":request_id": request_id},
+            )
+            .context(format!("Error deleting request {request_id}"))
+            .traced()
     }
 
     /// Convert this database connection into a handle for a single collection
@@ -323,19 +367,16 @@ impl CollectionDatabase {
     }
 
     /// Get a list of all requests for a profile+recipe combo
-    pub fn get_all_requests(
+    pub fn get_recipe_requests(
         &self,
-        profile_id: ProfileFilter,
+        profile_filter: ProfileFilter,
         recipe_id: &RecipeId,
     ) -> anyhow::Result<Vec<ExchangeSummary>> {
         trace!(
-            profile_id = ?profile_id,
+            profile_id = ?profile_filter,
             recipe_id = %recipe_id,
-            "Fetching request history from database"
+            "Fetching requests from database"
         );
-        // It would be nice to de-dupe this code with get_all_requests, but
-        // there's no good way to dynamically build a query with sqlite so it
-        // ends up not being worth it
         self.database
             .connection()
             .prepare(
@@ -354,8 +395,8 @@ impl CollectionDatabase {
             .query_map(
                 named_params! {
                     ":collection_id": self.collection_id,
-                    ":ignore_profile_id": profile_id == ProfileFilter::All,
-                    ":profile_id": profile_id,
+                    ":ignore_profile_id": profile_filter == ProfileFilter::All,
+                    ":profile_id": profile_filter,
                     ":recipe_id": recipe_id,
                 },
                 |row| row.try_into(),
@@ -440,6 +481,62 @@ impl CollectionDatabase {
             ))
             .traced()?;
         Ok(())
+    }
+
+    /// Delete all exchanges for this collection. Return the number of deleted
+    /// requests
+    pub fn delete_all_requests(&self) -> anyhow::Result<usize> {
+        self.ensure_write()?;
+        info!(
+            collection_id = %self.collection_id,
+            collection_path = ?self.collection_path(),
+            "Deleting all requests for collection",
+        );
+        self.database
+            .connection()
+            .execute(
+                "DELETE FROM requests_v2 WHERE collection_id = :collection_id",
+                named_params! {":collection_id": self.collection_id},
+            )
+            .context("Error deleting requests")
+            .traced()
+    }
+
+    /// Delete all requests for a recipe+profile combo. Return the number of
+    /// deleted requests
+    pub fn delete_recipe_requests(
+        &self,
+        profile_id: ProfileFilter,
+        recipe_id: &RecipeId,
+    ) -> anyhow::Result<usize> {
+        self.ensure_write()?;
+        info!(
+            collection_id = %self.collection_id,
+            collection_path = ?self.collection_path(),
+            %recipe_id,
+            ?profile_id,
+            "Deleting all requests for recipe+profile",
+        );
+        self.database
+            .connection()
+            .execute(
+                // `IS` needed for profile_id so `None` will match `NULL`.
+                // We want to dynamically ignore the profile filter if the user
+                // is asking for all profiles. Dynamically modifying the query
+                // is really ugly so the easiest thing is to use an additional
+                // parameter to bypass the filter
+                "DELETE FROM requests_v2 WHERE collection_id = :collection_id
+                    AND (:ignore_profile_id OR profile_id IS :profile_id)
+                    AND recipe_id = :recipe_id",
+                named_params! {
+                    ":collection_id": self.collection_id,
+                    ":ignore_profile_id": profile_id == ProfileFilter::All,
+                    ":profile_id": profile_id,
+                    ":recipe_id": recipe_id,
+                },
+            )
+            .context("Error deleting requests")
+            .traced()
     }
 
     /// Get the value of a UI state field. Key type is included as part of the
@@ -567,12 +664,12 @@ pub enum DatabaseMode {
 }
 
 /// Define how to filter requests by profile
-#[derive(Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub enum ProfileFilter<'a> {
     /// Show requests with _no_ associated profile
     None,
     /// Show requests for a particular profile
-    Some(&'a ProfileId),
+    Some(Cow<'a, ProfileId>),
     /// Show requests for all profiles
     #[default]
     All,
@@ -582,302 +679,19 @@ pub enum ProfileFilter<'a> {
 impl<'a> From<Option<&'a ProfileId>> for ProfileFilter<'a> {
     fn from(value: Option<&'a ProfileId>) -> Self {
         match value {
-            Some(profile_id) => Self::Some(profile_id),
+            Some(profile_id) => Self::Some(Cow::Borrowed(profile_id)),
             None => Self::None,
         }
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::{assert_err, test_util::Factory, util::paths::get_repo_root};
-    use itertools::Itertools;
-    use std::collections::HashMap;
-
-    #[test]
-    fn test_merge() {
-        let database = Database::factory(());
-        let path1 = get_repo_root().join("slumber.yml");
-        let path2 = get_repo_root().join("README.md"); // Has to be a real file
-        let collection1 = database
-            .clone()
-            .into_collection(&path1, DatabaseMode::ReadWrite)
-            .unwrap();
-        let collection2 = database
-            .clone()
-            .into_collection(&path2, DatabaseMode::ReadWrite)
-            .unwrap();
-
-        let exchange1 =
-            Exchange::factory((Some("profile1".into()), "recipe1".into()));
-        let exchange2 =
-            Exchange::factory((Some("profile1".into()), "recipe1".into()));
-        let profile_id = exchange1.request.profile_id.as_ref();
-        let recipe_id = &exchange1.request.recipe_id;
-        let key_type = "MyKey";
-        let ui_key = "key1";
-        collection1.insert_exchange(&exchange1).unwrap();
-        collection1.set_ui(key_type, ui_key, "value1").unwrap();
-        collection2.insert_exchange(&exchange2).unwrap();
-        collection2.set_ui(key_type, ui_key, "value2").unwrap();
-
-        // Sanity checks
-        assert_eq!(
-            collection1
-                .get_latest_request(profile_id.into(), recipe_id)
-                .unwrap()
-                .unwrap()
-                .id,
-            exchange1.id
-        );
-        assert_eq!(
-            collection1.get_ui::<_, String>(key_type, ui_key).unwrap(),
-            Some("value1".into())
-        );
-        assert_eq!(
-            collection2
-                .get_latest_request(profile_id.into(), recipe_id)
-                .unwrap()
-                .unwrap()
-                .id,
-            exchange2.id
-        );
-        assert_eq!(
-            collection2.get_ui::<_, String>(key_type, ui_key).unwrap(),
-            Some("value2".into())
-        );
-
-        // Do the merge
-        database.merge_collections(&path2, &path1).unwrap();
-
-        // Collection 2 values should've overwritten
-        assert_eq!(
-            collection1
-                .get_latest_request(profile_id.into(), recipe_id)
-                .unwrap()
-                .unwrap()
-                .id,
-            exchange2.id
-        );
-        assert_eq!(
-            collection1.get_ui::<_, String>(key_type, ui_key).unwrap(),
-            Some("value2".into())
-        );
-
-        // Make sure collection2 was deleted
-        assert_eq!(
-            database.collections().unwrap(),
-            vec![path1.canonicalize().unwrap()]
-        );
-    }
-
-    /// Test request storage and retrieval
-    #[test]
-    fn test_request() {
-        let database = Database::factory(());
-        let collection1 = database
-            .clone()
-            .into_collection(
-                &get_repo_root().join("slumber.yml"),
-                DatabaseMode::ReadWrite,
-            )
-            .unwrap();
-        let collection2 = database
-            .clone()
-            .into_collection(
-                &get_repo_root().join("README.md"),
-                DatabaseMode::ReadWrite,
-            )
-            .unwrap();
-
-        let exchange2 = Exchange::factory(());
-        collection2.insert_exchange(&exchange2).unwrap();
-
-        // We separate requests by 3 columns. Create multiple of each column to
-        // make sure we filter by each column correctly
-        let collections = [collection1, collection2];
-
-        // Store the created request ID for each cell in the matrix, so we can
-        // compare to what the DB spits back later
-        let mut request_ids: HashMap<
-            (CollectionId, Option<ProfileId>, RecipeId),
-            RequestId,
-        > = Default::default();
-
-        // Create and insert each request
-        for collection in &collections {
-            for profile_id in [None, Some("profile1"), Some("profile2")] {
-                for recipe_id in ["recipe1", "recipe2"] {
-                    let recipe_id: RecipeId = recipe_id.into();
-                    let profile_id = profile_id.map(ProfileId::from);
-                    let exchange = Exchange::factory((
-                        profile_id.clone(),
-                        recipe_id.clone(),
-                    ));
-                    collection.insert_exchange(&exchange).unwrap();
-                    request_ids.insert(
-                        (collection.collection_id(), profile_id, recipe_id),
-                        exchange.id,
-                    );
-                }
-            }
+/// Useful for CLI arguments
+impl From<Option<Option<ProfileId>>> for ProfileFilter<'static> {
+    fn from(value: Option<Option<ProfileId>>) -> Self {
+        match value {
+            Some(Some(profile_id)) => Self::Some(Cow::Owned(profile_id)),
+            Some(None) => Self::None,
+            None => Self::All,
         }
-
-        // Try to find each inserted recipe individually. Also try some
-        // expected non-matches
-        for collection in &collections {
-            for profile_id in [None, Some("profile1"), Some("extra_profile")] {
-                for recipe_id in ["recipe1", "extra_recipe"] {
-                    let collection_id = collection.collection_id();
-                    let profile_id = profile_id.map(ProfileId::from);
-                    let recipe_id = recipe_id.into();
-
-                    // Leave the Option here so a non-match will trigger a handy
-                    // assertion error
-                    let exchange_id = collection
-                        .get_latest_request(
-                            profile_id.as_ref().into(),
-                            &recipe_id,
-                        )
-                        .unwrap()
-                        .map(|exchange| exchange.id);
-                    let expected_id = request_ids.get(&(
-                        collection_id,
-                        profile_id.clone(),
-                        recipe_id.clone(),
-                    ));
-
-                    assert_eq!(
-                        exchange_id.as_ref(),
-                        expected_id,
-                        "Request mismatch for collection = {collection_id}, \
-                        profile = {profile_id:?}, recipe = {recipe_id}"
-                    );
-                }
-            }
-        }
-    }
-
-    #[test]
-    fn test_load_all_requests() {
-        let database = CollectionDatabase::factory(());
-
-        // Create and insert multiple requests per profile+recipe.
-        // Store the created request ID for each cell in the matrix, so we can
-        // compare to what the DB spits back later
-        let mut request_ids: HashMap<
-            (Option<ProfileId>, RecipeId),
-            Vec<RequestId>,
-        > = Default::default();
-        for profile_id in [None, Some("profile1"), Some("profile2")] {
-            for recipe_id in ["recipe1", "recipe2"] {
-                let recipe_id: RecipeId = recipe_id.into();
-                let profile_id = profile_id.map(ProfileId::from);
-                let mut ids = (0..3)
-                    .map(|_| {
-                        let exchange = Exchange::factory((
-                            profile_id.clone(),
-                            recipe_id.clone(),
-                        ));
-                        database.insert_exchange(&exchange).unwrap();
-                        exchange.id
-                    })
-                    .collect_vec();
-                // Order newest->oldest, that's the response we expect
-                ids.reverse();
-                request_ids.insert((profile_id, recipe_id), ids);
-            }
-        }
-
-        // Try to find each inserted recipe individually. Also try some
-        // expected non-matches
-        for profile_id in [None, Some("profile1"), Some("extra_profile")] {
-            for recipe_id in ["recipe1", "extra_recipe"] {
-                let profile_id = profile_id.map(ProfileId::from);
-                let recipe_id = recipe_id.into();
-
-                // Leave the Option here so a non-match will trigger a handy
-                // assertion error
-                let ids = database
-                    .get_all_requests(profile_id.as_ref().into(), &recipe_id)
-                    .unwrap()
-                    .into_iter()
-                    .map(|exchange| exchange.id)
-                    .collect_vec();
-                let expected_id = request_ids
-                    .get(&(profile_id.clone(), recipe_id.clone()))
-                    .cloned()
-                    .unwrap_or_default();
-
-                assert_eq!(
-                    ids, expected_id,
-                    "Requests mismatch for \
-                    profile = {profile_id:?}, recipe = {recipe_id}"
-                );
-            }
-        }
-
-        // Load all requests for a recipe (across all profiles)
-        let recipe_id = "recipe1".into();
-        let ids = database
-            .get_all_requests(ProfileFilter::All, &recipe_id)
-            .unwrap()
-            .into_iter()
-            .map(|exchange| exchange.id)
-            .sorted()
-            .collect_vec();
-        let expected_ids = request_ids
-            .iter()
-            .filter(|((_, r), _)| r == &recipe_id)
-            .flat_map(|(_, request_ids)| request_ids)
-            .sorted()
-            .copied()
-            .collect_vec();
-        assert_eq!(ids, expected_ids)
-    }
-
-    /// Test UI state storage and retrieval
-    #[test]
-    fn test_ui_state() {
-        let database = Database::factory(());
-        let collection1 = database
-            .clone()
-            .into_collection(
-                Path::new("../../slumber.yml"),
-                DatabaseMode::ReadWrite,
-            )
-            .unwrap();
-        let collection2 = database
-            .clone()
-            .into_collection(Path::new("Cargo.toml"), DatabaseMode::ReadWrite)
-            .unwrap();
-
-        let key_type = "MyKey";
-        let ui_key = "key1";
-        collection1.set_ui(key_type, ui_key, "value1").unwrap();
-        collection2.set_ui(key_type, ui_key, "value2").unwrap();
-
-        assert_eq!(
-            collection1.get_ui::<_, String>(key_type, ui_key).unwrap(),
-            Some("value1".into())
-        );
-        assert_eq!(
-            collection2.get_ui::<_, String>(key_type, ui_key).unwrap(),
-            Some("value2".into())
-        );
-    }
-
-    #[test]
-    fn test_readonly_mode() {
-        let database = CollectionDatabase::factory(DatabaseMode::ReadOnly);
-        assert_err!(
-            database.insert_exchange(&Exchange::factory(())),
-            "Database in read-only mode"
-        );
-        assert_err!(
-            database.set_ui("MyKey", "key1", "value1"),
-            "Database in read-only mode"
-        );
     }
 }

--- a/crates/core/src/db/migrations.rs
+++ b/crates/core/src/db/migrations.rs
@@ -1,4 +1,4 @@
-use dialoguer::Confirm;
+use crate::util::confirm;
 use rusqlite::Transaction;
 use rusqlite_migration::{HookError, HookResult, M, Migrations};
 
@@ -127,19 +127,14 @@ fn migrate_requests_v2(transaction: &Transaction) -> HookResult {
             row.get::<_, u64>(0)
         })?;
     if old_requests_count > 0 {
-        let delete = Confirm::new()
-            .with_prompt(
-                "You are upgrading from Slumber <1.8.0 to Slumber >=3.0.0. \
+        let delete = confirm(
+            "You are upgrading from Slumber <1.8.0 to Slumber >=3.0.0. \
                 Your request history database contains old requests that \
                 cannot be migrated directly to a newer format. You can proceed \
                 with the upgrade by DELETING THE OLD REQUESTS now, or you can \
                 retain the requests by upgrading to an intermediate version \
                 first.\nWould you like to DELETE YOUR REQUEST HISTORY?",
-            )
-            .default(false)
-            .wait_for_newline(true)
-            .interact()
-            .unwrap_or(false);
+        );
         if delete {
             // We can just proceed and a future migration will drop the old
             // table

--- a/crates/core/src/db/tests.rs
+++ b/crates/core/src/db/tests.rs
@@ -38,13 +38,11 @@ fn request_db(
     other_collection_path: PathBuf,
 ) -> RequestDb {
     let database = Database::factory(());
-    let collection1 = database
-        .clone()
-        .into_collection(&collection_path, DatabaseMode::ReadWrite)
-        .unwrap();
+    let collection1 =
+        database.clone().into_collection(&collection_path).unwrap();
     let collection2 = database
         .clone()
-        .into_collection(&other_collection_path, DatabaseMode::ReadWrite)
+        .into_collection(&other_collection_path)
         .unwrap();
 
     // We separate requests by 3 columns. Create multiple of each column to
@@ -95,13 +93,11 @@ struct RequestDb {
 #[rstest]
 fn test_merge(collection_path: PathBuf, other_collection_path: PathBuf) {
     let database = Database::factory(());
-    let collection1 = database
-        .clone()
-        .into_collection(&collection_path, DatabaseMode::ReadWrite)
-        .unwrap();
+    let collection1 =
+        database.clone().into_collection(&collection_path).unwrap();
     let collection2 = database
         .clone()
-        .into_collection(&other_collection_path, DatabaseMode::ReadWrite)
+        .into_collection(&other_collection_path)
         .unwrap();
 
     let exchange1 =
@@ -338,13 +334,11 @@ fn test_delete_request(request_db: RequestDb) {
 #[rstest]
 fn test_ui_state(collection_path: PathBuf) {
     let database = Database::factory(());
-    let collection1 = database
-        .clone()
-        .into_collection(&collection_path, DatabaseMode::ReadWrite)
-        .unwrap();
+    let collection1 =
+        database.clone().into_collection(&collection_path).unwrap();
     let collection2 = database
         .clone()
-        .into_collection(Path::new("Cargo.toml"), DatabaseMode::ReadWrite)
+        .into_collection(Path::new("Cargo.toml"))
         .unwrap();
 
     let key_type = "MyKey";

--- a/crates/core/src/db/tests.rs
+++ b/crates/core/src/db/tests.rs
@@ -1,0 +1,376 @@
+use super::*;
+use crate::{assert_err, test_util::Factory, util::paths::get_repo_root};
+use indexmap::IndexMap;
+use itertools::Itertools;
+use rstest::{fixture, rstest};
+use std::collections::HashMap;
+
+impl CollectionDatabase {
+    fn count_requests(&self) -> usize {
+        self.database
+            .connection()
+            .query_row(
+                "SELECT COUNT(*) FROM requests_v2
+                WHERE collection_id = :collection_id",
+                named_params! {
+                    ":collection_id": self.collection_id(),
+                },
+                |row| row.get(0),
+            )
+            .unwrap()
+    }
+}
+
+#[fixture]
+fn collection_path() -> PathBuf {
+    get_repo_root().join("slumber.yml")
+}
+
+#[fixture]
+fn other_collection_path() -> PathBuf {
+    get_repo_root().join("README.md") // Has to be a real file
+}
+
+/// Populate a DB with two collections, and a few exchanges in each one
+#[fixture]
+fn request_db(
+    collection_path: PathBuf,
+    other_collection_path: PathBuf,
+) -> RequestDb {
+    let database = Database::factory(());
+    let collection1 = database
+        .clone()
+        .into_collection(&collection_path, DatabaseMode::ReadWrite)
+        .unwrap();
+    let collection2 = database
+        .clone()
+        .into_collection(&other_collection_path, DatabaseMode::ReadWrite)
+        .unwrap();
+
+    // We separate requests by 3 columns. Create multiple of each column to
+    // make sure we filter by each column correctly
+    let collections = [collection1, collection2];
+
+    // Store the created request ID for each cell in the matrix, so we can
+    // compare to what the DB spits back later
+    let mut request_ids: IndexMap<
+        (CollectionId, Option<ProfileId>, RecipeId),
+        RequestId,
+    > = Default::default();
+
+    // Create and insert each request
+    for collection in &collections {
+        for profile_id in [None, Some("profile1"), Some("profile2")] {
+            for recipe_id in ["recipe1", "recipe2"] {
+                let recipe_id: RecipeId = recipe_id.into();
+                let profile_id = profile_id.map(ProfileId::from);
+                let exchange =
+                    Exchange::factory((profile_id.clone(), recipe_id.clone()));
+                collection.insert_exchange(&exchange).unwrap();
+                request_ids.insert(
+                    (collection.collection_id(), profile_id, recipe_id),
+                    exchange.id,
+                );
+            }
+        }
+    }
+
+    RequestDb {
+        database,
+        collections,
+        request_ids,
+    }
+}
+
+struct RequestDb {
+    database: Database,
+    collections: [CollectionDatabase; 2],
+    /// A map of the request IDs we inserted for each (collection, profile,
+    /// recipe) key. This makes it possible to do assertions on the inserted
+    /// IDs
+    request_ids:
+        IndexMap<(CollectionId, Option<ProfileId>, RecipeId), RequestId>,
+}
+
+#[rstest]
+fn test_merge(collection_path: PathBuf, other_collection_path: PathBuf) {
+    let database = Database::factory(());
+    let collection1 = database
+        .clone()
+        .into_collection(&collection_path, DatabaseMode::ReadWrite)
+        .unwrap();
+    let collection2 = database
+        .clone()
+        .into_collection(&other_collection_path, DatabaseMode::ReadWrite)
+        .unwrap();
+
+    let exchange1 =
+        Exchange::factory((Some("profile1".into()), "recipe1".into()));
+    let exchange2 =
+        Exchange::factory((Some("profile1".into()), "recipe1".into()));
+    let profile_id = exchange1.request.profile_id.as_ref();
+    let recipe_id = &exchange1.request.recipe_id;
+    let key_type = "MyKey";
+    let ui_key = "key1";
+    collection1.insert_exchange(&exchange1).unwrap();
+    collection1.set_ui(key_type, ui_key, "value1").unwrap();
+    collection2.insert_exchange(&exchange2).unwrap();
+    collection2.set_ui(key_type, ui_key, "value2").unwrap();
+
+    // Sanity checks
+    assert_eq!(
+        collection1
+            .get_latest_request(profile_id.into(), recipe_id)
+            .unwrap()
+            .unwrap()
+            .id,
+        exchange1.id
+    );
+    assert_eq!(
+        collection1.get_ui::<_, String>(key_type, ui_key).unwrap(),
+        Some("value1".into())
+    );
+    assert_eq!(
+        collection2
+            .get_latest_request(profile_id.into(), recipe_id)
+            .unwrap()
+            .unwrap()
+            .id,
+        exchange2.id
+    );
+    assert_eq!(
+        collection2.get_ui::<_, String>(key_type, ui_key).unwrap(),
+        Some("value2".into())
+    );
+
+    // Do the merge
+    database
+        .merge_collections(&other_collection_path, &collection_path)
+        .unwrap();
+
+    // Collection 2 values should've overwritten
+    assert_eq!(
+        collection1
+            .get_latest_request(profile_id.into(), recipe_id)
+            .unwrap()
+            .unwrap()
+            .id,
+        exchange2.id
+    );
+    assert_eq!(
+        collection1.get_ui::<_, String>(key_type, ui_key).unwrap(),
+        Some("value2".into())
+    );
+
+    // Make sure collection2 was deleted
+    assert_eq!(
+        database.collections().unwrap(),
+        vec![collection_path.canonicalize().unwrap()]
+    );
+}
+
+/// Test request storage and retrieval
+#[rstest]
+fn test_request(request_db: RequestDb) {
+    // Try to find each inserted recipe individually. Also try some
+    // expected non-matches
+    for collection in &request_db.collections {
+        for profile_id in [None, Some("profile1"), Some("extra_profile")] {
+            for recipe_id in ["recipe1", "extra_recipe"] {
+                let collection_id = collection.collection_id();
+                let profile_id = profile_id.map(ProfileId::from);
+                let recipe_id = recipe_id.into();
+
+                // Leave the Option here so a non-match will trigger a handy
+                // assertion error
+                let exchange_id = collection
+                    .get_latest_request(profile_id.as_ref().into(), &recipe_id)
+                    .unwrap()
+                    .map(|exchange| exchange.id);
+                let expected_id = request_db.request_ids.get(&(
+                    collection_id,
+                    profile_id.clone(),
+                    recipe_id.clone(),
+                ));
+
+                assert_eq!(
+                    exchange_id.as_ref(),
+                    expected_id,
+                    "Request mismatch for collection = {collection_id}, \
+                        profile = {profile_id:?}, recipe = {recipe_id}"
+                );
+            }
+        }
+    }
+}
+
+/// Test fetching all requests for a single recipe
+#[test]
+fn test_get_recipe_requests() {
+    let database = CollectionDatabase::factory(());
+
+    // Create and insert multiple requests per profile+recipe.
+    // Store the created request ID for each cell in the matrix, so we can
+    // compare to what the DB spits back later
+    let mut request_ids: HashMap<
+        (Option<ProfileId>, RecipeId),
+        Vec<RequestId>,
+    > = Default::default();
+    for profile_id in [None, Some("profile1"), Some("profile2")] {
+        for recipe_id in ["recipe1", "recipe2"] {
+            let recipe_id: RecipeId = recipe_id.into();
+            let profile_id = profile_id.map(ProfileId::from);
+            let mut ids = (0..3)
+                .map(|_| {
+                    let exchange = Exchange::factory((
+                        profile_id.clone(),
+                        recipe_id.clone(),
+                    ));
+                    database.insert_exchange(&exchange).unwrap();
+                    exchange.id
+                })
+                .collect_vec();
+            // Order newest->oldest, that's the response we expect
+            ids.reverse();
+            request_ids.insert((profile_id, recipe_id), ids);
+        }
+    }
+
+    // Try to find each inserted recipe individually. Also try some
+    // expected non-matches
+    for profile_id in [None, Some("profile1"), Some("extra_profile")] {
+        for recipe_id in ["recipe1", "extra_recipe"] {
+            let profile_id = profile_id.map(ProfileId::from);
+            let recipe_id = recipe_id.into();
+
+            // Leave the Option here so a non-match will trigger a handy
+            // assertion error
+            let ids = database
+                .get_recipe_requests(profile_id.as_ref().into(), &recipe_id)
+                .unwrap()
+                .into_iter()
+                .map(|exchange| exchange.id)
+                .collect_vec();
+            let expected_id = request_ids
+                .get(&(profile_id.clone(), recipe_id.clone()))
+                .cloned()
+                .unwrap_or_default();
+
+            assert_eq!(
+                ids, expected_id,
+                "Requests mismatch for \
+                    profile = {profile_id:?}, recipe = {recipe_id}"
+            );
+        }
+    }
+
+    // Load all requests for a recipe (across all profiles)
+    let recipe_id = "recipe1".into();
+    let ids = database
+        .get_recipe_requests(ProfileFilter::All, &recipe_id)
+        .unwrap()
+        .into_iter()
+        .map(|exchange| exchange.id)
+        .sorted()
+        .collect_vec();
+    let expected_ids = request_ids
+        .iter()
+        .filter(|((_, r), _)| r == &recipe_id)
+        .flat_map(|(_, request_ids)| request_ids)
+        .sorted()
+        .copied()
+        .collect_vec();
+    assert_eq!(ids, expected_ids)
+}
+
+/// Test deleting all requests for all collections
+#[rstest]
+fn test_database_delete_all_requests(request_db: RequestDb) {
+    let [collection1, collection2] = request_db.collections;
+    assert_eq!(request_db.database.delete_all_requests().unwrap(), 12);
+    assert_eq!(collection1.count_requests(), 0);
+    assert_eq!(collection2.count_requests(), 0);
+}
+
+/// Test deleting all requests for a collection
+#[rstest]
+fn test_collection_delete_all_requests(request_db: RequestDb) {
+    let [collection1, collection2] = request_db.collections;
+    assert_eq!(collection1.delete_all_requests().unwrap(), 6);
+    assert_eq!(collection1.count_requests(), 0);
+    assert_eq!(collection2.count_requests(), 6);
+}
+
+/// Test deleting all requests for a recipe/profile combo
+#[rstest]
+#[case(ProfileFilter::All, "recipe1", 3)]
+#[case(ProfileFilter::Some(Cow::Owned("profile1".into())), "recipe1", 1)]
+#[case(ProfileFilter::None, "recipe1", 1)]
+fn test_delete_recipe_requests(
+    request_db: RequestDb,
+    #[case] profile_filter: ProfileFilter<'static>,
+    #[case] recipe_id: RecipeId,
+    #[case] expected_deleted: usize,
+) {
+    let [collection1, collection2] = request_db.collections;
+    assert_eq!(
+        collection1
+            .delete_recipe_requests(profile_filter, &recipe_id)
+            .unwrap(),
+        expected_deleted
+    );
+    assert_eq!(collection1.count_requests(), 6 - expected_deleted);
+    assert_eq!(collection2.count_requests(), 6);
+}
+
+/// Test deleting a specific request
+#[rstest]
+fn test_delete_request(request_db: RequestDb) {
+    let [collection1, collection2] = request_db.collections;
+    let request_id = *request_db.request_ids.first().unwrap().1;
+
+    assert_eq!(request_db.database.delete_request(request_id).unwrap(), 1);
+    assert_eq!(collection1.count_requests(), 5);
+    assert_eq!(collection2.count_requests(), 6);
+}
+
+/// Test UI state storage and retrieval
+#[rstest]
+fn test_ui_state(collection_path: PathBuf) {
+    let database = Database::factory(());
+    let collection1 = database
+        .clone()
+        .into_collection(&collection_path, DatabaseMode::ReadWrite)
+        .unwrap();
+    let collection2 = database
+        .clone()
+        .into_collection(Path::new("Cargo.toml"), DatabaseMode::ReadWrite)
+        .unwrap();
+
+    let key_type = "MyKey";
+    let ui_key = "key1";
+    collection1.set_ui(key_type, ui_key, "value1").unwrap();
+    collection2.set_ui(key_type, ui_key, "value2").unwrap();
+
+    assert_eq!(
+        collection1.get_ui::<_, String>(key_type, ui_key).unwrap(),
+        Some("value1".into())
+    );
+    assert_eq!(
+        collection2.get_ui::<_, String>(key_type, ui_key).unwrap(),
+        Some("value2".into())
+    );
+}
+
+#[test]
+fn test_readonly_mode() {
+    let database = CollectionDatabase::factory(DatabaseMode::ReadOnly);
+    assert_err!(
+        database.insert_exchange(&Exchange::factory(())),
+        "Database in read-only mode"
+    );
+    assert_err!(
+        database.set_ui("MyKey", "key1", "value1"),
+        "Database in read-only mode"
+    );
+}

--- a/crates/core/src/util.rs
+++ b/crates/core/src/util.rs
@@ -8,6 +8,7 @@ use chrono::{
     format::{DelayedFormat, StrftimeItems},
 };
 use derive_more::{DerefMut, Display};
+use dialoguer::Confirm;
 use serde::de::DeserializeOwned;
 use std::{
     collections::{HashMap, hash_map::Entry},
@@ -89,6 +90,16 @@ pub fn format_byte_size(size: usize) -> String {
     };
     let size = size as f64 / denom as f64;
     format!("{size:.1} {suffix}B")
+}
+
+/// Show the user a confirmation prompt
+pub fn confirm(prompt: impl Into<String>) -> bool {
+    Confirm::new()
+        .with_prompt(prompt)
+        .default(false)
+        .wait_for_newline(true)
+        .interact()
+        .unwrap_or(false)
 }
 
 /// Extension trait for [Result]

--- a/crates/tui/src/http.rs
+++ b/crates/tui/src/http.rs
@@ -268,7 +268,7 @@ impl RequestStore {
         // store, because they don't include request/response data
         let loaded = self
             .database
-            .get_all_requests(profile_id.into(), recipe_id)?;
+            .get_recipe_requests(profile_id.into(), recipe_id)?;
 
         // Find what we have in memory already
         let iter = self

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -100,8 +100,8 @@ impl Tui {
         // to default, just show an error to the user
         let config = Config::load().reported(&messages_tx).unwrap_or_default();
         // Load a database for this particular collection
-        let database = Database::load()?
-            .into_collection(&collection_path, DatabaseMode::ReadWrite)?;
+        let database = Database::load(DatabaseMode::ReadWrite)?
+            .into_collection(&collection_path)?;
         // Initialize global view context
         TuiContext::init(config);
 


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Add a new subcommand to delete history from the DB. There are 4 ways to delete history:
- `slumber history delete all` - Delete all requests across all collections
- `slumber history delete collection` - Delete all requests for the current collection
- `slumber history delete recipe <recipe>` - Delete all requests for a recipe in the current collection (optionally with a `--profile` filter)
- `slumber history delete request <request>` - Delete a single request by ID (across all collections, since IDs are globally unique)

All 4 selectors will give a confirmation prompt before deleting. This can be skipped by passing `-y` or `--yes`

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

- Deletion is irreversible. Mitigated with the confirmation prompt
- The help text isn't perfect because I wrote the selector in a generic way that can be reused for `slumber history list`
- `--yes` has to be provided _before_ the selector because the selector is a subcommand, which is clunky

## QA

_How did you test this?_

Unit tests on the DB. Need to write CLI tests at some point.

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
