### PR TITLE
Add OpenAPI v3.1 importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `slumber import` now supports importing from stdin or a URL
   - If no input argument is given, it will read from stdin, e.g. `slumber import openapi < openapi.json`
   - If a URL is given, the file will be downloaded and imported, e.g. `slumber import openapi https://example.com/openapi.json`
+- Add OpenAPI v3.1 importer [#513](https://github.com/LucasPickering/slumber/issues/513)
 
 ## Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,16 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 1.0.0",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl 2.0.1",
 ]
 
 [[package]]
@@ -662,6 +671,18 @@ name = "derive_more-impl"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+ "unicode-xid",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1723,6 +1744,23 @@ checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "oas3"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467938ca71cb364150b7fe3564316d80f1deea1891020f85468ac01749f1a409"
+dependencies = [
+ "derive_more 2.0.1",
+ "http",
+ "log",
+ "once_cell",
+ "regex",
+ "semver",
+ "serde",
+ "serde_json",
+ "url",
 ]
 
 [[package]]
@@ -2809,7 +2847,7 @@ version = "3.1.3"
 dependencies = [
  "anyhow",
  "crossterm",
- "derive_more",
+ "derive_more 1.0.0",
  "dirs",
  "editor-command",
  "env-lock",
@@ -2833,7 +2871,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
- "derive_more",
+ "derive_more 1.0.0",
  "dialoguer",
  "env-lock",
  "futures",
@@ -2870,11 +2908,12 @@ name = "slumber_import"
 version = "3.1.3"
 dependencies = [
  "anyhow",
- "derive_more",
+ "derive_more 1.0.0",
  "futures",
  "indexmap 2.9.0",
  "itertools",
  "mime",
+ "oas3",
  "openapiv3",
  "pretty_assertions",
  "reqwest",
@@ -2903,7 +2942,7 @@ dependencies = [
  "chrono",
  "cli-clipboard",
  "crossterm",
- "derive_more",
+ "derive_more 1.0.0",
  "futures",
  "indexmap 2.9.0",
  "itertools",

--- a/crates/core/src/template/parse.rs
+++ b/crates/core/src/template/parse.rs
@@ -35,9 +35,11 @@ pub const ENV_PREFIX: &str = "env.";
 impl Template {
     /// Create a template that renders a single field, equivalent to
     /// `{{<field>}}`
-    pub fn from_field(field: Identifier) -> Self {
+    pub fn from_field(field: impl Into<Identifier>) -> Self {
         Self {
-            chunks: vec![TemplateInputChunk::Key(TemplateKey::Field(field))],
+            chunks: vec![TemplateInputChunk::Key(TemplateKey::Field(
+                field.into(),
+            ))],
         }
     }
 
@@ -380,7 +382,7 @@ mod tests {
     /// Test that [Template::from_field] generates the correct template
     #[test]
     fn test_from_field() {
-        let template = Template::from_field("field1".into());
+        let template = Template::from_field("field1");
         assert_eq!(template.display(), "{{field1}}");
         assert_eq!(&template.chunks, &[key_field("field1")]);
     }

--- a/crates/import/Cargo.toml
+++ b/crates/import/Cargo.toml
@@ -17,6 +17,7 @@ futures = {workspace = true}
 indexmap = {workspace = true, features = ["serde"]}
 itertools = {workspace = true}
 mime = {workspace = true}
+oas3 = "0.16.1"
 openapiv3 = "2.0.0"
 reqwest = {workspace = true}
 rest_parser = "0.1.7"

--- a/crates/import/src/openapi.rs
+++ b/crates/import/src/openapi.rs
@@ -15,6 +15,7 @@
 
 mod resolve;
 mod v3_0;
+mod v3_1;
 
 use crate::ImportInput;
 use anyhow::{Context, anyhow};
@@ -43,9 +44,11 @@ pub async fn from_openapi(input: &ImportInput) -> anyhow::Result<Collection> {
         get_version(&yaml).ok_or_else(|| anyhow!("Missing OpenAPI version"))?;
     if version.starts_with("3.0.") {
         v3_0::from_openapi_v3_0(yaml)
+    } else if version.starts_with("3.1.") {
+        v3_1::from_openapi_v3_1(yaml)
     } else {
         Err(anyhow!(
-            "Unsupported OpenAPI version. Only OpenAPI 3.0 is supported"
+            "Unsupported OpenAPI version. Supported versions are: 3.0, 3.1"
         ))
     }
 }
@@ -71,6 +74,10 @@ mod tests {
     const OPENAPI_V3_0_IMPORTED_FILE: &str =
         "openapi_v3_0_petstore_imported.yml";
 
+    const OPENAPI_V3_1_FILE: &str = "openapi_v3_1_petstore.yml";
+    const OPENAPI_V3_1_IMPORTED_FILE: &str =
+        "openapi_v3_1_petstore_imported.yml";
+
     /// Catch-all test for OpenAPI v3.0 import
     #[rstest]
     #[tokio::test]
@@ -79,6 +86,18 @@ mod tests {
         let imported = from_openapi(&input).await.unwrap();
         let expected =
             Collection::load(&test_data_dir.join(OPENAPI_V3_0_IMPORTED_FILE))
+                .unwrap();
+        assert_eq!(imported, expected);
+    }
+
+    /// Catch-all test for OpenAPI v3.1 import
+    #[rstest]
+    #[tokio::test]
+    async fn test_openapiv3_1_import(test_data_dir: PathBuf) {
+        let input = ImportInput::Path(test_data_dir.join(OPENAPI_V3_1_FILE));
+        let imported = from_openapi(&input).await.unwrap();
+        let expected =
+            Collection::load(&test_data_dir.join(OPENAPI_V3_1_IMPORTED_FILE))
                 .unwrap();
         assert_eq!(imported, expected);
     }

--- a/crates/import/src/openapi/v3_0.rs
+++ b/crates/import/src/openapi/v3_0.rs
@@ -28,21 +28,12 @@ pub fn from_openapi_v3_0(
     spec: serde_yaml::Value,
 ) -> anyhow::Result<Collection> {
     let OpenAPI {
-        openapi: openapi_version,
         components,
         paths,
         servers,
         ..
     } = serde_yaml::from_value(spec)
         .context("Error deserializing OpenAPI collection")?;
-
-    if !openapi_version.starts_with("3.0.") {
-        warn!(
-            "Importer currently only supports OpenAPI v3.0, this spec is
-                version {openapi_version}. We'll try the import anyway, but you
-                may experience issues."
-        );
-    }
 
     let profiles = build_profiles(servers);
     let recipes = build_recipe_tree(paths, components)?;
@@ -388,10 +379,8 @@ impl<'a> RecipeBuilder<'a> {
                 } => match scheme.as_str() {
                     "Basic" | "basic" => {
                         self.authentication = Some(Authentication::Basic {
-                            username: Template::from_field("username".into()),
-                            password: Some(Template::from_field(
-                                "password".into(),
-                            )),
+                            username: Template::from_field("username"),
+                            password: Some(Template::from_field("password")),
                         });
                     }
                     "Bearer" | "bearer" => {
@@ -412,12 +401,12 @@ impl<'a> RecipeBuilder<'a> {
                 {
                     APIKeyLocation::Query => self.query.push((
                         name.clone(),
-                        Template::from_field("api_key".into()),
+                        Template::from_field("api_key"),
                     )),
                     APIKeyLocation::Header => {
                         self.headers.insert(
                             name.clone(),
-                            Template::from_field("api_key".into()),
+                            Template::from_field("api_key"),
                         );
                     }
                     APIKeyLocation::Cookie => {

--- a/crates/import/src/openapi/v3_1.rs
+++ b/crates/import/src/openapi/v3_1.rs
@@ -1,0 +1,708 @@
+use anyhow::{Context, anyhow};
+use indexmap::IndexMap;
+use itertools::Itertools;
+use mime::Mime;
+use oas3::spec::{
+    FromRef, MediaType, MediaTypeExamples, ObjectOrReference, ObjectSchema,
+    Operation, Parameter, ParameterIn, PathItem, Ref, RefError, RefType,
+    RequestBody, SchemaType, SchemaTypeSet, SecurityRequirement,
+    SecurityScheme, Server, Spec,
+};
+use slumber_core::{
+    collection::{
+        Authentication, Collection, DuplicateRecipeIdError, Folder, Profile,
+        ProfileId, Recipe, RecipeBody, RecipeId, RecipeNode, RecipeTree,
+    },
+    http::HttpMethod,
+    template::Template,
+};
+use slumber_util::ResultTraced;
+use std::{iter, mem};
+use strum::IntoEnumIterator;
+use tracing::{debug, error, warn};
+
+/// Loads a collection from an OpenAPI v3.1 specification
+pub fn from_openapi_v3_1(
+    spec: serde_yaml::Value,
+) -> anyhow::Result<Collection> {
+    let mut spec: Spec = serde_yaml::from_value(spec)
+        .context("Error deserializing OpenAPI 3.1 collection")?;
+
+    let profiles = build_profiles(
+        // We don't need the servers anywhere else so we can move them out to
+        // avoid a clone
+        mem::take(&mut spec.servers),
+    );
+    let recipes = build_recipe_tree(spec)?;
+
+    Ok(Collection {
+        profiles,
+        recipes,
+        chains: IndexMap::new(),
+        _ignore: serde::de::IgnoredAny,
+    })
+}
+
+/// Build one profile per server
+fn build_profiles(servers: Vec<Server>) -> IndexMap<ProfileId, Profile> {
+    servers
+        .into_iter()
+        .map(|Server { url, variables, .. }| {
+            let id: ProfileId = url.clone().into();
+            // Include a "host" variable for each server, but allow the
+            // user-defined variables to override that
+            let data =
+                iter::once(("host".to_owned(), Template::raw(url.clone())))
+                    .chain(variables.into_iter().map(|(name, variable)| {
+                        (name, Template::raw(variable.default))
+                    }))
+                    .collect();
+            (
+                id.clone(),
+                Profile {
+                    id,
+                    // We could just omit this and fall back to the ID which
+                    // will be the same value, but we provide it for
+                    // discoverability; the user may want to rename it
+                    name: Some(url),
+                    default: false,
+                    data,
+                },
+            )
+        })
+        .collect()
+}
+
+/// Build a recipe tree out of all paths. Each path can have multiple operations
+/// (up to one per method), and each operation becomes a recipe. We'll also
+/// attempt to create folders from tags. Tags:operations are m2m but
+/// folders:recipes are o2m, so we'll just take the first tag for operation.
+///
+/// The *only* way this can fail is if we get an ID collision in the recipe
+/// tree. All other errors will be non-fatal.
+fn build_recipe_tree(spec: Spec) -> Result<RecipeTree, DuplicateRecipeIdError> {
+    let reference_resolver = ReferenceResolver::new(&spec);
+    let mut recipes: IndexMap<RecipeId, RecipeNode> = IndexMap::new();
+
+    // Helper to add a recipe to the tree, and potentially a folder too
+    let mut add_recipe = |path: &str, mut operation: Operation, method| {
+        let first_tag = if operation.tags.is_empty() {
+            None
+        } else {
+            Some(operation.tags.swap_remove(0))
+        };
+        let recipe = RecipeBuilder::build_recipe(
+            operation,
+            &reference_resolver,
+            path,
+            method,
+        );
+
+        let recipe_id = recipe.id.clone();
+        let recipe_node = RecipeNode::Recipe(recipe);
+
+        // If the recipe has any tags, insert into a folder. Otherwise insert
+        // into the root
+        if let Some(tag) = first_tag {
+            let folder_id: RecipeId = format!("tag/{tag}").into();
+            debug!("Inserting recipe `{recipe_id}` in folder `{folder_id}`");
+            let node = recipes.entry(folder_id.clone()).or_insert_with(|| {
+                Folder {
+                    id: folder_id,
+                    name: Some(tag),
+                    children: IndexMap::default(),
+                }
+                .into()
+            });
+
+            // If a recipe already exists with the folder ID we generated,
+            // that's a logic error and should be fatal
+            match node {
+                RecipeNode::Folder(folder) => {
+                    folder.children.insert(recipe_id, recipe_node);
+                }
+                RecipeNode::Recipe(recipe) => {
+                    // Skip the folder but retain the recipe
+                    error!(
+                        "Cannot create folder `{}`; \
+                        a recipe already exists with that ID",
+                        recipe.id
+                    );
+                    recipes.insert(recipe_id, recipe_node);
+                }
+            }
+        } else {
+            debug!("Inserting recipe `{recipe_id}`");
+            recipes.insert(recipe_id, recipe_node);
+        }
+    };
+
+    // Each path can have multiple methods. Each path:method pair maps to one
+    // recipe
+    for (path, item) in spec.paths.iter().flatten() {
+        // Note: we may fuck up the ordering of operations here. The
+        // ordering is already lost because the openapi lib deserializes
+        // into static fields instead of a map, so there's nothing we
+        // can do to preserve the old order
+        for method in HttpMethod::iter() {
+            if let Some(op) = get_operation(item, method) {
+                add_recipe(path, op, method);
+            }
+        }
+    }
+
+    // Error occurs if we have any duplicate folder/recipe IDs. This *shouldn't*
+    // happen because the OpenAPI spec requires op IDs to be unique:
+    // https://spec.openapis.org/oas/v3.0.3#fixed-fields-7
+    // It's possible a recipe ID collides with a folder ID, but that's very
+    // unlikely because we namespace all the folders under tag/
+    RecipeTree::new(recipes)
+}
+
+/// Get an operation from a path corresponding to a specific method. This will
+/// move the operation out of its wrapping Option if present in order to return
+/// an owned value. The goal here is to prevent a clone.
+fn get_operation(
+    path_item: &PathItem,
+    method: HttpMethod,
+) -> Option<Operation> {
+    match method {
+        HttpMethod::Connect => None,
+        HttpMethod::Delete => path_item.delete.clone(),
+        HttpMethod::Get => path_item.get.clone(),
+        HttpMethod::Head => path_item.head.clone(),
+        HttpMethod::Options => path_item.options.clone(),
+        HttpMethod::Patch => path_item.patch.clone(),
+        HttpMethod::Post => path_item.post.clone(),
+        HttpMethod::Put => path_item.put.clone(),
+        HttpMethod::Trace => path_item.trace.clone(),
+    }
+}
+
+/// Helper struct to hold intermediate state while converting an operation into
+/// a recipe
+struct RecipeBuilder<'a> {
+    id: RecipeId,
+    name: String,
+    method: HttpMethod,
+    url: String,
+    body: Option<RecipeBody>,
+    authentication: Option<Authentication>,
+    query: Vec<(String, Template)>,
+    headers: IndexMap<String, Template>,
+    reference_resolver: &'a ReferenceResolver<'a>,
+}
+
+impl<'a> RecipeBuilder<'a> {
+    /// Translate an OpenAPI Operation into a recipe
+    fn build_recipe(
+        operation: Operation,
+        reference_resolver: &'a ReferenceResolver,
+        path_name: &str,
+        method: HttpMethod,
+    ) -> Recipe {
+        // Use operation_id if one is provided, otherwise generate one
+        let id: RecipeId = operation
+            .operation_id
+            .unwrap_or_else(|| format!("{path_name}-{method}"))
+            .into();
+        let name = operation.summary.unwrap_or_else(|| path_name.to_owned());
+        // Build the base URL template. We may modify this to replace its path
+        // params with corresponding chain references, so don't convert it into
+        // a template until the end
+        let url = format!("{{{{host}}}}{path_name}");
+
+        let mut builder = Self {
+            id,
+            url,
+            name,
+            method,
+            body: None,
+            authentication: None,
+            query: Vec::new(),
+            headers: IndexMap::new(),
+            reference_resolver,
+        };
+
+        if let Some(request_body) = operation.request_body {
+            builder.process_body(request_body);
+        }
+        builder.process_parameters(operation.parameters);
+        builder.process_security(operation.security);
+
+        // Build the URL from the template we generated
+        let url = builder
+            .url
+            .parse()
+            // We just built this template ourselves, so hopefully parsing
+            // doesn't fail. If it does, fall back to the original URL
+            .with_context(|| {
+                format!(
+                "Error generating URL for recipe `{}`; plain path will be used",
+                builder.id
+            )
+            })
+            .traced()
+            .unwrap_or_else(|_| Template::raw(path_name.to_owned()));
+
+        Recipe {
+            id: builder.id,
+            persist: true,
+            name: Some(builder.name),
+            method: builder.method,
+            url,
+            body: builder.body,
+            authentication: builder.authentication,
+            query: builder.query,
+            headers: builder.headers,
+        }
+    }
+
+    /// Imperatively update the recipe to according to various parameters.
+    /// OpenAPI parameters can map to query params, headers, path params, or
+    /// cookies. We have to take the URL as a separate param because templates
+    /// can't be modified. This prevents us from having to stringify and
+    /// re-parse the template every time we make a modification.
+    fn process_parameters(
+        &mut self,
+        parameters: Vec<ObjectOrReference<Parameter>>,
+    ) {
+        parameters
+            .into_iter()
+            .filter_map(|parameter| {
+                // For any reference that fails to resolve, print the error and
+                // throw it away
+                self.reference_resolver.resolve::<Parameter>(&parameter)
+            })
+            .for_each(|parameter| match parameter.location {
+                ParameterIn::Query => {
+                    self.query.push((parameter.name, Template::default()));
+                }
+                ParameterIn::Header => {
+                    // if the name field is "Accept", "Content-Type" or
+                    // "Authorization", the parameter definition SHALL be
+                    // ignored. https://spec.openapis.org/oas/v3.0.3#fixed-fields-9
+                    let name = parameter.name;
+                    match name.as_str() {
+                        "Accept" | "Content-Type" | "Authorization" => {}
+                        _ => {
+                            self.headers.insert(name, Template::default());
+                        }
+                    }
+                }
+                ParameterIn::Path => {
+                    // Replace path params with a template key. The key probably
+                    // won't refer to anything, but it's better than being
+                    // completely invalid. We have no way of knowing how the
+                    // user actually wants to fill this
+                    // value
+                    let id = parameter.name;
+                    // {id} -> {{id}}
+                    self.url = self.url.replace(
+                        &format!("{{{id}}}"),
+                        &format!("{{{{{id}}}}}"),
+                    );
+                }
+                ParameterIn::Cookie => {
+                    error!(
+                        "Unsupported parameter type cookie for param `{}`",
+                        parameter.name
+                    );
+                }
+            });
+    }
+
+    /// Imperatively update the recipe to include security scheme(s). Depending
+    /// on the scheme this may map to first-class auth, query params, or headers
+    fn process_security(&mut self, security: Vec<SecurityRequirement>) {
+        security
+            .into_iter()
+            .flat_map(|s| s.0)
+            // Resolve references, throwing away invalid ones
+            .filter_map(|(scheme_name, _)| {
+                self.reference_resolver.security_schema(&scheme_name)
+            })
+            .for_each(|scheme| self.process_security_scheme(scheme));
+    }
+
+    /// Imperatively update the recipe according to a single security scheme
+    /// https://spec.openapis.org/oas/v3.1.0.html#security-scheme-object
+    fn process_security_scheme(&mut self, security_scheme: SecurityScheme) {
+        // Where we need an auth value but don't have one, we'll create
+        // a placeholder template. This should improve discoverability for
+        // template features. We don't expect the fields to actually map to
+        // anything
+
+        match security_scheme {
+            SecurityScheme::ApiKey { location, name, .. } => {
+                match location.as_str() {
+                    "header" => {
+                        self.headers.insert(
+                            name.clone(),
+                            Template::from_field("api_key"),
+                        );
+                    }
+                    "query" => {
+                        self.query.push((
+                            name.clone(),
+                            Template::from_field("api_key"),
+                        ));
+                    }
+                    _ => error!("Unsupported API key location `{location}`"),
+                }
+            }
+            SecurityScheme::Http { scheme, .. } => match scheme.as_str() {
+                "basic" => {
+                    self.authentication = Some(Authentication::Basic {
+                        username: Template::from_field("username"),
+                        password: Some(Template::from_field("password")),
+                    });
+                }
+                "bearer" => {
+                    self.authentication = Some(Authentication::Bearer(
+                        Template::from_field("api_token"),
+                    ));
+                }
+                _ => {
+                    error!("Unsupported HTTP authentication scheme `{scheme}`");
+                }
+            },
+            SecurityScheme::OAuth2 { .. } => {
+                error!("Unsupported security scheme: OAuth2");
+            }
+            SecurityScheme::OpenIdConnect { .. } => {
+                error!("Unsupported security scheme: OpenIDConnect");
+            }
+            SecurityScheme::MutualTls { .. } => {
+                error!("Unsupported security scheme: Mutual TLS");
+            }
+        }
+    }
+
+    /// Imperatively set the request body. The body can contain multiple
+    /// examples, either on the operation itself or the underlying schema. We'll
+    /// grab the first valid one.
+    fn process_body(&mut self, request_body: ObjectOrReference<RequestBody>) {
+        // If the reference is invalid, it'll be logged and we can fuck off
+        let Some(request_body) = self
+            .reference_resolver
+            .resolve::<RequestBody>(&request_body)
+        else {
+            return;
+        };
+
+        let body = request_body
+            .content
+            .iter()
+            // Parse each MIME type and exclude bodies with an invalid type
+            .filter_map(|(content_type, media_type)| {
+                let mime = content_type
+                    .parse::<Mime>()
+                    .map_err(|_| {
+                        anyhow!(
+                            "Invalid MIME type `{content_type}` for \
+                            recipe `{}`",
+                            self.id
+                        )
+                    })
+                    .traced()
+                    .ok()?;
+                Some((mime, media_type))
+            })
+            // Each MIME type could have multiple examples. We want all of them
+            // in case the first is invalid somehow
+            .flat_map(|(mime, media_type)| {
+                self.get_examples(media_type)
+                    .into_iter()
+                    .map(move |body| (mime.clone(), body))
+            })
+            // Convert each example into our body format
+            .filter_map(|(mime, value)| {
+                self.convert_body(&mime, value)
+                    .with_context(|| format!("{}.requestBody.{mime}", self.id))
+                    .traced()
+                    .ok()
+            })
+            // Sort known content types first
+            .sorted_by_key(|body| {
+                // This means bodies that *don't* match will sort first, because
+                // false < true
+                matches!(
+                    body,
+                    RecipeBody::Raw {
+                        content_type: None,
+                        ..
+                    }
+                )
+            })
+            .next();
+
+        if let Some(body) = body {
+            self.body = Some(body);
+        } else {
+            error!(
+                "No bodies with supported content type for recipe `{}`",
+                self.id
+            );
+        }
+    }
+
+    /// Get all examples for a particular media type. This combines these
+    /// sources (in order of decreasing precedence):
+    /// - `media_type.example`
+    /// - `media_type.examples` (mutually exclusive with `media_type.example`)
+    /// - `media_type.schema.examples`
+    /// - `media_type.schema.properties` (build an example from the schema def)
+    fn get_examples(
+        &'a self,
+
+        media_type: &'a MediaType,
+    ) -> Vec<serde_json::Value> {
+        // These are ordered by precedence. If any is empty we'll fall back to
+        // the next one
+        match &media_type.examples {
+            Some(MediaTypeExamples::Example { example }) => {
+                vec![example.clone()]
+            }
+            Some(MediaTypeExamples::Examples { examples }) => examples
+                .values()
+                .filter_map(|example| {
+                    let example = self.reference_resolver.resolve(example)?;
+                    example.value
+                })
+                .collect(),
+            // If there was no example for the operation, look at the underlying
+            // schema
+            None => {
+                let example = media_type
+                    .schema
+                    .as_ref()
+                    // Resolve the reference
+                    .and_then(|schema| self.reference_resolver.resolve(schema))
+                    .map(|schema| {
+                        schema
+                            .example
+                            .clone()
+                            // If there's no example declared on the schema,
+                            // generate one from its properties
+                            .unwrap_or_else(|| self.schema_to_json(&schema))
+                    });
+
+                // This is an option, so we get a vec of 0 or 1
+                example.into_iter().collect()
+            }
+        }
+    }
+
+    /// Build an example JSON value from a schema definition. This will be
+    /// called recursively to convert individual parts of complex bodies
+    fn schema_to_json(&self, schema: &ObjectSchema) -> serde_json::Value {
+        // If an example value exists, use it
+        if let Some(example) = &schema.example {
+            return example.clone();
+        }
+
+        // Otherwise if an enum is given, pull the first value
+        if let Some(value) = schema.enum_values.first() {
+            return value.clone();
+        }
+
+        // If anyOf, allOf, or oneOf is given, grab the first value from that
+        if let Some(inner_schema) = schema
+            .any_of
+            .iter()
+            .chain(schema.all_of.iter())
+            .chain(schema.one_of.iter())
+            .next()
+            .and_then(|schema| self.reference_resolver.resolve(schema))
+        {
+            return self.schema_to_json(&inner_schema);
+        }
+
+        // Derive a value from the schema type
+        let schema_type = schema
+            .schema_type
+            .as_ref()
+            .and_then(|type_set| match type_set {
+                SchemaTypeSet::Single(schema_type) => Some(*schema_type),
+                SchemaTypeSet::Multiple(items) => items.first().copied(),
+            })
+            .unwrap_or(SchemaType::Object);
+        match schema_type {
+            SchemaType::Null => serde_json::Value::Null,
+            SchemaType::Boolean => false.into(),
+            SchemaType::Integer | SchemaType::Number => {
+                // Try minimum or maximum to ensure the value is valid
+                schema
+                    .minimum
+                    .as_ref()
+                    .or(schema.maximum.as_ref())
+                    .cloned()
+                    // Fallback to a default
+                    .unwrap_or(0.into())
+                    .into()
+            }
+            // Just use default for a string. We could try to come up with
+            // something based on the `format` or `pattern` fields but I'm
+            // taking a shortcut
+            SchemaType::String => "".into(),
+            SchemaType::Array => schema
+                .items
+                .as_ref()
+                .and_then(|items| {
+                    // Figure out the type of the contained item, and include
+                    // one element of it as the prefilled value
+                    let item_schema = self.reference_resolver.resolve(items)?;
+                    let item_value = self.schema_to_json(&item_schema);
+                    Some(serde_json::Value::Array(vec![item_value]))
+                })
+                // No items given, use an empty array
+                .unwrap_or_else(|| serde_json::Value::Array(vec![])),
+            SchemaType::Object => schema
+                .properties
+                .iter()
+                .filter_map(|(property, schema)| {
+                    let schema = self.reference_resolver.resolve(schema)?;
+                    let value = self.schema_to_json(&schema);
+                    Some((property.clone(), value))
+                })
+                .collect(),
+        }
+    }
+
+    /// Convert a body of a single example to a recipe body
+    fn convert_body(
+        &self,
+        mime: &Mime,
+        body: serde_json::Value,
+    ) -> anyhow::Result<RecipeBody> {
+        fn unwrap_object(
+            value: serde_json::Value,
+        ) -> anyhow::Result<IndexMap<String, Template>> {
+            // This may not be correct, but we'll just stringify the value as
+            // JSON https://swagger.io/docs/specification/describing-request-body/multipart-requests/
+            if let serde_json::Value::Object(object) = value {
+                Ok(object
+                    .into_iter()
+                    .map(|(key, value)| {
+                        // Convert value to string
+                        let value = match value {
+                            serde_json::Value::String(s) => s,
+                            // Do *not* prettify here; we want to be able to
+                            // show this in one line in the UI
+                            _ => value.to_string(),
+                        };
+                        (key, Template::raw(value))
+                    })
+                    .collect())
+            } else {
+                Err(anyhow!("Expected object"))
+            }
+        }
+
+        if mime == &mime::APPLICATION_JSON {
+            // Currently we don't match against any JSON extensions. Just a
+            // shortcut, could fix later
+            Ok(RecipeBody::untemplated_json(body))
+        } else if mime == &mime::APPLICATION_WWW_FORM_URLENCODED {
+            let form = unwrap_object(body)?;
+            Ok(RecipeBody::FormUrlencoded(form))
+        } else if mime == &mime::MULTIPART_FORM_DATA {
+            let form = unwrap_object(body)?;
+            Ok(RecipeBody::FormMultipart(form))
+        } else {
+            warn!(
+                "Unknown content type `{mime}` for body of recipe `{}`",
+                self.id
+            );
+            Ok(RecipeBody::Raw {
+                body: Template::raw(format!("{body:#}")),
+                content_type: None,
+            })
+        }
+    }
+}
+
+struct ReferenceResolver<'a> {
+    spec: &'a Spec,
+}
+
+impl<'a> ReferenceResolver<'a> {
+    fn new(spec: &'a Spec) -> Self {
+        Self { spec }
+    }
+
+    /// Resolve an object or reference to an object. If this fails, the error
+    /// will be logged and we'll return None. This importer is meant to be
+    /// resilient, so errors should be skipped over instead of being fatal, so
+    /// there's no need to propagate a Result.
+    fn resolve<T>(&self, reference: &ObjectOrReference<T>) -> Option<T>
+    where
+        T: FromRef,
+    {
+        reference
+            .resolve(self.spec)
+            .with_context(|| {
+                let ObjectOrReference::Ref { ref_path } = reference else {
+                    unreachable!("Only references can fail to resolve")
+                };
+                format!("Error resolving reference `{ref_path}`")
+            })
+            .traced()
+            .ok()
+    }
+
+    /// Look up a security scheme by name. Used to resolve security requirements
+    /// in an operation
+    fn security_schema(&self, scheme_name: &str) -> Option<SecurityScheme> {
+        // SecuritySchema doesn't implement FromRef so we need a wrapper to
+        // implement it
+        // Remove this after https://github.com/x52dev/oas3-rs/pull/221
+        #[derive(Clone)]
+        struct SecuritySchemeWrap(SecurityScheme);
+
+        impl FromRef for SecuritySchemeWrap {
+            fn from_ref(
+                spec: &Spec,
+                path: &str,
+            ) -> Result<Self, oas3::spec::RefError> {
+                let refpath = path.parse::<Ref>()?;
+
+                match refpath.kind {
+                    RefType::SecurityScheme => spec
+                        .components
+                        .as_ref()
+                        .and_then(|cs| cs.security_schemes.get(&refpath.name))
+                        .ok_or_else(|| RefError::Unresolvable(path.to_owned()))
+                        .map(map_ref)
+                        .and_then(|oor| oor.resolve(spec)),
+                    typ => Err(RefError::MismatchedType(
+                        typ,
+                        RefType::SecurityScheme,
+                    )),
+                }
+            }
+        }
+
+        fn map_ref(
+            oor: &ObjectOrReference<SecurityScheme>,
+        ) -> ObjectOrReference<SecuritySchemeWrap> {
+            match oor {
+                ObjectOrReference::Object(o) => {
+                    ObjectOrReference::Object(SecuritySchemeWrap(o.clone()))
+                }
+                ObjectOrReference::Ref { ref_path } => ObjectOrReference::Ref {
+                    ref_path: ref_path.clone(),
+                },
+            }
+        }
+
+        let reference = self
+            .spec
+            .components
+            .as_ref()?
+            .security_schemes
+            .get(scheme_name)?;
+        self.resolve(&map_ref(reference)).map(|wrap| wrap.0)
+    }
+}

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, anyhow};
 use std::{
     borrow::Cow,
-    env, fs,
+    fs,
     path::{Path, PathBuf},
 };
 
@@ -58,7 +58,7 @@ fn debug_or(path: PathBuf) -> PathBuf {
     {
         let _ = path; // Remove unused warning
         // Check the env var, for tests
-        env::var(DATA_DIRECTORY_ENV_VARIABLE)
+        std::env::var(DATA_DIRECTORY_ENV_VARIABLE)
             .map(PathBuf::from)
             .unwrap_or_else(|_| get_repo_root().join("data/"))
     }

--- a/docs/src/cli/subcommands.md
+++ b/docs/src/cli/subcommands.md
@@ -108,8 +108,7 @@ Importers are **approximate**. They'll give the you skeleton of a collection fil
 Supported formats:
 
 - Insomnia
-- [OpenAPI v3.0](https://spec.openapis.org/oas/v3.0.3)
-  - Note: Despite the minor version bump, OpenAPI v3.1 is _not_ backward compatible with v3.0. If you have a v3.1 spec, it _may_ work with this importer, but no promises.
+- [OpenAPI v3.0](https://spec.openapis.org/oas/v3.0.3) and [OpenAPI v3.1](https://spec.openapis.org/oas/v3.1.1.html)
 - [VSCode `.rest`](https://github.com/Huachao/vscode-restclient)
 - [JetBrains `.http`](https://www.jetbrains.com/help/idea/http-client-in-product-code-editor.html)
 

--- a/test_data/openapi_v3_1_petstore.yml
+++ b/test_data/openapi_v3_1_petstore.yml
@@ -1,0 +1,692 @@
+# https://github.com/readmeio/oas-examples/blob/060d4ffbbe63003f923c8cd7268ee39a495cf21f/3.1/yaml/petstore.yaml
+openapi: 3.1.0
+info:
+  description:
+    "This is a sample server Petstore server.  You can find out more about
+    Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For
+    this sample, you can use the api key `special-key` to test the authorization filters."
+  version: 1.0.0
+  title: Swagger Petstore
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+  - url: http://petstore.swagger.io/v2
+externalDocs:
+  description: Find out more about Swagger
+  url: http://swagger.io
+tags:
+  - name: pet
+    description: Everything about your Pets
+    externalDocs:
+      description: Find out more
+      url: http://swagger.io
+  - name: store
+    description: Access to Petstore orders
+  - name: user
+    description: Operations about user
+    externalDocs:
+      description: Find out more about our store
+      url: http://swagger.io
+paths:
+  "/pet":
+    post:
+      tags:
+        - pet
+      summary: Add a new pet to the store
+      description: ""
+      operationId: addPet
+      parameters: []
+      responses:
+        "405":
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+      requestBody:
+        "$ref": "#/components/requestBodies/Pet"
+    put:
+      tags:
+        - pet
+      summary: Update an existing pet
+      description: ""
+      operationId: updatePet
+      parameters: []
+      responses:
+        "400":
+          description: Invalid ID supplied
+        "404":
+          description: Pet not found
+        "405":
+          description: Validation exception
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+      requestBody:
+        "$ref": "#/components/requestBodies/Pet"
+  "/pet/findByStatus":
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: findPetsByStatus
+      parameters:
+        - name: status
+          in: query
+          description: Status values that need to be considered for filter
+          required: true
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - available
+                - pending
+                - sold
+              default: available
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Pet"
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Pet"
+        "400":
+          description: Invalid status value
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+  "/pet/findByTags":
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by tags
+      description:
+        Muliple tags can be provided with comma separated strings. Use
+        tag1, tag2, tag3 for testing.
+      operationId: findPetsByTags
+      parameters:
+        - name: tags
+          in: query
+          description: Tags to filter by
+          required: true
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Pet"
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Pet"
+        "400":
+          description: Invalid tag value
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+      deprecated: true
+  "/pet/{petId}":
+    get:
+      tags:
+        - pet
+      summary: Find pet by ID
+      description: Returns a single pet
+      operationId: getPetById
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to return
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+        "400":
+          description: Invalid ID supplied
+        "404":
+          description: Pet not found
+        default:
+          description: successful response
+      security:
+        - api_key: []
+    post:
+      tags:
+        - pet
+      summary: Updates a pet in the store with form data
+      description: ""
+      operationId: updatePetWithForm
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet that needs to be updated
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "405":
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: Updated name of the pet
+                  type: string
+                status:
+                  description: Updated status of the pet
+                  type: string
+    delete:
+      tags:
+        - pet
+      summary: Deletes a pet
+      description: ""
+      operationId: deletePet
+      parameters:
+        - name: api_key
+          in: header
+          required: false
+          schema:
+            type: string
+        - name: petId
+          in: path
+          description: Pet id to delete
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "400":
+          description: Invalid ID supplied
+        "404":
+          description: Pet not found
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+  "/pet/{petId}/uploadImage":
+    post:
+      tags:
+        - pet
+      summary: uploads an image
+      description: ""
+      operationId: uploadFile
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to update
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ApiResponse"
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+      requestBody:
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+  "/store/inventory":
+    get:
+      tags:
+        - store
+      summary: Returns pet inventories by status
+      description: Returns a map of status codes to quantities
+      operationId: getInventory
+      parameters: []
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: integer
+                  format: int32
+      security:
+        - api_key: []
+  "/store/order":
+    post:
+      tags:
+        - store
+      summary: Place an order for a pet
+      description: ""
+      operationId: placeOrder
+      parameters: []
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                "$ref": "#/components/schemas/Order"
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Order"
+        "400":
+          description: Invalid Order
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/Order"
+        description: order placed for purchasing the pet
+        required: true
+  "/store/order/{orderId}":
+    get:
+      tags:
+        - store
+      summary: Find purchase order by ID
+      description:
+        For valid response try integer IDs with value >= 1 and <= 10. Other
+        values will generated exceptions
+      operationId: getOrderById
+      parameters:
+        - name: orderId
+          in: path
+          description: ID of pet that needs to be fetched
+          required: true
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+            maximum: 10
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                "$ref": "#/components/schemas/Order"
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Order"
+        "400":
+          description: Invalid ID supplied
+        "404":
+          description: Order not found
+    delete:
+      tags:
+        - store
+      summary: Delete purchase order by ID
+      description:
+        For valid response try integer IDs with positive integer value.
+        Negative or non-integer values will generate API errors
+      operationId: deleteOrder
+      parameters:
+        - name: orderId
+          in: path
+          description: ID of the order that needs to be deleted
+          required: true
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+      responses:
+        "400":
+          description: Invalid ID supplied
+        "404":
+          description: Order not found
+  "/user":
+    post:
+      tags:
+        - user
+      summary: Create user
+      description: This can only be done by the logged in user.
+      operationId: createUser
+      parameters: []
+      responses:
+        default:
+          description: successful operation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/User"
+        description: Created user object
+        required: true
+  # Removed /user/createWithArray because it's identical to /user/createWithList
+  "/user/createWithList":
+    post:
+      tags:
+        - user
+      summary: Creates list of users with given input array
+      description: ""
+      operationId: createUsersWithListInput
+      parameters: []
+      responses:
+        default:
+          description: successful operation
+      requestBody:
+        "$ref": "#/components/requestBodies/UserArray"
+  "/user/login":
+    get:
+      tags:
+        - user
+      summary: Logs user into the system
+      description: ""
+      operationId: loginUser
+      parameters:
+        - name: username
+          in: query
+          description: The user name for login
+          required: true
+          schema:
+            type: string
+        - name: password
+          in: query
+          description: The password for login in clear text
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: successful operation
+          headers:
+            X-Rate-Limit:
+              description: calls per hour allowed by the user
+              schema:
+                type: integer
+                format: int32
+            X-Expires-After:
+              description: date in UTC when token expires
+              schema:
+                type: string
+                format: date-time
+          content:
+            application/xml:
+              schema:
+                type: string
+            application/json:
+              schema:
+                type: string
+        "400":
+          description: Invalid username/password supplied
+  "/user/logout":
+    get:
+      tags:
+        - user
+      summary: Logs out current logged in user session
+      description: ""
+      operationId: logoutUser
+      parameters: []
+      responses:
+        default:
+          description: successful operation
+  "/user/{username}":
+    get:
+      tags:
+        - user
+      summary: Get user by user name
+      description: ""
+      operationId: getUserByName
+      parameters:
+        - name: username
+          in: path
+          description: "The name that needs to be fetched. Use user1 for testing. "
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                "$ref": "#/components/schemas/User"
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/User"
+        "400":
+          description: Invalid username supplied
+        "404":
+          description: User not found
+    put:
+      tags:
+        - user
+      summary: Updated user
+      description: This can only be done by the logged in user.
+      operationId: updateUser
+      parameters:
+        - name: username
+          in: path
+          description: name that need to be updated
+          required: true
+          schema:
+            type: string
+      responses:
+        "400":
+          description: Invalid user supplied
+        "404":
+          description: User not found
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/User"
+        description: Updated user object
+        required: true
+    delete:
+      tags:
+        - user
+      summary: Delete user
+      description: This can only be done by the logged in user.
+      operationId: deleteUser
+      parameters:
+        - name: username
+          in: path
+          description: The name that needs to be deleted
+          required: true
+          schema:
+            type: string
+      responses:
+        "400":
+          description: Invalid username supplied
+        "404":
+          description: User not found
+components:
+  schemas:
+    Order:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        petId:
+          type: integer
+          format: int64
+        quantity:
+          type: integer
+          format: int32
+        shipDate:
+          type: string
+          format: date-time
+        status:
+          type: string
+          description: Order Status
+          enum:
+            - placed
+            - approved
+            - delivered
+        complete:
+          type: boolean
+          default: false
+      xml:
+        name: Order
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Category
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        username:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+        email:
+          type: string
+        password:
+          type: string
+        phone:
+          type: string
+        userStatus:
+          type: integer
+          format: int32
+          description: User Status
+      xml:
+        name: User
+    Tag:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Tag
+    Pet:
+      type: object
+      required:
+        - name
+        - photoUrls
+      properties:
+        id:
+          type: integer
+          format: int64
+          readOnly: true
+        category:
+          "$ref": "#/components/schemas/Category"
+        name:
+          type: string
+          example: doggie
+        photoUrls:
+          type: array
+          xml:
+            name: photoUrl
+            wrapped: true
+          items:
+            type: string
+        tags:
+          type: array
+          xml:
+            name: tag
+            wrapped: true
+          items:
+            "$ref": "#/components/schemas/Tag"
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+            - available
+            - pending
+            - sold
+      xml:
+        name: Pet
+    ApiResponse:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        type:
+          type: string
+        message:
+          type: string
+  requestBodies:
+    Pet:
+      content:
+        application/json:
+          schema:
+            "$ref": "#/components/schemas/Pet"
+        application/xml:
+          schema:
+            "$ref": "#/components/schemas/Pet"
+      description: Pet object that needs to be added to the store
+      required: true
+    UserArray:
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              "$ref": "#/components/schemas/User"
+      description: List of user object
+      required: true
+  securitySchemes:
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: http://petstore.swagger.io/oauth/dialog
+          scopes:
+            write:pets: modify pets in your account
+            read:pets: read your pets
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header

--- a/test_data/openapi_v3_1_petstore_imported.yml
+++ b/test_data/openapi_v3_1_petstore_imported.yml
@@ -1,0 +1,171 @@
+profiles:
+  http://petstore.swagger.io/v2:
+    name: http://petstore.swagger.io/v2
+    data:
+      host: http://petstore.swagger.io/v2
+chains: {}
+requests:
+  tag/pet: !folder
+    name: pet
+    requests:
+      addPet: !request
+        name: Add a new pet to the store
+        method: POST
+        url: "{{host}}/pet"
+        body:
+          !json {
+            "category": { "id": 0, "name": "" },
+            "id": 0,
+            "name": "doggie",
+            "photoUrls": [""],
+            "status": "available",
+            "tags": [{ "id": 0, "name": "" }],
+          }
+      updatePet: !request
+        name: Update an existing pet
+        method: PUT
+        url: "{{host}}/pet"
+        body:
+          !json {
+            "category": { "id": 0, "name": "" },
+            "id": 0,
+            "name": "doggie",
+            "photoUrls": [""],
+            "status": "available",
+            "tags": [{ "id": 0, "name": "" }],
+          }
+      findPetsByStatus: !request
+        name: Finds Pets by status
+        method: GET
+        url: "{{host}}/pet/findByStatus"
+        query:
+          status: ""
+      findPetsByTags: !request
+        name: Finds Pets by tags
+        method: GET
+        url: "{{host}}/pet/findByTags"
+        query:
+          tags: ""
+      deletePet: !request
+        name: Deletes a pet
+        method: DELETE
+        url: "{{host}}/pet/{{petId}}"
+        headers:
+          api_key: ""
+      getPetById: !request
+        name: Find pet by ID
+        method: GET
+        url: "{{host}}/pet/{{petId}}"
+        headers:
+          api_key: "{{api_key}}"
+      updatePetWithForm: !request
+        name: Updates a pet in the store with form data
+        method: POST
+        url: "{{host}}/pet/{{petId}}"
+        body: !form_urlencoded
+          name: ""
+          status: ""
+      uploadFile: !request
+        name: uploads an image
+        method: POST
+        url: "{{host}}/pet/{{petId}}/uploadImage"
+        body: '""'
+  tag/store: !folder
+    name: store
+    requests:
+      getInventory: !request
+        name: Returns pet inventories by status
+        method: GET
+        url: "{{host}}/store/inventory"
+        headers:
+          api_key: "{{api_key}}"
+      placeOrder: !request
+        name: Place an order for a pet
+        method: POST
+        url: "{{host}}/store/order"
+        body:
+          !json {
+            complete: false,
+            id: 0,
+            petId: 0,
+            quantity: 0,
+            shipDate: "",
+            status: "placed",
+          }
+      deleteOrder: !request
+        name: Delete purchase order by ID
+        method: DELETE
+        url: "{{host}}/store/order/{{orderId}}"
+      getOrderById: !request
+        name: Find purchase order by ID
+        method: GET
+        url: "{{host}}/store/order/{{orderId}}"
+  tag/user: !folder
+    name: user
+    requests:
+      createUser: !request
+        name: Create user
+        method: POST
+        url: "{{host}}/user"
+        body:
+          !json {
+            email: "",
+            firstName: "",
+            id: 0,
+            lastName: "",
+            password: "",
+            phone: "",
+            userStatus: 0,
+            username: "",
+          }
+      createUsersWithListInput: !request
+        name: Creates list of users with given input array
+        method: POST
+        url: "{{host}}/user/createWithList"
+        body:
+          !json [
+            {
+              email: "",
+              firstName: "",
+              id: 0,
+              lastName: "",
+              password: "",
+              phone: "",
+              userStatus: 0,
+              username: "",
+            },
+          ]
+      loginUser: !request
+        name: Logs user into the system
+        method: GET
+        url: "{{host}}/user/login"
+        query:
+          username: ""
+          password: ""
+      logoutUser: !request
+        name: Logs out current logged in user session
+        method: GET
+        url: "{{host}}/user/logout"
+      deleteUser: !request
+        name: Delete user
+        method: DELETE
+        url: "{{host}}/user/{{username}}"
+      getUserByName: !request
+        name: Get user by user name
+        method: GET
+        url: "{{host}}/user/{{username}}"
+      updateUser: !request
+        name: Updated user
+        method: PUT
+        url: "{{host}}/user/{{username}}"
+        body:
+          !json {
+            email: "",
+            firstName: "",
+            id: 0,
+            lastName: "",
+            password: "",
+            phone: "",
+            userStatus: 0,
+            username: "",
+          }


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Add support for OpenAPI 3.1 collections, which are not compatible with OpenAPI 3.0. This pulls in a new library `oas3` because `openapiv3` only supports 3.0. The `openapi` format for `slumber import` will check the version of the given OpenAPI file so we didn't have to add a new target for this.

Closes #513

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

- This certainly has bugs. There's some edge cases where I cut corners, ambiguity in the OpenAPI library's types, and inherent incompatibilities between OpenAPI and Slumber. I did my best and we'll have to patch bugs as they're reported
- This can't be merged until [this oas3 PR is merged](https://github.com/x52dev/oas3-rs/pull/221)

## QA

_How did you test this?_

New integration test

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
