### PR TITLE
Split out TUI state to enable collectionless error state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- Use a dedicated error state if collection fails to load on TUI launch
+
 ### Fixed
 
 - Fix TUI crash when using an empty select list
+- Fix automatic collection reloading in Windows
+  - I don't use Windows so I'm not sure exactly what scenarios it may have been broken in, but new unit tests indicate it's working now
 
 ## [3.1.1] - 2025-04-23
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,6 +682,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "file-id"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bc904b9bbefcadbd8e3a9fb0d464a9b979de6324c03b3c663e8994f46a5be36"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1489,6 +1498,19 @@ dependencies = [
  "notify-types",
  "walkdir",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "notify-debouncer-full"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d88b1a7538054351c8258338df7c931a590513fb3745e8c15eb9ff4199b8d1"
+dependencies = [
+ "file-id",
+ "log",
+ "notify",
+ "notify-types",
+ "walkdir",
 ]
 
 [[package]]
@@ -2589,6 +2611,7 @@ dependencies = [
  "itertools",
  "mime",
  "notify",
+ "notify-debouncer-full",
  "persisted",
  "pretty_assertions",
  "ratatui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,9 +210,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 dependencies = [
  "serde",
 ]
@@ -437,10 +437,10 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "crossterm_winapi",
  "futures-core",
- "mio 1.0.3",
+ "mio",
  "parking_lot",
  "rustix",
  "signal-hook",
@@ -1205,11 +1205,11 @@ checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "inotify"
-version = "0.9.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.9.1",
  "inotify-sys",
  "libc",
 ]
@@ -1330,7 +1330,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "libc",
  "redox_syscall",
 ]
@@ -1440,18 +1440,6 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "mio"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
@@ -1486,21 +1474,28 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "6.1.1"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+checksum = "2fee8403b3d66ac7b26aee6e40a897d85dc5ce26f44da36b8b73e987cc52e943"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "filetime",
  "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",
  "log",
- "mio 0.8.11",
+ "mio",
+ "notify-types",
  "walkdir",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "notify-types"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
 name = "nu-ansi-term"
@@ -1761,7 +1756,7 @@ checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "lazy_static",
  "num-traits",
  "rand",
@@ -1896,7 +1891,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdef7f9be5c0122f890d58bdf4d964349ba6a6161f705907526d891efabba57d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "cassowary",
  "compact_str",
  "crossterm",
@@ -1918,7 +1913,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -2074,7 +2069,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "chrono",
  "fallible-iterator",
  "fallible-streaming-iterator",
@@ -2121,7 +2116,7 @@ version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2237,7 +2232,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81d3f8c9bfcc3cbb6b0179eb57042d75b1582bdc65c3cb95f3fa999509c03cbc"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2425,7 +2420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
 dependencies = [
  "libc",
- "mio 1.0.3",
+ "mio",
  "signal-hook",
 ]
 
@@ -2850,7 +2845,7 @@ dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio 1.0.3",
+ "mio",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/crates/cli/src/commands/history.rs
+++ b/crates/cli/src/commands/history.rs
@@ -107,11 +107,11 @@ impl Subcommand for HistoryCommand {
                     (None, None, true) => database.get_all_requests()?,
                     // All requests for the current collection
                     (None, None, false) => database
-                        .into_collection(&global.collection_path()?)?
+                        .into_collection(&global.collection_file()?)?
                         .get_all_requests()?,
                     // All requests for a single recipe in current collection
                     (Some(recipe_id), profile, false) => database
-                        .into_collection(&global.collection_path()?)?
+                        .into_collection(&global.collection_file()?)?
                         .get_recipe_requests(profile.into(), &recipe_id)?,
 
                     // Reject invalid arg groupings. This is a bit of a code
@@ -155,7 +155,7 @@ impl Subcommand for HistoryCommand {
 
             HistorySubcommand::Get { request, display } => {
                 let database = Database::load()?
-                    .into_collection(&global.collection_path()?)?;
+                    .into_collection(&global.collection_file()?)?;
                 let exchange = match request {
                     RecipeOrRequest::Recipe(recipe_id) => database
                         .get_latest_request(ProfileFilter::All, &recipe_id)?

--- a/crates/cli/src/commands/request.rs
+++ b/crates/cli/src/commands/request.rs
@@ -11,7 +11,7 @@ use indexmap::IndexMap;
 use itertools::Itertools;
 use slumber_config::Config;
 use slumber_core::{
-    collection::{Collection, ProfileId, RecipeId},
+    collection::{ProfileId, RecipeId},
     database::{CollectionDatabase, Database},
     http::{
         BuildOptions, Exchange, HttpEngine, RequestRecord, RequestSeed,
@@ -189,10 +189,10 @@ impl BuildRequestCommand {
         RequestSeed,
         TemplateContext,
     )> {
-        let collection_path = global.collection_path()?;
+        let collection_file = global.collection_file()?;
         let config = Config::load()?;
-        let collection = Collection::load(&collection_path)?;
-        let database = Database::load()?.into_collection(&collection_path)?;
+        let collection = collection_file.load()?;
+        let database = Database::load()?.into_collection(&collection_file)?;
         let http_engine = HttpEngine::new(&config.http);
 
         // Validate profile ID, so we can provide a good error if it's invalid

--- a/crates/cli/src/completions.rs
+++ b/crates/cli/src/completions.rs
@@ -60,8 +60,8 @@ pub fn complete_request_id(current: &OsStr) -> Vec<CompletionCandidate> {
 fn load_collection() -> anyhow::Result<Collection> {
     // For now we just lean on the default collection paths. In the future we
     // should be able to look for a --file arg in the command and use that path
-    let path = CollectionFile::try_path(None, None)?;
-    Collection::load(&path)
+    let collection_file = CollectionFile::new(None)?;
+    collection_file.load()
 }
 
 fn get_candidates<T: Into<String>>(

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -64,8 +64,8 @@ pub struct GlobalArgs {
 impl GlobalArgs {
     /// Get the path to the active collection file. Return an error if there is
     /// no collection file present, or if the user specified an invalid file.
-    fn collection_path(&self) -> anyhow::Result<PathBuf> {
-        CollectionFile::try_path(None, self.file.clone())
+    fn collection_file(&self) -> anyhow::Result<CollectionFile> {
+        CollectionFile::new(self.file.clone())
     }
 }
 

--- a/crates/cli/tests/common.rs
+++ b/crates/cli/tests/common.rs
@@ -1,6 +1,7 @@
 #![allow(unused)]
 
 use assert_cmd::Command;
+use slumber_core::collection::CollectionFile;
 use slumber_util::{TempDir, paths::DATA_DIRECTORY_ENV_VARIABLE, temp_dir};
 use std::{
     env,
@@ -24,6 +25,6 @@ fn tests_dir() -> PathBuf {
 }
 
 /// Path to the CLI test collection file
-pub fn collection_file() -> PathBuf {
-    tests_dir().join("slumber.yml")
+pub fn collection_file() -> CollectionFile {
+    CollectionFile::new(Some(tests_dir().join("slumber.yml"))).unwrap()
 }

--- a/crates/cli/tests/test_history.rs
+++ b/crates/cli/tests/test_history.rs
@@ -6,7 +6,7 @@ use crate::common::collection_file;
 use itertools::Itertools;
 use rstest::rstest;
 use slumber_core::{
-    collection::{ProfileId, RecipeId},
+    collection::{CollectionFile, ProfileId, RecipeId},
     database::Database,
     http::{Exchange, RequestId},
 };
@@ -126,7 +126,10 @@ fn init_db(data_dir: &Path) -> Database {
     // Add one under a different collection
     let db = database
         .clone()
-        .into_collection(&get_repo_root().join("slumber.yml"))
+        .into_collection(
+            &CollectionFile::new(Some(get_repo_root().join("slumber.yml")))
+                .unwrap(),
+        )
         .unwrap();
     db.insert_exchange(&Exchange::factory(OTHER_COLLECTION_ID))
         .unwrap();

--- a/crates/core/src/database.rs
+++ b/crates/core/src/database.rs
@@ -7,7 +7,7 @@ mod migrations;
 mod tests;
 
 use crate::{
-    collection::{ProfileId, RecipeId},
+    collection::{CollectionFile, ProfileId, RecipeId},
     database::convert::{CollectionPath, JsonEncoded, SqlWrap},
     http::{Exchange, ExchangeSummary, RequestId},
 };
@@ -218,10 +218,10 @@ impl Database {
     /// then grab its generated ID to create a [CollectionDatabase].
     pub fn into_collection(
         self,
-        path: &Path,
+        file: &CollectionFile,
     ) -> anyhow::Result<CollectionDatabase> {
         // Convert to canonicalize and make serializable
-        let path: CollectionPath = path.try_into()?;
+        let path: CollectionPath = file.path().try_into()?;
 
         // We have to set/get in two separate queries, because RETURNING doesn't
         // return anything if the insert didn't modify
@@ -640,7 +640,10 @@ impl slumber_util::Factory for CollectionDatabase {
     fn factory(_: ()) -> Self {
         use slumber_util::paths::get_repo_root;
         Database::factory(())
-            .into_collection(&get_repo_root().join("slumber.yml"))
+            .into_collection(
+                &CollectionFile::new(Some(get_repo_root().join("slumber.yml")))
+                    .unwrap(),
+            )
             .expect("Error initializing DB collection")
     }
 }

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -24,6 +24,7 @@ indexmap = {workspace = true}
 itertools = {workspace = true}
 mime = {workspace = true}
 notify = {version = "8.0.0", default-features = false, features = ["macos_fsevent"]}
+notify-debouncer-full = {version = "0.5.0", default-features = false}
 persisted = {version = "0.3.1", features = ["serde"]}
 ratatui = {workspace = true, features = ["crossterm", "underline-color", "unstable-widget-ref"]}
 reqwest = {workspace = true}

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -23,7 +23,7 @@ futures = {workspace = true}
 indexmap = {workspace = true}
 itertools = {workspace = true}
 mime = {workspace = true}
-notify = {version = "6.1.1", default-features = false, features = ["macos_fsevent"]}
+notify = {version = "8.0.0", default-features = false, features = ["macos_fsevent"]}
 persisted = {version = "0.3.1", features = ["serde"]}
 ratatui = {workspace = true, features = ["crossterm", "underline-color", "unstable-widget-ref"]}
 reqwest = {workspace = true}

--- a/crates/tui/src/http/tests.rs
+++ b/crates/tui/src/http/tests.rs
@@ -407,7 +407,6 @@ fn test_delete_recipe_requests(harness: TestHarness) {
     let r2p1_id = create_exchange(&harness, Some(&profile1), Some(&recipe2)).id;
     let r2p2_id = create_exchange(&harness, Some(&profile2), Some(&recipe2)).id;
     let all_ids = [r1p1_id, r2p1_id, r1p2_id, r2p2_id];
-    dbg!(all_ids);
 
     let mut store = harness.request_store.borrow_mut();
 

--- a/crates/tui/src/message.rs
+++ b/crates/tui/src/message.rs
@@ -15,7 +15,7 @@ use slumber_core::{
     template::{Prompt, ResponseChannel, Select, Template, TemplateChunk},
 };
 use slumber_util::ResultTraced;
-use std::{fmt::Debug, path::PathBuf, sync::Arc};
+use std::{fmt::Debug, path::PathBuf, process::Command, sync::Arc};
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::trace;
 
@@ -53,6 +53,10 @@ pub enum Message {
     /// Open the collection in the user's editor
     CollectionEdit,
 
+    /// Run a command in a **blocking** subprocess. The command will take over
+    /// the screen while running. Use for editors.
+    Command(Command),
+
     /// Show a yes/no confirmation to the user. Use the included channel to
     /// return the value.
     ConfirmStart(Confirm),
@@ -65,6 +69,10 @@ pub enum Message {
     CopyRequestCurl,
     /// Copy some text to the clipboard
     CopyText(String),
+
+    /// Trigger a redraw. This should be called whenever we have reason to
+    /// believe the UI may have changed due to a background task
+    Draw,
 
     /// An error occurred in some async process and should be shown to the user
     Error { error: anyhow::Error },
@@ -157,10 +165,6 @@ pub enum Message {
         #[debug(skip)]
         on_complete: Callback<Vec<TemplateChunk>>,
     },
-
-    /// Trigger a redraw. This should be called whenever we have reason to
-    /// believe the UI may have changed due to a background task
-    Tick,
 }
 
 /// A static callback included in a message

--- a/crates/tui/src/state.rs
+++ b/crates/tui/src/state.rs
@@ -1,0 +1,824 @@
+use crate::{
+    context::TuiContext,
+    http::{RequestState, RequestStore, TuiHttpProvider},
+    message::{Callback, Message, MessageSender, RequestConfig},
+    util::{self, ResultReported},
+    view::{PreviewPrompter, TuiPrompter, UpdateContext, View},
+};
+use anyhow::{Context, anyhow, bail};
+use bytes::Bytes;
+use notify::{RecommendedWatcher, RecursiveMode, Watcher};
+use ratatui::Frame;
+use slumber_core::{
+    collection::{Collection, CollectionFile, ProfileId},
+    database::CollectionDatabase,
+    http::{Exchange, RequestError, RequestId, RequestSeed},
+    template::{Prompter, Template, TemplateChunk, TemplateContext},
+};
+use slumber_util::ResultTraced;
+use std::{path::Path, sync::Arc};
+use tokio::task;
+use tracing::{error, info};
+
+/// Main TUI state. This is responsible for handling most of the TUI messages
+/// and state updates, as well the case of the collection failing to load on
+/// initial startup.
+#[derive(Debug)]
+pub struct TuiState(TuiStateInner);
+
+impl TuiState {
+    /// Load the collection file and initialize TUI state. If the collection
+    /// fails to load, initialize an error state instead to show the error to
+    /// the user. The error state will watch the file so the user can try to
+    /// fix it without having to restart the TUI.
+    ///
+    /// ## Panics
+    ///
+    /// Panic if the collection fails to load and we're not able to start a file
+    /// watcher on it
+    pub fn load(
+        database: CollectionDatabase,
+        collection_file: CollectionFile,
+        messages_tx: MessageSender,
+    ) -> Self {
+        let collection = match collection_file.load() {
+            Ok(collection) => collection,
+            Err(error) => {
+                return {
+                    // Collection failed to load. Store the error so we can show
+                    // it to the user, and watch the file for changes so they
+                    // don't have to restart the TUI once it's fixed
+                    let Ok(watcher) = watch_collection(
+                        collection_file.path(),
+                        messages_tx.clone(),
+                    ) else {
+                        // If the watcher fails to initialize, there's no point
+                        // in sitting in this error state. Show the original
+                        // collection error. The watcher error is much less
+                        // useful. It's accessible in the logs if needed.
+                        panic!("{error:#}")
+                    };
+                    Self(TuiStateInner::Error {
+                        database,
+                        collection_file,
+                        error,
+                        messages_tx,
+                        _watcher: watcher,
+                    })
+                };
+            }
+        };
+
+        Self(TuiStateInner::Loaded(LoadedState::new(
+            database,
+            collection_file,
+            collection,
+            messages_tx,
+        )))
+    }
+
+    /// Handle an incoming message. Any error here should trigger a subsequent
+    /// message with the error, which will display a modal.
+    ///
+    /// Some messages should be handle in the parent `Tui`, if they require
+    /// access to root-level state. Most message types are handled here though.
+    ///
+    /// ## Panics
+    ///
+    /// Panic if we receive a message of a type that we expected the root TUI
+    /// to handle.
+    pub fn handle_message(&mut self, message: Message) -> anyhow::Result<()> {
+        match &mut self.0 {
+            TuiStateInner::Loaded(state) => state.handle_message(message),
+            // Nothing to do in the error state
+            TuiStateInner::Error {
+                database,
+                collection_file,
+                messages_tx,
+                ..
+            } => match message {
+                // Try to reload from scratch. If it fails again, we'll just
+                // end up with another error state. Unlike the live reloading
+                // which runs in a background task, this will block the main
+                // thread. It makes the logic simpler and blocking shouldn't
+                // be an issue since there isn't anything for the user to do
+                Message::CollectionStartReload => {
+                    *self = Self::load(
+                        database.clone(),
+                        collection_file.clone(),
+                        messages_tx.clone(),
+                    );
+                    Ok(())
+                }
+                // Any other message is not useful to us
+                _ => Ok(()),
+            },
+        }
+    }
+
+    /// Are there any active HTTP requests?
+    pub fn has_active_requests(&self) -> bool {
+        match &self.0 {
+            TuiStateInner::Loaded(state) => {
+                state.request_store.has_active_requests()
+            }
+            TuiStateInner::Error { .. } => false,
+        }
+    }
+
+    /// Handle all events in the queue. Return `true` if at least one event was
+    /// consumed, `false` if the queue was empty
+    pub fn drain_events(&mut self) -> bool {
+        match &mut self.0 {
+            TuiStateInner::Loaded(state) => {
+                state.view.handle_events(UpdateContext {
+                    request_store: &mut state.request_store,
+                })
+            }
+            // There is no event queue in the error state
+            TuiStateInner::Error { .. } => false,
+        }
+    }
+
+    /// Draw the view onto the screen
+    pub fn draw(&self, frame: &mut Frame) {
+        match &self.0 {
+            TuiStateInner::Loaded(state) => {
+                state.view.draw(frame, &state.request_store)
+            }
+            TuiStateInner::Error {
+                collection_file,
+                error,
+                ..
+            } => {
+                // We can't show the real UI without a collection, so just show
+                // the error. We have a watcher on the file so when it changes,
+                // we'll reload it
+                View::draw_collection_load_error(frame, collection_file, error)
+            }
+        }
+    }
+}
+
+/// Inner enum for [TuiState] to avoid exposing the variant values
+#[derive(Debug)]
+enum TuiStateInner {
+    /// TUI loaded successfully and is off and running
+    Loaded(LoadedState),
+    /// Collection failed to load on startup. Without a collection we can't
+    /// show the UI. We'll just sit and wait for it to come back.
+    Error {
+        database: CollectionDatabase,
+        collection_file: CollectionFile,
+        /// Error that occurred while loading the collection
+        error: anyhow::Error,
+        messages_tx: MessageSender,
+        /// Watch the collection file and wait for changes that will hopefully
+        /// fix it. We have to hang onto this because watching stops when it's
+        /// dropped.
+        _watcher: RecommendedWatcher,
+    },
+}
+
+/// Main state for the running TUI. This handles most of the TUI's state
+/// management, event processing, and other life cycle activities. This is only
+/// initialized one we have a valid initial collection.
+#[derive(Debug)]
+struct LoadedState {
+    /// Handle for the file from which the collection will be loaded
+    collection_file: CollectionFile,
+    /// Loaded and deserialized request collection
+    collection: Arc<Collection>,
+
+    /// Persistence database, for storing request state, UI state, etc.
+    database: CollectionDatabase,
+    /// Sender for the mpsc message queue
+    messages_tx: MessageSender,
+    /// In-memory store of request state. This tracks state for requests that
+    /// are in progress, and also serves as a cache for requests from the DB.
+    request_store: RequestStore,
+    /// UI presentation and state
+    view: View,
+
+    /// Watcher for changes to the collection file. Whenever the file changes,
+    /// the collection will be reloaded. This will be `None` iff the watcher
+    /// fails to initialize
+    _watcher: Option<RecommendedWatcher>,
+}
+
+impl LoadedState {
+    /// Initialize state when the collection has been loaded successfully
+    fn new(
+        database: CollectionDatabase,
+        collection_file: CollectionFile,
+        collection: Collection,
+        messages_tx: MessageSender,
+    ) -> Self {
+        let collection = Arc::new(collection);
+        let request_store = RequestStore::new(database.clone());
+        let view =
+            View::new(&collection, database.clone(), messages_tx.clone());
+        let watcher =
+            watch_collection(collection_file.path(), messages_tx.clone()).ok();
+
+        LoadedState {
+            collection_file,
+            collection,
+            database,
+            messages_tx,
+            request_store,
+            view,
+            _watcher: watcher,
+        }
+    }
+
+    /// Handle an incoming message. Any error here should trigger a subsequent
+    /// message with the error, which will display a modal.
+    ///
+    /// Some messages should be handle in the parent `Tui`, if they require
+    /// access to root-level state. Most message types are handled here though.
+    ///
+    /// ## Panics
+    ///
+    /// Panic if we receive a message of a type that we expected the root TUI
+    /// to handle.
+    fn handle_message(&mut self, message: Message) -> anyhow::Result<()> {
+        match message {
+            Message::CollectionStartReload => {
+                let messages_tx = self.messages_tx();
+                let collection_file = self.collection_file.clone();
+                // YAML parsing is CPU-bound so do it in a blocking task. In all
+                // likelihood this will be extremely fast, but it's possible
+                // there's some edge case that causes it to be slow and we don't
+                // want to block the render loop
+                task::spawn_blocking(move || {
+                    let message = match collection_file.load() {
+                        Ok(collection) => {
+                            Message::CollectionEndReload(collection)
+                        }
+                        Err(error) => Message::Error { error },
+                    };
+                    messages_tx.send(message);
+                });
+            }
+            Message::CollectionEndReload(collection) => {
+                self.reload_collection(collection)
+            }
+            Message::CollectionEdit => {
+                let path = self.collection_file.path().to_owned();
+                let command = util::get_editor_command(&path)?;
+                self.messages_tx.send(Message::Command(command));
+            }
+            Message::CopyRequestUrl => self.copy_request_url()?,
+            Message::CopyRequestBody => self.copy_request_body()?,
+            Message::CopyRequestCurl => self.copy_request_curl()?,
+            Message::CopyText(text) => self.view.copy_text(text),
+            Message::SaveResponseBody { request_id, data } => {
+                self.save_response_body(request_id, data).with_context(
+                    || {
+                        format!(
+                            "Error saving response body \
+                            for request {request_id}"
+                        )
+                    },
+                )?;
+            }
+            Message::FileEdit { path, on_complete } => {
+                let command = util::get_editor_command(&path)?;
+                self.messages_tx.send(Message::Command(command));
+                on_complete(path);
+                // The callback may queue an event to read the file, so we can't
+                // delete it yet. Caller is responsible for cleaning up
+            }
+            Message::FileView { path, mime } => {
+                let command = util::get_pager_command(&path, mime.as_ref())?;
+                self.messages_tx.send(Message::Command(command));
+                // We don't need to read the contents back so we can clean up
+                util::delete_temp_file(&path);
+            }
+            Message::Error { error } => self.view.open_modal(error),
+            Message::HttpBeginRequest => self.send_request()?,
+            Message::HttpBuildingTriggered {
+                id,
+                profile_id,
+                recipe_id,
+            } => self.request_store.start(id, profile_id, recipe_id, None),
+            Message::HttpBuildError { error } => {
+                self.request_store.build_error(error);
+            }
+            Message::HttpLoading { request } => {
+                self.request_store.loading(request);
+            }
+            Message::HttpComplete(result) => self.complete_request(result),
+            Message::HttpCancel(request_id) => {
+                self.request_store.cancel(request_id);
+            }
+            Message::HttpGetLatest {
+                profile_id,
+                recipe_id,
+                channel,
+            } => {
+                let exchange = self
+                    .request_store
+                    .load_latest_exchange(profile_id.as_ref(), &recipe_id)
+                    .reported(&self.messages_tx)
+                    .flatten()
+                    .cloned();
+                channel.respond(exchange);
+            }
+            Message::Input { event, action } => {
+                self.view.handle_input(event, action);
+            }
+            Message::Notify(message) => self.view.notify(message),
+            Message::PromptStart(prompt) => {
+                self.view.open_modal(prompt);
+            }
+            Message::SelectStart(select) => {
+                self.view.open_modal(select);
+            }
+            Message::ConfirmStart(confirm) => {
+                self.view.open_modal(confirm);
+            }
+            Message::TemplatePreview {
+                template,
+                on_complete,
+            } => {
+                self.render_template_preview(
+                    template,
+                    // Note: there's a potential bug here, if the selected
+                    // profile changed since this message was queued. In
+                    // practice is extremely unlikely (potentially impossible),
+                    // and this shortcut saves us a lot of plumbing so it's
+                    // worth it
+                    self.view.selected_profile_id().cloned(),
+                    on_complete,
+                )?;
+            }
+
+            // All other messages are handled by the root TUI and should never
+            // get here
+            Message::Command(_) | Message::Quit | Message::Draw => {
+                panic!(
+                    "Unexpected message in TuiState; should have been handled \
+                    by parent: {message:?}"
+                )
+            }
+        }
+        Ok(())
+    }
+
+    /// Get a cheap clone of the message queue transmitter
+    fn messages_tx(&self) -> MessageSender {
+        self.messages_tx.clone()
+    }
+
+    /// Reload state with a new collection
+    fn reload_collection(&mut self, collection: Collection) {
+        self.collection = collection.into();
+
+        // Rebuild the whole view, because tons of things can change
+        self.view = View::new(
+            &self.collection,
+            self.database.clone(),
+            self.messages_tx(),
+        );
+        self.view.notify(format!(
+            "Reloaded collection from {}",
+            self.collection_file.path().to_string_lossy()
+        ));
+    }
+    /// Render URL for a request, then copy it to the clipboard
+    fn copy_request_url(&self) -> anyhow::Result<()> {
+        let RequestConfig {
+            profile_id,
+            recipe_id,
+            options,
+        } = self.request_config()?;
+        let seed = RequestSeed::new(recipe_id, options);
+        let template_context = self.template_context(profile_id, false)?;
+        let messages_tx = self.messages_tx();
+        // Spawn a task to do the render+copy
+        util::spawn_result(async move {
+            let url = TuiContext::get()
+                .http_engine
+                .build_url(seed, &template_context)
+                .await?;
+            messages_tx.send(Message::CopyText(url.to_string()));
+            Ok(())
+        });
+        Ok(())
+    }
+
+    /// Render body for a request, then copy it to the clipboard
+    fn copy_request_body(&self) -> anyhow::Result<()> {
+        let RequestConfig {
+            profile_id,
+            recipe_id,
+            options,
+        } = self.request_config()?;
+        let seed = RequestSeed::new(recipe_id, options);
+        let template_context = self.template_context(profile_id, false)?;
+        let messages_tx = self.messages_tx();
+        // Spawn a task to do the render+copy
+        util::spawn_result(async move {
+            let body = TuiContext::get()
+                .http_engine
+                .build_body(seed, &template_context)
+                .await?
+                .ok_or(anyhow!("Request has no body"))?;
+            // Clone the bytes :(
+            let body = String::from_utf8(body.into())
+                .context("Cannot copy request body")?;
+            messages_tx.send(Message::CopyText(body));
+            Ok(())
+        });
+        Ok(())
+    }
+
+    /// Render a request, then copy the equivalent curl command to the clipboard
+    fn copy_request_curl(&self) -> anyhow::Result<()> {
+        let RequestConfig {
+            profile_id,
+            recipe_id,
+            options,
+        } = self.request_config()?;
+        let seed = RequestSeed::new(recipe_id, options);
+        let template_context = self.template_context(profile_id, false)?;
+        let messages_tx = self.messages_tx();
+        // Spawn a task to do the render+copy
+        util::spawn_result(async move {
+            let command = TuiContext::get()
+                .http_engine
+                .build_curl(seed, &template_context)
+                .await?;
+            messages_tx.send(Message::CopyText(command));
+            Ok(())
+        });
+        Ok(())
+    }
+
+    /// Save the body of a response to a file, prompting the user for a file
+    /// path. If the body text is provided, that will be used. Useful when
+    /// what's being saved differs from the actual response body (because of
+    /// prettification/querying). If not provided, we'll pull the body from the
+    /// request store.
+    fn save_response_body(
+        &self,
+        request_id: RequestId,
+        text: Option<String>,
+    ) -> anyhow::Result<()> {
+        let Some(request_state) = self.request_store.get(request_id) else {
+            bail!("Request not in store")
+        };
+        let RequestState::Response { exchange } = request_state else {
+            bail!("Request is not complete")
+        };
+        // Get a suggested file name from the response if possible
+        let default_path = exchange.response.file_name();
+
+        let data = text.map(Bytes::from).unwrap_or_else(|| {
+            // This is the path we hit for binary and/or large bodies that were
+            // never parsed. This clone is cheap so we're being efficient!
+            exchange.response.body.bytes().clone()
+        });
+        util::spawn_result(util::save_file(
+            self.messages_tx(),
+            default_path,
+            data,
+        ));
+        Ok(())
+    }
+
+    /// Get the current request config for the selected recipe. The config
+    /// defines how to build a request. If no recipe is selected, this returns
+    /// an error. This should only be called in contexts where we can safely
+    /// assume that a recipe is selected (e.g. triggered via an action on a
+    /// recipe), so an error indicates a bug.
+    fn request_config(&self) -> anyhow::Result<RequestConfig> {
+        self.view
+            .request_config()
+            .ok_or_else(|| anyhow!("No recipe selected"))
+    }
+
+    /// Launch an HTTP request in a separate task
+    fn send_request(&mut self) -> anyhow::Result<()> {
+        let RequestConfig {
+            profile_id,
+            recipe_id,
+            options,
+        } = self.request_config()?;
+        // Launch the request in a separate task so it doesn't block.
+        // These clones are all cheap.
+
+        let template_context =
+            self.template_context(profile_id.clone(), false)?;
+        let messages_tx = self.messages_tx();
+
+        let seed = RequestSeed::new(recipe_id.clone(), options);
+        let request_id = seed.id;
+
+        // Don't use spawn_result here, because errors are handled specially for
+        // requests
+        let join_handle = util::spawn(async move {
+            // Build the request
+            let result = TuiContext::get()
+                .http_engine
+                .build(seed, &template_context)
+                .await;
+            let ticket = match result {
+                Ok(ticket) => ticket,
+                Err(error) => {
+                    // Report the error, but don't actually return anything
+                    messages_tx.send(Message::HttpBuildError {
+                        error: error.into(),
+                    });
+                    return;
+                }
+            };
+
+            // Report liftoff
+            messages_tx.send(Message::HttpLoading {
+                request: Arc::clone(ticket.record()),
+            });
+
+            // Send the request and report the result to the main thread
+            let result = ticket.send().await.map_err(Arc::new);
+            messages_tx.send(Message::HttpComplete(result));
+        });
+
+        // Add the new request to the store. This has to go after spawning the
+        // task so we can include the join handle (for cancellation)
+        self.request_store.start(
+            request_id,
+            profile_id,
+            recipe_id,
+            Some(join_handle.abort_handle()),
+        );
+
+        // New requests should get shown in the UI
+        self.view
+            .select_request(&mut self.request_store, request_id);
+
+        Ok(())
+    }
+
+    /// Process the result of an HTTP request
+    fn complete_request(
+        &mut self,
+        result: Result<Exchange, Arc<RequestError>>,
+    ) {
+        match result {
+            Ok(exchange) => {
+                // Persist in the DB if not disabled by global config or recipe
+                let persist = TuiContext::get().config.persist
+                    && self
+                        .collection
+                        .recipes
+                        .try_get_recipe(&exchange.request.recipe_id)
+                        .is_ok_and(|recipe| recipe.persist);
+                if persist {
+                    let _ = self.database.insert_exchange(&exchange).traced();
+                }
+
+                self.request_store.response(exchange);
+            }
+            Err(error) => {
+                self.request_store.request_error(error);
+            }
+        }
+    }
+
+    /// Spawn a task to render a template, storing the result in a pre-defined
+    /// lock. As this is a preview, the user will *not* be prompted for any
+    /// input. A placeholder value will be used for any prompts.
+    fn render_template_preview(
+        &self,
+        template: Template,
+        profile_id: Option<ProfileId>,
+        on_complete: Callback<Vec<TemplateChunk>>,
+    ) -> anyhow::Result<()> {
+        let context = self.template_context(profile_id, true)?;
+        util::spawn(async move {
+            // Render chunks, then write them to the output destination
+            let chunks = template.render_chunks(&context).await;
+            on_complete(chunks);
+        });
+        Ok(())
+    }
+
+    /// Expose app state to the templater. Most of the data has to be cloned out
+    /// to be passed across async boundaries. This is annoying but in reality
+    /// it should be small data.
+    fn template_context(
+        &self,
+        profile_id: Option<ProfileId>,
+        is_preview: bool,
+    ) -> anyhow::Result<TemplateContext> {
+        let collection = &self.collection;
+        let http_provider =
+            TuiHttpProvider::new(self.messages_tx(), is_preview);
+        let prompter: Box<dyn Prompter> = if is_preview {
+            Box::new(PreviewPrompter)
+        } else {
+            Box::new(TuiPrompter::new(self.messages_tx()))
+        };
+
+        Ok(TemplateContext {
+            selected_profile: profile_id,
+            collection: Arc::clone(collection),
+            http_provider: Box::new(http_provider),
+            prompter,
+            overrides: Default::default(),
+            state: Default::default(),
+        })
+    }
+}
+
+/// Spawn a file system watcher that watches the collection file for changes.
+/// When it changes, trigger a collection reload by sending a message. **The
+/// watcher will stop when it is dropped, so hang onto the return value!!**
+fn watch_collection(
+    path: &Path,
+    messages_tx: MessageSender,
+) -> notify::Result<RecommendedWatcher> {
+    let on_file_event = move |result: notify::Result<notify::Event>| {
+        match dbg!(result) {
+            // Only reload if the file is modified. Some editors may truncrate
+            // and recreate files instead of modifying
+            // https://docs.rs/notify/latest/notify/#editor-behaviour
+            Ok(
+                event @ notify::Event {
+                    // Modify/create type is useless on Windows
+                    // https://github.com/notify-rs/notify/issues/633
+                    kind:
+                        notify::EventKind::Modify(_) | notify::EventKind::Create(_),
+                    ..
+                },
+            ) => {
+                info!(?event, "Collection file changed, reloading");
+                messages_tx.send(Message::CollectionStartReload);
+            }
+            // Do nothing for other event kinds
+            Ok(_) => {}
+            Err(err) => {
+                error!(error = %err, "Error watching file");
+            }
+        }
+    };
+
+    // Spawn the watcher
+    let mut watcher = notify::recommended_watcher(on_file_event)?;
+    watcher.watch(path, RecursiveMode::NonRecursive)?;
+    info!(path = ?path, ?watcher, "Watching file for changes");
+    Ok(watcher)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_util::{TestHarness, harness};
+    use rstest::rstest;
+    use slumber_util::{TempDir, assert_matches, temp_dir};
+    use std::fs;
+
+    /// Load a collection, then change the file to trigger a reload
+    #[rstest]
+    #[tokio::test]
+    async fn test_reload_collection(
+        temp_dir: TempDir,
+        mut harness: TestHarness,
+    ) {
+        // Start with an empty collection
+        let file = collection_file(&temp_dir);
+
+        let mut state = TuiState::load(
+            harness.database.clone(),
+            file.clone(),
+            harness.messages_tx().clone(),
+        );
+        // Make sure it loaded correctly
+        let collection = assert_matches!(
+            &state.0,
+            TuiStateInner::Loaded(LoadedState { collection, ..}) => collection,
+        );
+        assert_eq!(collection.recipes.iter().count(), 0);
+
+        // Update the file, make sure it's reflected
+        fs::write(
+            file.path(),
+            r#"
+requests:
+    test: !request
+        method: "GET"
+        url: "test"
+"#,
+        )
+        .unwrap();
+
+        // We need to manually plumb messages through. Normally the TUI loop
+        // does this
+        let message = harness.pop_message_wait().await;
+        assert_matches!(message, Message::CollectionStartReload);
+        state.handle_message(message).unwrap();
+        let message = harness.pop_message_wait().await;
+        assert_matches!(message, Message::CollectionEndReload { .. });
+        state.handle_message(message).unwrap();
+
+        // And it's done!
+        let collection = assert_matches!(
+            &state.0,
+            TuiStateInner::Loaded(LoadedState { collection, ..}) => collection,
+        );
+        assert_eq!(collection.recipes.iter().count(), 1);
+    }
+
+    /// Test an error in the collection during initial load. Should shove us
+    /// into an error state. After fixing the error, it will reload with the
+    /// valid collection.
+    #[rstest]
+    #[tokio::test]
+    async fn test_initial_load_error(
+        temp_dir: TempDir,
+        mut harness: TestHarness,
+    ) {
+        // Start with an invalid collection
+        let file = collection_file(&temp_dir);
+        fs::write(file.path(), "requests: 3").unwrap();
+
+        // Should load into an error state
+        let mut state = TuiState::load(
+            harness.database.clone(),
+            file.clone(),
+            harness.messages_tx().clone(),
+        );
+        assert_matches!(&state.0, TuiStateInner::Error { error, .. });
+
+        // Update the file, make sure it's reflected
+        fs::write(file.path(), "requests: {}").unwrap();
+
+        // We need to manually plumb messages through. Normally the TUI loop
+        // does this
+        let message = harness.pop_message_wait().await;
+        assert_matches!(message, Message::CollectionStartReload);
+        state.handle_message(message).unwrap();
+        // The error state loads the collection in the main thread so there's no
+        // CollectionEndReload message
+
+        // And it's done!
+        let collection = assert_matches!(
+            &state.0,
+            TuiStateInner::Loaded(LoadedState { collection, ..}) => collection,
+        );
+        assert_eq!(collection.recipes.iter().count(), 0);
+    }
+
+    /// Collection is loaded successfully on startup, but then changed to have
+    /// an error. The old collection should remain in use but the error is
+    /// shown.
+    #[rstest]
+    #[tokio::test]
+    async fn test_reload_error(temp_dir: TempDir, mut harness: TestHarness) {
+        // Start with an empty collection
+        let file = collection_file(&temp_dir);
+
+        let mut state = TuiState::load(
+            harness.database.clone(),
+            file.clone(),
+            harness.messages_tx().clone(),
+        );
+        // Make sure it loaded correctly
+        let collection = assert_matches!(
+            &state.0,
+            TuiStateInner::Loaded(LoadedState { collection, ..}) => collection,
+        );
+        assert_eq!(collection.recipes.iter().count(), 0);
+
+        // Update the file with an invalid colletion
+        fs::write(file.path(), "requests: 3").unwrap();
+
+        // We need to manually plumb messages through. Normally the TUI loop
+        // does this
+        let message = harness.pop_message_wait().await;
+        assert_matches!(message, Message::CollectionStartReload);
+        state.handle_message(message).unwrap();
+        // Load failed!!
+        let message = harness.pop_message_wait().await;
+        assert_matches!(message, Message::Error { .. });
+        state.handle_message(message).unwrap();
+
+        // We remain in valid mode with the original collection
+        let collection = assert_matches!(
+            &state.0,
+            TuiStateInner::Loaded(LoadedState { collection, ..}) => collection,
+        );
+        assert_eq!(collection.recipes.iter().count(), 0);
+    }
+
+    /// Get a path to a collection file in a directory. The file will be created
+    /// with an empty collection
+    fn collection_file(directory: &Path) -> CollectionFile {
+        let path = directory.join("slumber.yml");
+        fs::write(&path, "requests: {}").unwrap();
+        CollectionFile::new(Some(path)).unwrap()
+    }
+}

--- a/crates/tui/src/util.rs
+++ b/crates/tui/src/util.rs
@@ -148,7 +148,7 @@ pub fn spawn(future: impl 'static + Future<Output = ()>) -> JoinHandle<()> {
             _ = future => {
                 // Assume the task updated _something_ visible to the user,
                 // so trigger a redraw here
-                ViewContext::messages_tx().send(Message::Tick);
+                ViewContext::messages_tx().send(Message::Draw);
             },
             _ = CANCEL_TOKEN.cancelled() => {},
         }

--- a/crates/tui/src/view/component/response_view.rs
+++ b/crates/tui/src/view/component/response_view.rs
@@ -277,7 +277,7 @@ mod tests {
             })
             .await;
             // Background task sends a message to redraw
-            assert_matches!(harness.pop_message_now(), Message::Tick);
+            assert_matches!(harness.pop_message_now(), Message::Draw);
             component.int().drain_draw().assert_empty();
         }
 


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Split TUI state into an enum that handles two separate cases:

- Normal operations
- Collection fails to load

This prevents the user from dropping into the TUI when we have no collection to show them.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_



## QA

_How did you test this?_

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
