### PR TITLE
Fix fx opening slowly sometimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Import JSON bodies from OpenAPI spec operations that don't have an `example` field
   - Now it will infer a body from the schema definition if no examples are provided
+- Fix occasional hang when opening `fx` as a pager [#506](https://github.com/LucasPickering/slumber/issues/506)
 
 ## [3.1.3] - 2025-06-07
 


### PR DESCRIPTION

## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

This was a complicated interaction between slumber and fx related to event handling on the tty. The subprocess is spawned in the main thread and blocks the entire thread, which prevents slumber from doing any work (this is intentional). The issue shows up when the event reader stream is reading for an event (which happens in a background task) while the subprocess is spawned. It ends up contending with fx during startup. The issue happened intermittently because by default, tokio::select! randomly chooses the order in which branches will be polled. If the event reader branch was polled first (one third of the time), the issue happened.

This is a simple and small fix: always check the message queue _before_ spawning the event reader. If a message is immediately available, the event reader won't spawn. Since the subprocess spawn is triggered by a FileView message, this prevents the event reader from spawning before the subprocess.


## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

The fix is not located close to the code that causes the program (the subprocess spawning), so it's very possible it could be broken again in the future. Additionally, this is hard to test so it would be hard to catch a regression. Mitigated with comments but there's probably a way to rearchitect the entire loop to make it better.

## QA

_How did you test this?_

Manually. Writing integration tests that mock the entire terminal sounds like a nightmare.

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
