### PR TITLE
Fix selected request not changing with profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Fix output format of `slumber request --dry-run ...` to match `slumber request --verbose`
 - Fix `curl` output for URL-encoded and multipart forms
+- Fix selected request not changing when profile changes
 
 ## [3.0.1] - 2025-02-19
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -51,7 +51,7 @@ slumber_util = {workspace = true, features = ["test"]}
 wiremock = {workspace = true}
 
 [features]
-test = ["dep:rstest"]
+test = ["dep:rstest", "slumber_util/test"]
 
 [package.metadata.release]
 tag = false


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

When the selected profile changes, the selected request would remain the same. This was because the root component was only checking if the selected _recipe_ changed, not the profile. Easy fix.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

This is clearly fragile. Added tests to make that less so.

## QA

_How did you test this?_

Added unit tests, confirmed manually.

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
