### PR TITLE
Add CLI feature for local dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ That's it!
 - [Fork the repo](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo)
 - Clone your fork
 - `cd slumber`
-- Run `./run.sh`
+- Run `./tui.sh`
   - This will install the appropriate Rust/Cargo toolchain if you don't have it already
   - If you don't have `watchexec-cli` installed, you can just run `cargo run` instead
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ wiremock = {version = "0.6.1", default-features = false}
 
 [dependencies]
 anyhow = {workspace = true, features = ["backtrace"]}
-slumber_cli = {workspace = true}
+slumber_cli = {workspace = true, optional = true}
 slumber_core = {workspace = true}
 slumber_tui = {workspace = true, optional = true}
 tokio = {workspace = true, features = ["macros", "rt"]}
@@ -69,8 +69,9 @@ tracing = {workspace = true}
 tracing-subscriber = {version = "0.3.17", default-features = false, features = ["ansi", "fmt", "registry"]}
 
 [features]
-default = ["tui"]
-# TUI can be disabled in dev to speed compilation while testing CLI
+default = ["cli", "tui"]
+# TUI and CLI can be disabled in dev to speed compilation while not in use
+cli = ["dep:slumber_cli"]
 tui = ["dep:slumber_tui"]
 
 # The profile that 'cargo dist' will build with

--- a/cli.sh
+++ b/cli.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Run the CLI, for development
+
+RUST_LOG=${RUST_LOG:-slumber=${LOG:-DEBUG}} RUST_BACKTRACE=1 \
+    cargo run --no-default-features --features cli \
+    -- $@

--- a/tui.sh
+++ b/tui.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Run the program with watchexec, for development. Normally we could use
+# Run the TUI with watchexec, for development. Normally we could use
 # cargo-watch, but it kills the TUI with SIGKILL so it isn't able to clean up
 # after itself, which fucks the terminal. Once cargo-watch is updated to the
 # latest watchexec we can get rid of this.
@@ -8,5 +8,5 @@
 
 RUST_LOG=${RUST_LOG:-slumber=${LOG:-DEBUG}} RUST_BACKTRACE=1 watchexec --restart --no-process-group \
     --watch Cargo.toml --watch Cargo.lock --watch src/ --watch crates/ \
-    -- cargo run \
+    -- cargo run --no-default-features --features tui \
     -- $@


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Add another feature `cli` that enables/disables compilation of the CLI. This is useful to disable when modifying `slumber_core` but only working on the TUI. It's one less thing to compile. The CLI has a lot of codegen so I bet it's a meaningful piece.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Competing feature sets could lead to more recompilation than necessary in some scenarios.

## QA

_How did you test this?_

Manually

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
