### PR TITLE
Add `slumber db` subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Add `--persist` flag to `slumber request`
   - By default, CLI-based requests are not stored in the history database. Use this flag to enable persistence for the sent request.
 - Add `slumber history delete` subcommand for deleting request history
+- Add `slumber db` subcommand to open a shell to the local SQLite database
 - Add `persist` field to the global config and individual recipes
   - Both default to `true`, but you can now set them to `false` to disable data persistence a single recipe, or all instances of the app. [See here for more](https://slumber.lucaspickering.me/book/user_guide/database.html#controlling-persistence)
 - Add actions to delete requests from the TUI

--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -1,4 +1,5 @@
 pub mod collections;
+pub mod db;
 pub mod generate;
 pub mod history;
 pub mod import;

--- a/crates/cli/src/commands/db.rs
+++ b/crates/cli/src/commands/db.rs
@@ -1,0 +1,78 @@
+use crate::{GlobalArgs, Subcommand};
+use anyhow::Context;
+use clap::Parser;
+use slumber_core::db::Database;
+use std::process::ExitCode;
+use tokio::process::Command;
+
+/// Access the local Slumber database file.
+///
+/// This is an advanced command; most users never need to manually view or
+/// modify the database file. By default this executes `sqlite3` and thus
+/// requires `sqlite3` to be installed. You can customize which binary to invoke
+/// with `--shell`. Read more about the Slumber database:
+///
+/// https://slumber.lucaspickering.me/book/user_guide/database.html
+///
+/// This is simply an alias to make it easy to run your preferred SQLite shell
+/// against the Slumber database. These two commands are equivalent:
+///
+///   slumber db -s <shell> -- <args...>
+///
+///   <shell> <path> <...args>
+///
+/// Where `<path>` is the path to the database file.
+///
+/// EXAMPLES:
+///
+/// Open a shell to the database:
+///
+///   slumber db
+///
+/// Run a single query and exit:
+///
+///   slumber db 'select 1'
+#[derive(Clone, Debug, Parser)]
+#[clap(verbatim_doc_comment)]
+pub struct DbCommand {
+    /// Program to execute
+    #[clap(short = 'x', long, default_value = "sqlite3")]
+    exec: String,
+    /// Additional arguments to forward to the invoked program. Positional
+    /// arguments can be passed like so:
+    ///
+    ///   slumber db 'select 1'
+    ///
+    /// However if you want to pass flags that begin with "-", you have to
+    /// precede the forwarded arguments with "--" to separate them from
+    /// arguments intended for `slumber`.
+    ///
+    ///   slumber db -- -cmd 'select 1'
+    #[clap(num_args = 1.., verbatim_doc_comment)]
+    args: Vec<String>,
+}
+
+impl Subcommand for DbCommand {
+    async fn execute(self, _: GlobalArgs) -> anyhow::Result<ExitCode> {
+        // Open a shell
+        let path = Database::path();
+        let exit_status = Command::new(self.exec)
+            .arg(&path)
+            .args(self.args)
+            .spawn()
+            .with_context(|| format!("Error opening database file {path:?}"))?
+            .wait()
+            .await?;
+
+        // Forward exit code if we can, otherwise just match success/failure
+        if let Some(code) =
+            exit_status.code().and_then(|code| u8::try_from(code).ok())
+        {
+            Ok(code.into())
+        } else if exit_status.success() {
+            Ok(ExitCode::SUCCESS)
+        } else {
+            Ok(ExitCode::FAILURE)
+        }
+    }
+}

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -11,7 +11,7 @@ mod commands;
 mod completions;
 
 use crate::commands::{
-    collections::CollectionsCommand, generate::GenerateCommand,
+    collections::CollectionsCommand, db::DbCommand, generate::GenerateCommand,
     history::HistoryCommand, import::ImportCommand, new::NewCommand,
     request::RequestCommand, show::ShowCommand,
 };
@@ -26,7 +26,7 @@ const COMMAND_NAME: &str = "slumber";
 ///
 /// If subcommand is omitted, start the TUI.
 ///
-/// https://slumber.lucaspickering.me/book/
+/// <https://slumber.lucaspickering.me/book/>
 #[derive(Debug, Parser)]
 #[clap(author, version, about, name = COMMAND_NAME)]
 pub struct Args {
@@ -73,6 +73,7 @@ impl GlobalArgs {
 #[derive(Clone, Debug, clap::Subcommand)]
 pub enum CliCommand {
     Collections(CollectionsCommand),
+    Db(DbCommand),
     Generate(GenerateCommand),
     History(HistoryCommand),
     Import(ImportCommand),
@@ -86,6 +87,7 @@ impl CliCommand {
     pub async fn execute(self, global: GlobalArgs) -> anyhow::Result<ExitCode> {
         match self {
             Self::Collections(command) => command.execute(global).await,
+            Self::Db(command) => command.execute(global).await,
             Self::Generate(command) => command.execute(global).await,
             Self::History(command) => command.execute(global).await,
             Self::Import(command) => command.execute(global).await,

--- a/docs/src/cli/subcommands.md
+++ b/docs/src/cli/subcommands.md
@@ -8,6 +8,22 @@ View and manipulate stored collection history/state. Slumber uses a local databa
 
 See `slumber collections --help` for more options.
 
+## `slumber db`
+
+Access the local Slumber database file. This is an advanced command; most users never need to manually view or modify the database file. By default this executes `sqlite3` and thus requires `sqlite3` to be installed.
+
+Open a shell to the database:
+
+```
+slumber db
+```
+
+Run a single query and exit:
+
+```
+slumber db 'select 1'
+```
+
 ## `slumber generate`
 
 Generate an HTTP request in an external format. Currently the only supported format is cURL.


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Invoke a binary on the database file. By default, `slumber db` will open a sqlite3 shell.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

This is fairly advanced. Exposing it as a top-level command might be too much exposure.

## QA

_How did you test this?_

Did some manual tests

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
