### PR TITLE
Add `target` argument to `slumber show paths`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   - The behavior has always been to follow redirects, so this adds the ability to disable that globally
   - **Reminder:** Global configuration is not automatically reloaded. After making changes to your `config.yml`, you'll need to restart Slumber for changes to take effect
   - [See docs for more](https://slumber.lucaspickering.me/book/api/configuration/index.html#follow_redirects)
+- Add optional `target` argument to `slumber show paths` to show just a single path
+  - E.g. `slumber show paths config` prints just the config path
 
 ## Fixed
 

--- a/crates/cli/src/commands/show.rs
+++ b/crates/cli/src/commands/show.rs
@@ -15,18 +15,37 @@ pub struct ShowCommand {
 
 #[derive(Copy, Clone, Debug, clap::Subcommand)]
 enum ShowTarget {
-    /// Print the path of all directories/files that Slumber uses
-    Paths,
+    /// Print the path of directories/files that Slumber uses
+    Paths {
+        /// Print the path for just a single target
+        target: Option<PathsTarget>,
+    },
     /// Print loaded configuration
+    ///
+    /// This loads the config and re-stringifies it, so it will print exactly
+    /// what Slumber will use in action.
     Config,
     /// Print current request collection
+    ///
+    /// This loads the collection and re-stringifies it, so it will print
+    /// exactly what Slumber will use in action.
     Collection,
+}
+
+#[derive(Copy, Clone, Debug, clap::ValueEnum)]
+enum PathsTarget {
+    Collection,
+    Config,
+    #[value(name = "db")]
+    Database,
+    Log,
 }
 
 impl Subcommand for ShowCommand {
     async fn execute(self, global: GlobalArgs) -> anyhow::Result<ExitCode> {
         match self.target {
-            ShowTarget::Paths => {
+            // Print paths
+            ShowTarget::Paths { target: None } => {
                 println!("Config: {}", Config::path().display());
                 println!("Database: {}", Database::path().display());
                 println!("Log file: {}", paths::log_file().display());
@@ -38,10 +57,33 @@ impl Subcommand for ShowCommand {
                         .unwrap_or_else(|error| error.to_string())
                 );
             }
+            ShowTarget::Paths {
+                target: Some(PathsTarget::Config),
+            } => {
+                println!("{}", Config::path().display());
+            }
+            ShowTarget::Paths {
+                target: Some(PathsTarget::Collection),
+            } => {
+                println!("{}", global.collection_file()?);
+            }
+            ShowTarget::Paths {
+                target: Some(PathsTarget::Database),
+            } => {
+                println!("{}", Database::path().display());
+            }
+            ShowTarget::Paths {
+                target: Some(PathsTarget::Log),
+            } => {
+                println!("{}", paths::log_file().display());
+            }
+
+            // Print config
             ShowTarget::Config => {
                 let config = Config::load()?;
                 println!("{}", to_yaml(&config));
             }
+            // Print collection
             ShowTarget::Collection => {
                 let collection_file = global.collection_file()?;
                 let collection = collection_file.load()?;

--- a/crates/cli/tests/common.rs
+++ b/crates/cli/tests/common.rs
@@ -21,7 +21,7 @@ pub fn slumber() -> (Command, TempDir) {
 }
 
 fn tests_dir() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/")
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests")
 }
 
 /// Path to the CLI test collection file

--- a/crates/cli/tests/test_show.rs
+++ b/crates/cli/tests/test_show.rs
@@ -1,0 +1,70 @@
+//! Test the `slumber show` subcommand and its sub-subcommands: paths, config,
+//! collection
+
+mod common;
+
+use predicates::{prelude::predicate, str::PredicateStrExt};
+use rstest::rstest;
+use slumber_config::Config;
+use std::path::PathBuf;
+
+/// Test `slumber show paths` prints all relevant paths
+#[test]
+fn test_show_paths_all() {
+    let (mut command, data_dir) = common::slumber();
+    command.args(["show", "paths"]);
+    command.assert().success().stdout(format!(
+        "Config: {config}
+Database: {database}
+Log file: {log_file}
+Collection: {collection}
+",
+        config = data_dir.join("config.yml").display(),
+        database = data_dir.join("state.sqlite").display(),
+        log_file = data_dir.join("slumber.log").display(),
+        collection = common::collection_file(),
+    ));
+}
+
+/// Parameterized test for `slumber show paths <target>` for each target
+#[rstest]
+#[case::config("config", "config.yml")]
+#[case::collection("collection", common::collection_file().path().to_owned())]
+#[case::database("db", "state.sqlite")]
+#[case::log("log", "slumber.log")]
+fn test_show_paths_targets(#[case] target: &str, #[case] expected: PathBuf) {
+    let (mut command, data_dir) = common::slumber();
+    command.args(["show", "paths", target]);
+    // If the expected path is absolute (in the case of collection file), the
+    // join won't do anything. Most of them are relative to the data dir
+    let expected = format!("{}\n", data_dir.join(expected).display());
+    command.assert().stdout(expected);
+}
+
+/// Test `slumber show config` prints the loaded config in YAML
+#[test]
+fn test_show_config() {
+    let (mut command, _) = common::slumber();
+    command.args(["show", "config"]);
+    // There shouldn't be a config file in the temp data dir, so we'll just see
+    // the default config
+    let expected = serde_yaml::to_string(&Config::default()).unwrap();
+    command
+        .assert()
+        .success()
+        .stdout(predicate::eq(expected.trim()).trim());
+}
+
+/// Test `slumber show collection` prints the loaded collection in YAML
+#[test]
+fn test_show_collection() {
+    let (mut command, _) = common::slumber();
+    command.args(["show", "collection"]);
+    let expected =
+        serde_yaml::to_string(&common::collection_file().load().unwrap())
+            .unwrap();
+    command
+        .assert()
+        .success()
+        .stdout(predicate::eq(expected.trim()).trim());
+}

--- a/docs/src/api/configuration/index.md
+++ b/docs/src/api/configuration/index.md
@@ -15,7 +15,7 @@ By default, configuration is stored in a platform-specific configuration directo
 You can also find the config path by running:
 
 ```sh
-slumber show paths
+slumber show paths config
 ```
 
 If the config directory doesn't exist yet, Slumber will create it automatically when starting the TUI for the first time.

--- a/docs/src/cli/subcommands.md
+++ b/docs/src/cli/subcommands.md
@@ -59,7 +59,7 @@ slumber generate curl --profile production list_fishes -o host=http://localhost:
 
 ## `slumber history`
 
-View and modify your Slumber request history. Slumber stores every command sent **from the TUI** in a local SQLite database (requests are **not** stored remotely). You can find the database file with `slumber show paths`.
+View and modify your Slumber request history. Slumber stores every command sent **from the TUI** in a local SQLite database (requests are **not** stored remotely). You can find the database file with `slumber show paths db`.
 
 You can use the `slumber history` subcommand to browse and delete request history.
 

--- a/docs/src/troubleshooting/logs.md
+++ b/docs/src/troubleshooting/logs.md
@@ -4,7 +4,7 @@ Each Slumber session logs information and events to a log file. This can often b
 
 ## Finding the Log File
 
-To find the path to the log file, hit the `?` to open the help dialog. It will be listed under the General section. Alternatively, run the command `slumber show paths`.
+To find the path to the log file, hit the `?` to open the help dialog. It will be listed under the General section. Alternatively, run the command `slumber show paths log`.
 
 Once you have the path to a log file, you can watch the logs with `tail -f <log file>`, or get the entire log contents with `cat <log file>`.
 


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Add a new optional `target` argument to the 

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Added complexity. I think this is pretty intuitive though

## QA

_How did you test this?_

Added integration tests for `slumber show`

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
