### PR TITLE
Add follow_redirects config field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Add config field `follow_redirects` to enable/disable following 3xx redirects (enabled by default)
+  - The behavior has always been to follow redirects, so this adds the ability to disable that globally
+  - **Reminder:** Global configuration is not automatically reloaded. After making changes to your `config.yml`, you'll need to restart Slumber for changes to take effect
+  - [See docs for more](https://slumber.lucaspickering.me/book/api/configuration/index.html#follow_redirects)
+
 ## [3.1.3] - 2025-06-07
 
 ### Fixed

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -175,6 +175,8 @@ pub struct HttpEngineConfig {
     /// Request/response bodies over this size are treated differently, for
     /// performance reasons
     pub large_body_size: usize,
+    /// Follow 3xx redirects automatically. Enabled by default
+    pub follow_redirects: bool,
 }
 
 impl HttpEngineConfig {
@@ -191,6 +193,7 @@ impl Default for HttpEngineConfig {
         Self {
             ignore_certificate_hosts: Default::default(),
             large_body_size: 1000 * 1000, // 1MB
+            follow_redirects: true,
         }
     }
 }

--- a/docs/src/api/configuration/index.md
+++ b/docs/src/api/configuration/index.md
@@ -66,6 +66,14 @@ Enable developer information in the TUI
 
 Command to use when opening files for in-app editing. [More info](../../user_guide/tui/editor.md#editing)
 
+### `follow_redirects`
+
+**Type:** `boolean`
+
+**Default:** `true`
+
+Enable/disable following redirects (3xx status codes) automatically. If enabled, the HTTP client follow redirects [up to 10 times](https://docs.rs/reqwest/0.12.15/reqwest/index.html#redirect-policies).
+
 ### `ignore_certificate_hosts`
 
 **Type:** `string`

--- a/slumber.yml
+++ b/slumber.yml
@@ -171,3 +171,8 @@ requests:
     name: Dynamic Response Type
     method: GET
     url: "{{host}}/{{chains.response_type}}"
+
+  redirect: !request
+    name: Redirect
+    method: GET
+    url: "{{host}}/redirect-to?url={{host}}/get"


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Users can globally disable the default behavior to follow 3xx redirects.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Enabling/disabling globally may be annoying. I considered adding a recipe field to control this as well, but I went with the more conservative change to begin with. I don't want to clutter the `Recipe` model with stuff that will never be used.

## QA

_How did you test this?_

Tested manually, added unit tests

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
