### PR TITLE
Fully deinitialize terminal when yielding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - Fix pager view action (regression in 3.1.2)
+- Fully restore terminal before exiting to editor/pager
+  - This means any stdout/stderr that the external process writes will be properly formatted in the terminal
 
 ## [3.1.2] - 2025-05-30
 

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -90,7 +90,9 @@ impl Tui {
         // The code to revert the terminal takeover is in `Tui::drop`, so we
         // shouldn't take over the terminal until right before creating the
         // `Tui`.
-        let terminal = initialize_terminal()?;
+        initialize_panic_handler();
+        initialize_terminal()?;
+        let terminal = Terminal::new(CrosstermBackend::new(io::stdout()))?;
 
         let app = Tui {
             terminal,
@@ -183,10 +185,8 @@ impl Tui {
     /// Handle an incoming message. Any error here will be displayed as a modal
     fn handle_message(&mut self, message: Message) -> anyhow::Result<()> {
         match message {
-            Message::ClearTerminal { message } => {
-                self.terminal.draw(|frame| {
-                    frame.render_widget(message, frame.area());
-                })?;
+            Message::ClearTerminal => {
+                self.terminal.clear()?;
                 Ok(())
             }
 

--- a/crates/tui/src/message.rs
+++ b/crates/tui/src/message.rs
@@ -46,9 +46,8 @@ impl MessageSender {
 /// context), but are all handled by the top-level controller.
 #[derive(derive_more::Debug)]
 pub enum Message {
-    /// Clear the terminal and display a message. Use this before deferring to
-    /// a subprocess
-    ClearTerminal { message: &'static str },
+    /// Clear the terminal. Use this before deferring to a subprocess
+    ClearTerminal,
 
     /// Trigger collection reload
     CollectionStartReload,

--- a/crates/tui/src/state.rs
+++ b/crates/tui/src/state.rs
@@ -362,7 +362,7 @@ impl LoadedState {
 
             // All other messages are handled by the root TUI and should never
             // get here
-            Message::ClearTerminal { .. } | Message::Quit | Message::Draw => {
+            Message::ClearTerminal | Message::Quit | Message::Draw => {
                 panic!(
                     "Unexpected message in TuiState; should have been handled \
                     by parent: {message:?}"


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Should fix line indentation in stdout/stderr from external pagers/editors.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

We can no longer show the "Waiting for subprocess..." message. This was only useful for GUIs though and I get the sense not many people use that, so I think it's worth the tradeoff.

## QA

_How did you test this?_

Manually printing stdout content from the pager

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
