### PR TITLE
Fix flaky http tests and improve test perf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -22,7 +22,7 @@ indexmap = {workspace = true, features = ["serde"]}
 itertools = {workspace = true}
 mime = {workspace = true}
 regex = {version = "1.10.5", default-features = false}
-reqwest = {workspace = true, features = ["multipart", "rustls-tls", "rustls-tls-native-roots"]}
+reqwest = {workspace = true, features = ["multipart", "rustls-tls", "rustls-tls-native-roots", "rustls-tls-native-roots-no-provider"]}
 rstest = {workspace = true, optional = true}
 rusqlite = {version = "0.35.0", default-features = false, features = ["bundled", "chrono", "uuid"]}
 rusqlite_migration = "2.1.0"

--- a/crates/core/src/http/tests.rs
+++ b/crates/core/src/http/tests.rs
@@ -52,7 +52,6 @@ fn template_context(
             recipes: by_id(recipes).into(),
             profiles: by_id([profile]),
             chains: by_id(chains),
-            ..Collection::factory(())
         }
         .into(),
         selected_profile: Some(profile_id.clone()),
@@ -92,7 +91,7 @@ async fn mock_server() -> String {
 #[case::safe("safe", false)]
 #[case::danger("danger", true)]
 fn test_get_client(
-    http_engine: &HttpEngine,
+    http_engine: HttpEngine,
     #[case] hostname: &str,
     #[case] expected_danger: bool,
 ) {
@@ -110,7 +109,7 @@ fn test_get_client(
 
 #[rstest]
 #[tokio::test]
-async fn test_build_request(http_engine: &HttpEngine) {
+async fn test_build_request(http_engine: HttpEngine) {
     let recipe = Recipe {
         method: HttpMethod::Post,
         url: "{{host}}/users/{{user_id}}".into(),
@@ -173,7 +172,7 @@ async fn test_build_request(http_engine: &HttpEngine) {
 /// should *not* be built
 #[rstest]
 #[tokio::test]
-async fn test_build_url(http_engine: &HttpEngine) {
+async fn test_build_url(http_engine: HttpEngine) {
     let recipe = Recipe {
         url: "{{host}}/users/{{user_id}}".into(),
         query: vec![
@@ -224,7 +223,7 @@ async fn test_build_url(http_engine: &HttpEngine) {
 )]
 #[tokio::test]
 async fn test_build_body(
-    http_engine: &HttpEngine,
+    http_engine: HttpEngine,
     invalid_utf8_chain: ChainSource,
     #[case] body: RecipeBody,
     #[case] expected_body: &[u8],
@@ -272,7 +271,7 @@ async fn test_build_body(
 #[case::bearer(Authentication::Bearer("{{token}}".into()), "Bearer tokenzzz")]
 #[tokio::test]
 async fn test_authentication(
-    http_engine: &HttpEngine,
+    http_engine: HttpEngine,
     #[case] authentication: Authentication,
     #[case] expected_header: &str,
 ) {
@@ -371,7 +370,7 @@ async fn test_authentication(
 )]
 #[tokio::test]
 async fn test_structured_body(
-    http_engine: &HttpEngine,
+    http_engine: HttpEngine,
     invalid_utf8_chain: ChainSource,
     #[case] body: RecipeBody,
     #[case] content_type: Option<&str>,
@@ -448,7 +447,7 @@ async fn test_structured_body(
 /// bodies
 #[rstest]
 #[tokio::test]
-async fn test_build_options(http_engine: &HttpEngine) {
+async fn test_build_options(http_engine: HttpEngine) {
     let recipe = Recipe {
         authentication: Some(Authentication::Basic {
             username: "username".into(),
@@ -533,7 +532,7 @@ async fn test_build_options(http_engine: &HttpEngine) {
 /// because it's incompatible with testing raw body overrides
 #[rstest]
 #[tokio::test]
-async fn test_build_options_form(http_engine: &HttpEngine) {
+async fn test_build_options_form(http_engine: HttpEngine) {
     let recipe = Recipe {
         // This should implicitly set the content-type header
         body: Some(RecipeBody::FormUrlencoded(indexmap! {
@@ -585,7 +584,7 @@ async fn test_build_options_form(http_engine: &HttpEngine) {
 /// so that the chain is only computed once
 #[rstest]
 #[tokio::test]
-async fn test_chain_duplicate(http_engine: &HttpEngine) {
+async fn test_chain_duplicate(http_engine: HttpEngine) {
     let recipe = Recipe {
         method: HttpMethod::Post,
         url: "{{host}}/{{chains.text}}".into(),
@@ -612,7 +611,7 @@ async fn test_chain_duplicate(http_engine: &HttpEngine) {
 /// Test launching a built request
 #[rstest]
 #[tokio::test]
-async fn test_send_request(http_engine: &HttpEngine) {
+async fn test_send_request(http_engine: HttpEngine) {
     let host = mock_server().await;
     let recipe = Recipe {
         url: format!("{host}/get").as_str().into(),
@@ -694,7 +693,7 @@ fn test_trim_bytes(#[case] bytes: &[u8], #[case] expected: &[u8]) {
 /// Build a curl command with query parameters and headers
 #[rstest]
 #[tokio::test]
-async fn test_build_curl(http_engine: &HttpEngine) {
+async fn test_build_curl(http_engine: HttpEngine) {
     let recipe = Recipe {
         method: HttpMethod::Get,
         query: vec![
@@ -745,7 +744,7 @@ async fn test_build_curl(http_engine: &HttpEngine) {
 )]
 #[tokio::test]
 async fn test_build_curl_authentication(
-    http_engine: &HttpEngine,
+    http_engine: HttpEngine,
     #[case] authentication: Authentication,
     #[case] expected_arguments: &str,
 ) {
@@ -793,7 +792,7 @@ async fn test_build_curl_authentication(
 )]
 #[tokio::test]
 async fn test_build_curl_body(
-    http_engine: &HttpEngine,
+    http_engine: HttpEngine,
     #[case] body: RecipeBody,
     #[case] expected_arguments: &str,
 ) {
@@ -817,7 +816,7 @@ async fn test_build_curl_body(
 /// By default, the engine will follow 3xx redirects
 #[rstest]
 #[tokio::test]
-async fn test_follow_redirects(http_engine: &HttpEngine) {
+async fn test_follow_redirects(http_engine: HttpEngine) {
     let host = mock_server().await;
     let recipe = Recipe {
         url: format!("{host}/redirect").as_str().into(),

--- a/crates/core/src/template/tests.rs
+++ b/crates/core/src/template/tests.rs
@@ -201,7 +201,6 @@ async fn test_chain_request(
             recipes: by_id([recipe]).into(),
             chains: by_id([chain]),
             profiles: by_id([profile]),
-            ..Collection::factory(())
         }
         .into(),
         http_provider: Box::new(TestHttpProvider::new(database, None)),
@@ -395,7 +394,7 @@ async fn test_chain_request_error(
     )]
 #[tokio::test]
 async fn test_triggered_request(
-    http_engine: &HttpEngine,
+    http_engine: HttpEngine,
     #[case] trigger: ChainRequestTrigger,
     // Optional request data to store in the database
     #[case] exchange: Option<Exchange>,
@@ -804,7 +803,6 @@ async fn test_chain_dynamic_select(
             recipes: by_id([recipe]).into(),
             chains: by_id([sut_chain, request_chain]),
             profiles: by_id([profile]),
-            ..Collection::factory(())
         }
         .into(),
         http_provider: Box::new(TestHttpProvider::new(database, None)),

--- a/crates/core/src/test_util.rs
+++ b/crates/core/src/test_util.rs
@@ -32,10 +32,11 @@ pub fn invalid_utf8_chain(test_data_dir: PathBuf) -> ChainSource {
     }
 }
 
-/// Create an HTTP engine for building/sending requests. This is a singleton
-/// because creation is expensive (~300ms), and the engine is immutable.
+/// Create an HTTP engine for building/sending requests. We need to create a new
+/// engine for each test because each reqwest client is bound to a specific
+/// tokio runtime, and each test gets its own runtime.
+/// See https://github.com/LucasPickering/slumber/pull/524
 #[fixture]
-#[once]
 pub fn http_engine() -> HttpEngine {
     HttpEngine::new(&HttpEngineConfig {
         ignore_certificate_hosts: vec!["danger".to_owned()],


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

A reqwest client can't be used across multiple tests because each client is bound to a particular tokio runtime and #[tokio::test] creates a new runtime for each test (see https://github.com/tokio-rs/tokio/issues/2374).

The fix for this is to create a new HttpEngine for each test, which will create a new reqwest client as well underneath. This fixes the flakiness but adds a 100-300ms delay to each test.

I fixed the delay by disabling loading native certs in tests only. We need to keep the native cert loading enabled in prd because of https://github.com/LucasPickering/slumber/issues/275

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

This could break cert loading. I tested requests against `https://httpbin.org` and it worked so I think the certs are being loaded correctly outside tests.

## QA

_How did you test this?_

Confirmed tests are running fast now with:

```
cargo +nightly test -p slumber_core -- -Z unstable-options --report-time
```

All tests finished in <20ms each except for `test_round_trip_prop`

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
