### PR TITLE
Add TUI actions to delete requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Add `slumber history delete` subcommand for deleting request history
 - Add `persist` field to the global config and individual recipes
   - Both default to `true`, but you can now set them to `false` to disable data persistence a single recipe, or all instances of the app. [See here for more](https://slumber.lucaspickering.me/book/user_guide/database.html#controlling-persistence)
+- Add actions to delete requests from the TUI
 
 ### Changed
 

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -244,15 +244,9 @@ impl Tui {
                 self.run_command(command)?;
             }
 
-            Message::CopyRequestUrl => {
-                self.copy_request_url()?;
-            }
-            Message::CopyRequestBody => {
-                self.copy_request_body()?;
-            }
-            Message::CopyRequestCurl => {
-                self.copy_request_curl()?;
-            }
+            Message::CopyRequestUrl => self.copy_request_url()?,
+            Message::CopyRequestBody => self.copy_request_body()?,
+            Message::CopyRequestCurl => self.copy_request_curl()?,
             Message::CopyText(text) => self.view.copy_text(text),
             Message::SaveResponseBody { request_id, data } => {
                 self.save_response_body(request_id, data).with_context(

--- a/crates/tui/src/util.rs
+++ b/crates/tui/src/util.rs
@@ -370,7 +370,10 @@ async fn prompt(
 }
 
 /// Ask the user a yes/no question and wait for a response
-async fn confirm(messages_tx: &MessageSender, message: impl ToString) -> bool {
+pub async fn confirm(
+    messages_tx: &MessageSender,
+    message: impl ToString,
+) -> bool {
     let (tx, rx) = oneshot::channel();
     let confirm = Confirm {
         message: message.to_string(),

--- a/crates/tui/src/view/common/button.rs
+++ b/crates/tui/src/view/common/button.rs
@@ -76,18 +76,12 @@ impl<T: FixedSelect> EventHandler for ButtonGroup<T> {
 
 impl<T: FixedSelect> Draw for ButtonGroup<T> {
     fn draw(&self, frame: &mut Frame, _: (), metadata: DrawMetadata) {
-        // The button width is based on the longest button
-        let width = self
-            .select
-            .items()
-            .map(|button| button.to_string().len())
-            .max()
-            .unwrap_or(0) as u16;
-        let (areas, _) = Layout::horizontal(
-            self.select.items().map(|_| Constraint::Length(width)),
-        )
-        .flex(Flex::SpaceAround)
-        .split_with_spacers(metadata.area());
+        let (areas, _) =
+            Layout::horizontal(self.select.items().map(|button| {
+                Constraint::Length(button.to_string().len() as u16)
+            }))
+            .flex(Flex::SpaceBetween)
+            .split_with_spacers(metadata.area());
 
         for (button, area) in self.select.items().zip(areas.iter()) {
             frame.render_widget(

--- a/crates/tui/src/view/common/modal.rs
+++ b/crates/tui/src/view/common/modal.rs
@@ -212,8 +212,8 @@ impl Draw for ModalQueue {
             let mut area = centered_rect(width, height, metadata.area());
             let x_buffer = margin.horizontal + 1;
             let y_buffer = margin.vertical + 1;
-            area.x -= x_buffer;
-            area.y -= y_buffer;
+            area.x = area.x.saturating_sub(x_buffer);
+            area.y = area.y.saturating_sub(y_buffer);
             area.width += x_buffer * 2;
             area.height += y_buffer * 2;
 

--- a/crates/tui/src/view/component/request_view.rs
+++ b/crates/tui/src/view/component/request_view.rs
@@ -17,7 +17,7 @@ use crate::{
 use ratatui::{Frame, layout::Layout, prelude::Constraint, text::Text};
 use slumber_config::Action;
 use slumber_core::{
-    http::{RequestRecord, content_type::ContentType},
+    http::{RequestId, RequestRecord, content_type::ContentType},
     util::{MaybeStr, format_byte_size},
 };
 use std::sync::Arc;
@@ -42,6 +42,10 @@ impl RequestView {
             body,
             body_text_window: Default::default(),
         }
+    }
+
+    pub fn id(&self) -> RequestId {
+        self.request.id
     }
 
     pub fn has_body(&self) -> bool {


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Added a few new actions

- Delete all requests for recipe (from recipe list/pane)
- Delete selected request (from exchange pane)

<img width="523" alt="image" src="https://github.com/user-attachments/assets/4aa53a99-9cd5-4f22-b8ce-c5d56a9c3a44" />


<img width="494" alt="image" src="https://github.com/user-attachments/assets/65e7d45e-2da7-46f4-81b4-4fc8a607c303" />



## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

- The terminology of "Delete Recipe" might be bad. I might change that.

## QA

_How did you test this?_

Unit tests!!

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
