### PR TITLE
Add shortcuts to delete requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Add `persist` field to the global config and individual recipes
   - Both default to `true`, but you can now set them to `false` to disable data persistence a single recipe, or all instances of the app. [See here for more](https://slumber.lucaspickering.me/book/user_guide/database.html#controlling-persistence)
 - Add actions to delete requests from the TUI
+  - Delete a single request from the history modal or the Request/Response pane
+  - Delete all requests for a recipe from the Recipe List/Recipe panes
 
 ### Changed
 

--- a/crates/config/src/input.rs
+++ b/crates/config/src/input.rs
@@ -141,6 +141,8 @@ pub enum Action {
     Toggle,
     /// Close the current modal/dialog/etc. OR cancel a request
     Cancel,
+    /// Delete the selected object (e.g. a request)
+    Delete,
     /// Trigger the workflow to provide a temporary override for a recipe value
     /// (body/param/etc.)
     Edit,
@@ -298,6 +300,7 @@ impl Display for KeyCombination {
             KeyCode::Right => write!(f, "→"),
             KeyCode::Esc => write!(f, "<esc>"),
             KeyCode::Enter => write!(f, "<enter>"),
+            KeyCode::Delete => write!(f, "<del>"),
             KeyCode::F(num) => write!(f, "F{}", num),
             KeyCode::Char(' ') => write!(f, "<space>"),
             KeyCode::Char(c) => write!(f, "{c}"),

--- a/crates/tui/src/http.rs
+++ b/crates/tui/src/http.rs
@@ -756,7 +756,7 @@ pub struct ResponseMetadata {
 /// A simplified version of [RequestState], which only stores metadata. This is
 /// useful when you want to show a list of requests and don't need the entire
 /// request/response data for each one.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum RequestStateSummary {
     Building {
         id: RequestId,

--- a/crates/tui/src/input.rs
+++ b/crates/tui/src/input.rs
@@ -176,6 +176,7 @@ impl Default for InputEngine {
                 Action::Submit => KeyCode::Enter.into(),
                 Action::Toggle => KeyCode::Char(' ').into(),
                 Action::Cancel => KeyCode::Esc.into(),
+                Action::Delete => KeyCode::Delete.into(),
                 Action::Edit => KeyCode::Char('e').into(),
                 Action::Reset => KeyCode::Char('z').into(),
                 Action::View => KeyCode::Char('v').into(),

--- a/crates/tui/src/view/component/exchange_pane.rs
+++ b/crates/tui/src/view/component/exchange_pane.rs
@@ -302,49 +302,61 @@ impl ExchangePaneContent {
 
 impl EventHandler for ExchangePaneContent {
     fn update(&mut self, _: &mut UpdateContext, event: Event) -> Option<Event> {
-        event.opt().emitted(self.actions_emitter, |menu_action| {
-            match menu_action {
-                // Generally if we get an action the corresponding
-                // request/response will be present, but we double check in case
-                // the action got delayed in being handled somehow
-                ExchangePaneMenuAction::CopyUrl => {
-                    if let Some(request) = self.state.request() {
-                        request.copy_url();
-                    }
-                }
-                ExchangePaneMenuAction::ViewRequestBody => {
-                    if let Some(request) = self.state.request() {
-                        request.view_body();
-                    }
-                }
-                ExchangePaneMenuAction::CopyRequestBody => {
-                    if let Some(request) = self.state.request() {
-                        request.copy_body();
-                    }
-                }
-                ExchangePaneMenuAction::CopyResponseBody => {
-                    if let Some(response) = self.state.response() {
-                        response.copy_body();
-                    }
-                }
-                ExchangePaneMenuAction::ViewResponseBody => {
-                    if let Some(response) = self.state.response() {
-                        response.view_body();
-                    }
-                }
-                ExchangePaneMenuAction::SaveResponseBody => {
-                    if let Some(response) = self.state.response() {
-                        response.save_response_body();
-                    }
-                }
-                ExchangePaneMenuAction::DeleteRequest => {
+        event
+            .opt()
+            .action(|action, propagate| match action {
+                Action::Delete => {
                     if let Some(request) = self.state.request() {
                         // Show a confirmation modal
                         DeleteRequestModal::new(request.id()).open();
                     }
                 }
-            }
-        })
+                _ => propagate.set(),
+            })
+            .emitted(self.actions_emitter, |menu_action| {
+                match menu_action {
+                    // Generally if we get an action the corresponding
+                    // request/response will be present, but we double check in
+                    // case the action got delayed in being
+                    // handled somehow
+                    ExchangePaneMenuAction::CopyUrl => {
+                        if let Some(request) = self.state.request() {
+                            request.copy_url();
+                        }
+                    }
+                    ExchangePaneMenuAction::ViewRequestBody => {
+                        if let Some(request) = self.state.request() {
+                            request.view_body();
+                        }
+                    }
+                    ExchangePaneMenuAction::CopyRequestBody => {
+                        if let Some(request) = self.state.request() {
+                            request.copy_body();
+                        }
+                    }
+                    ExchangePaneMenuAction::CopyResponseBody => {
+                        if let Some(response) = self.state.response() {
+                            response.copy_body();
+                        }
+                    }
+                    ExchangePaneMenuAction::ViewResponseBody => {
+                        if let Some(response) = self.state.response() {
+                            response.view_body();
+                        }
+                    }
+                    ExchangePaneMenuAction::SaveResponseBody => {
+                        if let Some(response) = self.state.response() {
+                            response.save_response_body();
+                        }
+                    }
+                    ExchangePaneMenuAction::DeleteRequest => {
+                        if let Some(request) = self.state.request() {
+                            // Show a confirmation modal
+                            DeleteRequestModal::new(request.id()).open();
+                        }
+                    }
+                }
+            })
     }
 
     fn menu_actions(&self) -> Vec<MenuAction> {
@@ -529,8 +541,7 @@ impl IntoMenuAction<ExchangePaneContent> for ExchangePaneMenuAction {
             Self::CopyUrl
             | Self::CopyRequestBody
             | Self::CopyResponseBody
-            | Self::SaveResponseBody
-            | Self::DeleteRequest => None,
+            | Self::SaveResponseBody => None,
             Self::ViewRequestBody => {
                 if matches!(data.tabs.data().selected(), Tab::Request) {
                     Some(Action::View)
@@ -545,6 +556,7 @@ impl IntoMenuAction<ExchangePaneContent> for ExchangePaneMenuAction {
                     None
                 }
             }
+            Self::DeleteRequest => Some(Action::Delete),
         }
     }
 }

--- a/crates/tui/src/view/component/history.rs
+++ b/crates/tui/src/view/component/history.rs
@@ -1,11 +1,11 @@
 use crate::{
     context::TuiContext,
-    http::RequestStateSummary,
+    http::{RequestStateSummary, RequestStore},
     util::ResultReported,
     view::{
         UpdateContext, ViewContext,
-        common::{list::List, modal::Modal},
-        component::Component,
+        common::{button::ButtonGroup, list::List, modal::Modal},
+        component::{Component, misc::ConfirmButton},
         draw::{Draw, DrawMetadata, Generate},
         event::{Child, Event, EventHandler, OptionEvent, ToEmitter},
         state::select::{SelectState, SelectStateEvent, SelectStateEventType},
@@ -16,6 +16,7 @@ use ratatui::{
     layout::Constraint,
     text::{Line, Span},
 };
+use slumber_config::Action;
 use slumber_core::{collection::RecipeId, http::RequestId};
 
 /// Browse request/response history for a recipe
@@ -23,6 +24,13 @@ use slumber_core::{collection::RecipeId, http::RequestId};
 pub struct History {
     recipe_name: String,
     select: Component<SelectState<RequestStateSummary>>,
+    /// Are we in the process of deleting the selected request? If so, we'll
+    /// show a delete confirmation instead of the normal list.
+    deleting: bool,
+    /// Confirmation buttons for a deletion. This can't be part of the above
+    /// option because it makes the emitter handling logic in `update()`
+    /// annoying. This needs to be reset between deletes.
+    delete_confirm_buttons: Component<ButtonGroup<ConfirmButton>>,
 }
 
 impl History {
@@ -47,54 +55,111 @@ impl History {
         Self {
             recipe_name,
             select: select.into(),
+            deleting: false,
+            delete_confirm_buttons: Default::default(),
+        }
+    }
+
+    /// Delete the selected request from the request store and our own list
+    fn delete_selected(&mut self, request_store: &mut RequestStore) {
+        // It doesn't make sense to get to this point in the workflow without
+        // a selected request ID, but we don't want to panic if we do
+        if let Some(request) = self.select.data().selected() {
+            request_store
+                .delete_request(request.id())
+                .reported(&ViewContext::messages_tx());
+        }
+        self.select.data_mut().delete_selected();
+        if self.select.data().is_empty() {
+            // Let the root know there's nothing left. This is necessary because
+            // the select doesn't emit an event when the final item is deleted
+            ViewContext::push_event(Event::HttpSelectRequest(None));
         }
     }
 }
 
 impl Modal for History {
     fn title(&self) -> Line<'_> {
-        vec![
-            "History for ".into(),
-            Span::styled(
-                self.recipe_name.as_str(),
-                TuiContext::get().styles.text.primary,
-            ),
-        ]
-        .into()
+        if self.deleting {
+            "Delete Request?".into()
+        } else {
+            vec![
+                "History for ".into(),
+                Span::styled(
+                    self.recipe_name.as_str(),
+                    TuiContext::get().styles.text.primary,
+                ),
+            ]
+            .into()
+        }
     }
 
     fn dimensions(&self) -> (Constraint, Constraint) {
-        (
-            Constraint::Length(40),
-            Constraint::Length(self.select.data().len().min(20) as u16),
-        )
+        let height = if self.deleting {
+            1
+        } else {
+            self.select.data().len().min(20) as u16
+        };
+        (Constraint::Length(40), Constraint::Length(height))
     }
 }
 
 impl EventHandler for History {
-    fn update(&mut self, _: &mut UpdateContext, event: Event) -> Option<Event> {
-        event.opt().emitted(self.select.to_emitter(), |event| {
-            if let SelectStateEvent::Select(index) = event {
-                ViewContext::push_event(Event::HttpSelectRequest(Some(
-                    self.select.data()[index].id(),
-                )))
-            }
-        })
+    fn update(
+        &mut self,
+        context: &mut UpdateContext,
+        event: Event,
+    ) -> Option<Event> {
+        event
+            .opt()
+            .action(|action, propagate| match action {
+                Action::Delete => {
+                    if self.select.data().selected().is_some() {
+                        // Morph into a confirmation modal
+                        self.deleting = true;
+                    }
+                }
+                _ => propagate.set(),
+            })
+            .emitted(self.delete_confirm_buttons.to_emitter(), |event| {
+                if event == ConfirmButton::Yes {
+                    self.delete_selected(context.request_store);
+                }
+                // Reset state for next time
+                self.deleting = false;
+                self.delete_confirm_buttons = Default::default();
+            })
+            .emitted(self.select.to_emitter(), |event| {
+                if let SelectStateEvent::Select(index) = event {
+                    ViewContext::push_event(Event::HttpSelectRequest(Some(
+                        self.select.data()[index].id(),
+                    )))
+                }
+            })
     }
 
     fn children(&mut self) -> Vec<Component<Child<'_>>> {
-        vec![self.select.to_child_mut()]
+        if self.deleting {
+            vec![self.delete_confirm_buttons.to_child_mut()]
+        } else {
+            vec![self.select.to_child_mut()]
+        }
     }
 }
 
 impl Draw for History {
     fn draw(&self, frame: &mut Frame, _: (), metadata: DrawMetadata) {
-        self.select.draw(
-            frame,
-            List::from(self.select.data()),
-            metadata.area(),
-            true,
-        );
+        if self.deleting {
+            self.delete_confirm_buttons
+                .draw(frame, (), metadata.area(), true);
+        } else {
+            self.select.draw(
+                frame,
+                List::from(self.select.data()),
+                metadata.area(),
+                true,
+            );
+        }
     }
 }
 
@@ -138,5 +203,131 @@ impl Generate for &RequestStateSummary {
 impl PartialEq<RequestStateSummary> for RequestId {
     fn eq(&self, other: &RequestStateSummary) -> bool {
         self == &other.id()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        test_util::{TestHarness, TestTerminal, harness, terminal},
+        view::test_util::TestComponent,
+    };
+    use crossterm::event::KeyCode;
+    use itertools::Itertools;
+    use rstest::rstest;
+    use slumber_core::http::Exchange;
+    use slumber_util::{Factory, assert_matches};
+
+    /// Test that we can browse requests, and selecting one updates root state
+    #[rstest]
+    fn test_navigation(harness: TestHarness, terminal: TestTerminal) {
+        let profile_id = harness.collection.first_profile_id();
+        let recipe_id = harness.collection.first_recipe_id();
+        // Populate the DB
+        let exchanges = (0..2)
+            .map(|_| {
+                Exchange::factory((Some(profile_id.clone()), recipe_id.clone()))
+            })
+            // Sort to match the modal
+            .sorted_by_key(|exchange| exchange.start_time)
+            .rev()
+            .collect_vec();
+        for exchange in &exchanges {
+            harness.database.insert_exchange(exchange).unwrap();
+        }
+
+        let requests = harness
+            .request_store
+            .borrow_mut()
+            .load_summaries(Some(profile_id), recipe_id)
+            .unwrap()
+            .collect();
+        let mut component = TestComponent::new(
+            &harness,
+            &terminal,
+            History::new(recipe_id, requests, None),
+        );
+
+        // Initial state
+        let selected = assert_matches!(
+            component.int().drain_draw().events(),
+            &[Event::HttpSelectRequest(Some(selected))] => selected,
+        );
+        assert_eq!(selected, exchanges[0].id);
+
+        // Select the next one
+        let selected = assert_matches!(
+            component.int().send_key(KeyCode::Down).events(),
+            &[Event::HttpSelectRequest(Some(selected))] => selected,
+        );
+        assert_eq!(selected, exchanges[1].id);
+    }
+
+    /// Test that we can delete requests from the store
+    #[rstest]
+    fn test_delete(harness: TestHarness, terminal: TestTerminal) {
+        let profile_id = harness.collection.first_profile_id();
+        let recipe_id = harness.collection.first_recipe_id();
+        // Populate the DB
+        let exchanges = (0..2)
+            .map(|_| {
+                Exchange::factory((Some(profile_id.clone()), recipe_id.clone()))
+            })
+            // Sort to match the modal
+            .sorted_by_key(|exchange| exchange.start_time)
+            .rev()
+            .collect_vec();
+        for exchange in &exchanges {
+            harness.database.insert_exchange(exchange).unwrap();
+        }
+
+        let requests = harness
+            .request_store
+            .borrow_mut()
+            .load_summaries(Some(profile_id), recipe_id)
+            .unwrap()
+            .collect();
+        let mut component = TestComponent::new(
+            &harness,
+            &terminal,
+            History::new(recipe_id, requests, None),
+        );
+
+        // Initial state
+        let selected = assert_matches!(
+            component.int().drain_draw().events(),
+            &[Event::HttpSelectRequest(Some(selected))] => selected,
+        );
+        assert_eq!(selected, exchanges[0].id);
+
+        // Delete the first. Second is now selected
+        let selected = assert_matches!(
+            component
+                .int()
+                .send_keys([KeyCode::Delete, KeyCode::Enter])
+                .events(),
+            &[Event::HttpSelectRequest(Some(selected))] => selected,
+        );
+        assert_eq!(selected, exchanges[1].id);
+
+        // Delete the second. Nothing selected now
+        assert_matches!(
+            component
+                .int()
+                .send_keys([KeyCode::Delete, KeyCode::Enter])
+                .events(),
+            &[Event::HttpSelectRequest(None)],
+        );
+
+        // Make sure both the request store and the DB were updated
+        let requests = harness
+            .request_store
+            .borrow_mut()
+            .load_summaries(Some(profile_id), recipe_id)
+            .unwrap()
+            .collect_vec();
+        assert_eq!(&requests, &[]);
+        assert_eq!(&harness.database.get_all_requests().unwrap(), &[]);
     }
 }

--- a/crates/tui/src/view/component/misc.rs
+++ b/crates/tui/src/view/component/misc.rs
@@ -274,6 +274,16 @@ impl IntoModal for Select {
     }
 }
 
+/// Buttons in a yes/no confirmation modal
+#[derive(
+    Copy, Clone, Debug, Default, Display, EnumCount, EnumIter, PartialEq,
+)]
+pub enum ConfirmButton {
+    No,
+    #[default]
+    Yes,
+}
+
 /// Inner state for the prompt modal
 #[derive(derive_more::Debug)]
 pub struct ConfirmModal {
@@ -286,16 +296,6 @@ pub struct ConfirmModal {
     answer: bool,
     #[debug(skip)]
     on_submit: Box<dyn 'static + FnOnce(bool)>,
-}
-
-/// Buttons in the confirmation modal
-#[derive(
-    Copy, Clone, Debug, Default, Display, EnumCount, EnumIter, PartialEq,
-)]
-enum ConfirmButton {
-    No,
-    #[default]
-    Yes,
 }
 
 impl ConfirmModal {

--- a/crates/tui/src/view/component/recipe_pane.rs
+++ b/crates/tui/src/view/component/recipe_pane.rs
@@ -193,7 +193,7 @@ pub enum RecipeMenuAction {
     CopyUrl,
     #[display("Copy as cURL")]
     CopyCurl,
-    #[display("Delete Recipe")]
+    #[display("Delete Requests")]
     DeleteRecipe,
 }
 

--- a/crates/tui/src/view/component/root.rs
+++ b/crates/tui/src/view/component/root.rs
@@ -539,7 +539,7 @@ mod tests {
         assert_eq!(component.data().selected_request_id(), Some(exchange2.id));
     }
 
-    /// Test "Delete Recipe" action via both the recipe pane
+    /// Test "Delete Requests" action via both the recipe pane
     #[rstest]
     fn test_delete_recipe_requests(
         harness: TestHarness,
@@ -577,7 +577,7 @@ mod tests {
             Some(new_exchange.id)
         );
 
-        // Select "Delete Recipe" but decline the confirmation
+        // Select "Delete Requests" but decline the confirmation
         component
             .int_props(props_factory)
             .open_actions()
@@ -599,7 +599,7 @@ mod tests {
             Some(new_exchange.id)
         );
 
-        // Select "Delete Recipe" and accept. I don't feel like testing Delete
+        // Select "Delete Requests" and accept. I don't feel like testing Delete
         // for All Profiles
         component
             .int_props(props_factory)

--- a/docs/src/api/configuration/input_bindings.md
+++ b/docs/src/api/configuration/input_bindings.md
@@ -54,6 +54,7 @@ input_bindings:
 | `submit`              | `enter`                     | Send a request, submit a text box, etc.               |
 | `toggle`              | `space`                     | Toggle a checkbox on/off                              |
 | `cancel`              | `esc`                       | Cancel current dialog or request                      |
+| `delete`              | `delete`                    | Delete the selected object (e.g. a request)           |
 | `edit`                | `e`                         | Apply a temporary override to a recipe value          |
 | `reset`               | `r`                         | Reset temporary recipe override to its default        |
 | `view`                | `v`                         | Open the selected content (e.g. body) in your pager   |


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

- `delete` keybinding now deletes a request from the request/response pane
- Delete requests from the history modal with that action as well

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Users who have `delete` bound to something else already will have issues.

## QA

_How did you test this?_

Unit tests, manually tested history delete

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
