### PR TITLE
Persist response queries separately for each content type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+- Persist response query commands separately for each content type
+  - This prevents commands from running on the incorrect content type when the response type changes
+
 ## [3.1.0] - 2025-04-04
 
 This releases focuses on history and data management. A suite of new features and improvements make it easy to disable request persistence and delete past requests from history.

--- a/slumber.yml
+++ b/slumber.yml
@@ -59,6 +59,12 @@ chains:
   big_file:
     source: !file
       path: Cargo.lock
+  response_type:
+    source: !select
+      options:
+        - json
+        - html
+        - xml
 
 .ignore:
   base: &base
@@ -154,3 +160,8 @@ requests:
     name: Delay
     method: GET
     url: "{{host}}/delay/5"
+
+  dynamic_repsonse_type: !request
+    name: Dynamic Response Type
+    method: GET
+    url: "{{host}}/{{chains.response_type}}"


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

This prevents running the command on the wrong response type when the response content type changes. E.g. if a response type changes from JSON to an HTML error page, we won't try to run the previous `jq` command on the body. When switching back to JSON, the old command will come back.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

- More persisted data in the DB takes up more space. Commands are small though and most recipes will only have 1 or 2 response types tops
- Change in the persisted key means old commands will be lost on the next upgrade.

## QA

_How did you test this?_

Manually

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
