### PR TITLE
Ignore any top-level YAML field beginning with .

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   - If a URL is given, the file will be downloaded and imported, e.g. `slumber import openapi https://example.com/openapi.json`
 - Add OpenAPI v3.1 importer [#513](https://github.com/LucasPickering/slumber/issues/513)
 
+### Changed
+
+- Any top-level fields in the config or collection file beginning with `.` will now be ignored
+  - The goal is to support "hidden" fields to store reusable components. YAML aliases can be used to pull those components into various parts of your collection
+  - Previously the field `.ignore` was specially supported in the collection format for this purpose; this is a generalization of that special case.
+
 ## Fixed
 
 - Import JSON bodies from OpenAPI spec operations that don't have an `example` field

--- a/crates/cli/src/commands/new.rs
+++ b/crates/cli/src/commands/new.rs
@@ -147,7 +147,6 @@ mod tests {
                 }),
             ])
             .into(),
-            _ignore: serde::de::IgnoredAny,
         };
         assert_eq!(collection, expected);
     }

--- a/crates/core/src/collection.rs
+++ b/crates/core/src/collection.rs
@@ -144,7 +144,6 @@ mod tests {
     use indexmap::indexmap;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
-    use serde::de::IgnoredAny;
     use serde_json::json;
     use slumber_util::{Factory, TempDir, assert_err, temp_dir, test_data_dir};
     use std::{fs, fs::File, time::Duration};
@@ -539,7 +538,6 @@ mod tests {
                 }),
             ])
             .into(),
-            _ignore: IgnoredAny,
         };
         assert_eq!(loaded, expected);
     }

--- a/crates/core/src/collection/models.rs
+++ b/crates/core/src/collection/models.rs
@@ -35,13 +35,6 @@ pub struct Collection {
     /// intuitive
     #[serde(default, rename = "requests")]
     pub recipes: RecipeTree,
-    /// A hack-ish to allow users to add arbitrary data to their collection
-    /// file without triggering a unknown field error. Ideally we could
-    /// ignore anything that starts with `.` (recursively) but that
-    /// requires a custom serde impl for each type, or changes to the macro
-    #[serde(default, skip_serializing, rename = ".ignore")]
-    #[expect(clippy::pub_underscore_fields)]
-    pub _ignore: serde::de::IgnoredAny,
 }
 
 impl Collection {

--- a/crates/import/src/insomnia.rs
+++ b/crates/import/src/insomnia.rs
@@ -61,7 +61,6 @@ pub async fn from_insomnia(input: &ImportInput) -> anyhow::Result<Collection> {
         profiles,
         recipes,
         chains,
-        _ignore: serde::de::IgnoredAny,
     })
 }
 

--- a/crates/import/src/openapi/v3_0.rs
+++ b/crates/import/src/openapi/v3_0.rs
@@ -42,7 +42,6 @@ pub fn from_openapi_v3_0(
         profiles,
         recipes,
         chains: IndexMap::new(),
-        _ignore: serde::de::IgnoredAny,
     })
 }
 

--- a/crates/import/src/openapi/v3_1.rs
+++ b/crates/import/src/openapi/v3_1.rs
@@ -39,7 +39,6 @@ pub fn from_openapi_v3_1(
         profiles,
         recipes,
         chains: IndexMap::new(),
-        _ignore: serde::de::IgnoredAny,
     })
 }
 

--- a/crates/import/src/rest.rs
+++ b/crates/import/src/rest.rs
@@ -5,7 +5,6 @@
 use anyhow::anyhow;
 use indexmap::IndexMap;
 use itertools::Itertools;
-use serde::de::IgnoredAny;
 use slumber_core::{
     collection::{
         Authentication, Chain, ChainId, ChainOutputTrim, ChainSource,
@@ -325,7 +324,6 @@ fn build_collection(rest_format: RestFormat) -> Collection {
         profiles,
         chains,
         recipes,
-        _ignore: IgnoredAny,
     }
 }
 

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -25,6 +25,7 @@ uuid = {workspace = true, features = ["v4"], optional = true}
 
 [dev-dependencies]
 rstest = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
 uuid = {workspace = true, features = ["v4"]}
 
 [features]

--- a/docs/src/api/configuration/index.md
+++ b/docs/src/api/configuration/index.md
@@ -137,3 +137,7 @@ Visual customizations for the TUI. [More info](./theme.md)
 **Default:** `less` (Unix), `more` (Windows)
 
 Command to use when opening files for viewing. [More info](../../user_guide/tui/editor.md#paging)
+
+### Ignored Fields
+
+In addition to the above fields, any top-level field beginning with `.` will be ignored. This can be combined with [YAML anchors](https://yaml.org/spec/1.2.2/#anchors-and-aliases) to define reusable components in your config file.

--- a/docs/src/api/request_collection/index.md
+++ b/docs/src/api/request_collection/index.md
@@ -24,12 +24,13 @@ slumber --file ../another-project/
 
 A request collection supports the following top-level fields:
 
-| Field      | Type                                                    | Description                                                                                                        | Default |
-| ---------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------- |
-| `profiles` | [`mapping[string, Profile]`](./profile.md)              | Static template values                                                                                             | `{}`    |
-| `requests` | [`mapping[string, RequestRecipe]`](./request_recipe.md) | Requests Slumber can send                                                                                          | `{}`    |
-| `chains`   | [`mapping[string, Chain]`](./chain.md)                  | Complex template values                                                                                            | `{}`    |
-| `.ignore`  | Any                                                     | Extra data to be ignored by Slumber (useful with [YAML anchors](https://yaml.org/spec/1.2.2/#anchors-and-aliases)) |         |
+| Field      | Type                                                    | Description               | Default |
+| ---------- | ------------------------------------------------------- | ------------------------- | ------- |
+| `profiles` | [`mapping[string, Profile]`](./profile.md)              | Static template values    | `{}`    |
+| `requests` | [`mapping[string, RequestRecipe]`](./request_recipe.md) | Requests Slumber can send | `{}`    |
+| `chains`   | [`mapping[string, Chain]`](./chain.md)                  | Complex template values   | `{}`    |
+
+In addition to these fields, any top-level field beginning with `.` will be ignored. This can be combined with [YAML anchors](https://yaml.org/spec/1.2.2/#anchors-and-aliases) to define reusable components in your collection file.
 
 ## Examples
 
@@ -59,11 +60,11 @@ chains:
       recipe: login
     selector: $.token
 
-# Use YAML anchors for de-duplication (Anything under .ignore will not trigger an error for unknown fields)
-.ignore:
-  base: &base
-    headers:
-      Accept: application/json
+# Use YAML anchors for de-duplication. Normally unknown fields in the
+# collection trigger an error; the . prefix tells Slumber to ignore this field
+.base: &base
+  headers:
+    Accept: application/json
 
 requests:
   login: !request

--- a/docs/src/user_guide/inheritance.md
+++ b/docs/src/user_guide/inheritance.md
@@ -57,13 +57,12 @@ chains:
     source: !prompt
       message: Fish ID
 
-# This is needed to tell Slumber not to complain about an unknown key
-.ignore:
-  # The name here is arbitrary, pick any name you like
-  request_base: &request_base
-    headers:
-      Accept: application/json
-    authentication: !bearer "{{chains.token}}"
+# The name here is arbitrary, pick any name you like. Make sure it starts with
+# . to avoid errors about an unknown field
+.request_base: &request_base
+  headers:
+    Accept: application/json
+  authentication: !bearer "{{chains.token}}"
 
 requests:
   list_fish: !request
@@ -99,11 +98,10 @@ chains:
     source: !prompt
       message: Fish ID
 
-.ignore:
-  request_base: &request_base
-    headers: &headers_base # This will let us pull in the header map
-      Accept: application/json
-    authentication: !bearer "{{chains.token}}"
+.request_base: &request_base
+  headers: &headers_base # This will let us pull in the header map
+    Accept: application/json
+  authentication: !bearer "{{chains.token}}"
 
 requests:
   list_fish: !request

--- a/slumber.yml
+++ b/slumber.yml
@@ -72,11 +72,10 @@ chains:
         - html
         - xml
 
-.ignore:
-  base: &base
-    authentication: !bearer "{{chains.auth_token}}"
-    headers:
-      Accept: application/json
+.base_request: &base
+  authentication: !bearer "{{chains.auth_token}}"
+  headers:
+    Accept: application/json
 
 requests:
   login: !request

--- a/test_data/regression.yml
+++ b/test_data/regression.yml
@@ -2,12 +2,11 @@
 # deserialization, to make sure we don't accidentally introduce breaking changes
 # to the format
 
-.ignore:
-  base_profile_data: &base_profile_data
-    host: https://httpbin.org
-  base_recipe: &base_recipe
-    headers:
-      Accept: application/json
+.base_profile_data: &base_profile_data
+  host: https://httpbin.org
+.base_recipe: &base_recipe
+  headers:
+    Accept: application/json
 
 profiles:
   profile1:


### PR DESCRIPTION

## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

This applies to both the collection and config formats. This is not a breaking change because the allowable set of fields is a superset of the previously allowed fields.


## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Very low, as fields other than `.ignore` were previously disallowed, so this can't cause any breaking changes.

## QA

_How did you test this?_

- Unit tests
- Manual testing

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
