### PR TITLE
Store JSON bodies natively

### DIFF
--- a/crates/cli/src/commands/new.rs
+++ b/crates/cli/src/commands/new.rs
@@ -49,12 +49,13 @@ mod tests {
     use indexmap::indexmap;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
+    use serde_json::json;
     use slumber_core::{
         collection::{
             Chain, ChainSource, Collection, Folder, Profile, Recipe,
             RecipeBody, RecipeNode,
         },
-        http::{HttpMethod, content_type::ContentType},
+        http::HttpMethod,
         test_util::by_id,
     };
     use slumber_util::{Factory, TempDir, temp_dir};
@@ -137,11 +138,12 @@ mod tests {
                         name: Some("Example Request 2".into()),
                         method: HttpMethod::Post,
                         url: "{{host}}/anything".into(),
-                        body: Some(RecipeBody::Raw {
-                            body: "{\n  \"data\": \"{{chains.example}}\"\n}"
-                                .into(),
-                            content_type: Some(ContentType::Json),
-                        }),
+                        body: Some(
+                            RecipeBody::json(
+                                json!({"data": "{{chains.example}}"}),
+                            )
+                            .unwrap(),
+                        ),
                         ..Recipe::factory(())
                     })]),
                 }),

--- a/crates/cli/tests/test_request.rs
+++ b/crates/cli/tests/test_request.rs
@@ -81,10 +81,7 @@ async fn test_request_dry_run() {
     command.assert().success().stderr(
         "> POST http://server/json HTTP/1.1
 > content-type: application/json
-> {
-  \"username\": \"username1\",
-  \"name\": \"Frederick Smidgen\"
-}
+> {\"username\":\"username1\",\"name\":\"Frederick Smidgen\"}
 ",
     );
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -22,7 +22,7 @@ indexmap = {workspace = true, features = ["serde"]}
 itertools = {workspace = true}
 mime = {workspace = true}
 regex = {version = "1.10.5", default-features = false}
-reqwest = {workspace = true, features = ["multipart", "rustls-tls", "rustls-tls-native-roots", "rustls-tls-native-roots-no-provider"]}
+reqwest = {workspace = true, features = ["json", "multipart", "rustls-tls", "rustls-tls-native-roots", "rustls-tls-native-roots-no-provider"]}
 rstest = {workspace = true, optional = true}
 rusqlite = {version = "0.35.0", default-features = false, features = ["bundled", "chrono", "uuid"]}
 rusqlite_migration = "2.1.0"

--- a/crates/core/src/collection.rs
+++ b/crates/core/src/collection.rs
@@ -2,10 +2,12 @@
 //! possible
 
 mod cereal;
+mod json;
 mod models;
 mod recipe_tree;
 
 pub use cereal::HasId;
+pub use json::JsonTemplate;
 pub use models::*;
 pub use recipe_tree::*;
 
@@ -454,12 +456,11 @@ mod tests {
                     id: "text_body".into(),
                     method: HttpMethod::Post,
                     url: "{{host}}/anything/login".into(),
-                    body: Some(RecipeBody::Raw {
-                        body: "{\"username\": \"{{username}}\", \
+                    body: Some(RecipeBody::Raw(
+                        "{\"username\": \"{{username}}\", \
                         \"password\": \"{{chains.password}}\"}"
                             .into(),
-                        content_type: None,
-                    }),
+                    )),
                     query: vec![
                         ("sudo".into(), "yes_please".into()),
                         ("fast".into(), "no_thanks".into()),
@@ -489,11 +490,12 @@ mod tests {
                             name: Some("Modify User".into()),
                             method: HttpMethod::Put,
                             url: "{{host}}/anything/{{user_guid}}".into(),
-                            body: Some(RecipeBody::Raw {
-                                body: json!({"username": "new username"})
-                                    .into(),
-                                content_type: Some(ContentType::Json),
-                            }),
+                            body: Some(
+                                RecipeBody::json(
+                                    json!({"username": "new username"}),
+                                )
+                                .unwrap(),
+                            ),
                             authentication: Some(Authentication::Bearer(
                                 "{{chains.auth_token}}".into(),
                             )),
@@ -507,11 +509,12 @@ mod tests {
                             name: Some("Modify User".into()),
                             method: HttpMethod::Put,
                             url: "{{host}}/anything/{{user_guid}}".into(),
-                            body: Some(RecipeBody::Raw {
-                                body: json!(r#"{"warning": "NOT an object"}"#)
-                                    .into(),
-                                content_type: Some(ContentType::Json),
-                            }),
+                            body: Some(
+                                RecipeBody::json(json!(
+                                    r#"{"warning": "NOT an object"}"#
+                                ))
+                                .unwrap(),
+                            ),
                             authentication: Some(Authentication::Basic {
                                 username: "{{username}}".into(),
                                 password: Some("{{password}}".into()),

--- a/crates/core/src/collection/json.rs
+++ b/crates/core/src/collection/json.rs
@@ -1,0 +1,162 @@
+//! Utilities for working with templated JSON
+
+use crate::template::{
+    Template, TemplateContext, TemplateError, TemplateParseError,
+};
+use futures::future;
+use indexmap::IndexMap;
+use std::str::FromStr;
+use thiserror::Error;
+
+/// A JSON value like [serde_json::Value], but all strings are templates
+#[derive(Clone, Debug)]
+#[cfg_attr(any(test, feature = "test"), derive(PartialEq))]
+pub enum JsonTemplate {
+    Null,
+    Bool(bool),
+    Number(serde_json::Number),
+    String(Template),
+    Array(Vec<Self>),
+    Object(IndexMap<String, Self>),
+}
+
+impl JsonTemplate {
+    /// Build a JSON value without parsing strings as templates
+    pub fn raw(json: serde_json::Value) -> Self {
+        match json {
+            serde_json::Value::Null => Self::Null,
+            serde_json::Value::Bool(b) => Self::Bool(b),
+            serde_json::Value::Number(number) => Self::Number(number),
+            serde_json::Value::String(s) => Self::String(Template::raw(s)),
+            serde_json::Value::Array(values) => {
+                Self::Array(values.into_iter().map(Self::raw).collect())
+            }
+            serde_json::Value::Object(map) => Self::Object(
+                map.into_iter()
+                    .map(|(key, value)| (key, Self::raw(value)))
+                    .collect(),
+            ),
+        }
+    }
+
+    /// Render all templates to strings and return a static JSON value
+    pub async fn render(
+        &self,
+        context: &TemplateContext,
+    ) -> Result<serde_json::Value, TemplateError> {
+        let rendered = match self {
+            Self::Null => serde_json::Value::Null,
+            Self::Bool(b) => serde_json::Value::Bool(*b),
+            Self::Number(number) => serde_json::Value::Number(number.clone()),
+            Self::String(template) => serde_json::Value::String(
+                template.render_string(context).await?,
+            ),
+            Self::Array(array) => {
+                let array = future::try_join_all(
+                    array.iter().map(|item| item.render(context)),
+                )
+                .await?;
+                serde_json::Value::Array(array)
+            }
+            Self::Object(map) => {
+                let map = future::try_join_all(map.iter().map(
+                    |(key, value)| async {
+                        let value = value.render(context).await?;
+                        Ok((key.clone(), value))
+                    },
+                ))
+                .await?;
+                serde_json::Value::Object(map.into_iter().collect())
+            }
+        };
+        Ok(rendered)
+    }
+}
+
+impl From<&JsonTemplate> for serde_json::Value {
+    /// Convert a [JsonTemplate] to a [serde_json::Value], stringifying
+    /// templates
+    fn from(template: &JsonTemplate) -> Self {
+        match template {
+            JsonTemplate::Null => serde_json::Value::Null,
+            JsonTemplate::Bool(b) => serde_json::Value::Bool(*b),
+            JsonTemplate::Number(number) => {
+                serde_json::Value::Number(number.clone())
+            }
+            JsonTemplate::String(template) => {
+                serde_json::Value::String(template.display().to_string())
+            }
+            JsonTemplate::Array(json_templates) => serde_json::Value::Array(
+                json_templates.iter().map(serde_json::Value::from).collect(),
+            ),
+            JsonTemplate::Object(index_map) => serde_json::Value::Object(
+                index_map
+                    .iter()
+                    .map(|(key, value)| {
+                        (key.clone(), serde_json::Value::from(value))
+                    })
+                    .collect(),
+            ),
+        }
+    }
+}
+
+impl FromStr for JsonTemplate {
+    type Err = JsonTemplateError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // First, parse it as regular JSON
+        let json: serde_json::Value = serde_json::from_str(s)?;
+        // Then map all the strings as templates
+        let mapped = json.try_into()?;
+        Ok(mapped)
+    }
+}
+
+impl TryFrom<serde_json::Value> for JsonTemplate {
+    type Error = TemplateParseError;
+
+    /// Convert static JSON to templated JSON, parsing each string as a template
+    fn try_from(json: serde_json::Value) -> Result<Self, Self::Error> {
+        let mapped = match json {
+            serde_json::Value::Null => Self::Null,
+            serde_json::Value::Bool(b) => Self::Bool(b),
+            serde_json::Value::Number(number) => Self::Number(number),
+            serde_json::Value::String(s) => Self::String(s.parse()?),
+            serde_json::Value::Array(values) => Self::Array(
+                values
+                    .into_iter()
+                    .map(JsonTemplate::try_from)
+                    .collect::<Result<Vec<_>, _>>()?,
+            ),
+            serde_json::Value::Object(map) => Self::Object(
+                map.into_iter()
+                    .map(|(key, value)| {
+                        let value = value.try_into()?;
+                        Ok::<_, TemplateParseError>((key, value))
+                    })
+                    .collect::<Result<_, _>>()?,
+            ),
+        };
+        Ok(mapped)
+    }
+}
+
+#[cfg(any(test, feature = "test"))]
+impl From<&'static str> for JsonTemplate {
+    fn from(value: &'static str) -> Self {
+        Self::String(value.into())
+    }
+}
+
+/// Error that can occur when parsing to [JsonTemplate]
+#[derive(Debug, Error)]
+pub enum JsonTemplateError {
+    /// Content was invalid JSON
+    #[error(transparent)]
+    JsonParse(#[from] serde_json::Error),
+    /// Content was valid JSON but one of the contained strings was an invalid
+    /// template
+    #[error(transparent)]
+    TemplateParse(#[from] TemplateParseError),
+}

--- a/crates/core/src/http/curl.rs
+++ b/crates/core/src/http/curl.rs
@@ -86,6 +86,9 @@ impl CurlBuilder {
                 let body = as_text(body)?;
                 write!(&mut self.command, " --data '{body}'").unwrap();
             }
+            RenderedBody::Json(json) => {
+                write!(&mut self.command, " --json '{json}'").unwrap();
+            }
             // Use the first-class form support where possible
             RenderedBody::FormUrlencoded(form) => {
                 for (field, value) in form {

--- a/crates/core/src/template.rs
+++ b/crates/core/src/template.rs
@@ -8,7 +8,9 @@ mod render;
 #[cfg(test)]
 mod tests;
 
-pub use error::{ChainError, TemplateError, TriggeredRequestError};
+pub use error::{
+    ChainError, TemplateError, TemplateParseError, TriggeredRequestError,
+};
 pub use prompt::{Prompt, Prompter, ResponseChannel, Select};
 
 use crate::{

--- a/crates/import/src/openapi/v3_0.rs
+++ b/crates/import/src/openapi/v3_0.rs
@@ -468,13 +468,7 @@ impl<'a> RecipeBuilder<'a> {
             .sorted_by_key(|body| {
                 // This means bodies that *don't* match will sort first, because
                 // false < true
-                matches!(
-                    body,
-                    RecipeBody::Raw {
-                        content_type: None,
-                        ..
-                    }
-                )
+                matches!(body, RecipeBody::Raw(_))
             })
             .next();
 
@@ -704,10 +698,7 @@ impl<'a> RecipeBuilder<'a> {
                 "Unknown content type `{mime}` for body of recipe `{}`",
                 self.id
             );
-            Ok(RecipeBody::Raw {
-                body: Template::raw(format!("{body:#}")),
-                content_type: None,
-            })
+            Ok(RecipeBody::Raw(Template::raw(format!("{body:#}"))))
         }
     }
 }
@@ -770,10 +761,7 @@ mod tests {
                 ..Default::default()
             }
         )],
-        RecipeBody::Raw {
-            body: "{\n  \"field\": \"value\"\n}".into(),
-            content_type: None
-        },
+        RecipeBody::Raw("{\n  \"field\": \"value\"\n}".into()),
     )]
     // We can load from the `schema.example` field
     #[case::schema_example(

--- a/crates/import/src/openapi/v3_1.rs
+++ b/crates/import/src/openapi/v3_1.rs
@@ -426,13 +426,7 @@ impl<'a> RecipeBuilder<'a> {
             .sorted_by_key(|body| {
                 // This means bodies that *don't* match will sort first, because
                 // false < true
-                matches!(
-                    body,
-                    RecipeBody::Raw {
-                        content_type: None,
-                        ..
-                    }
-                )
+                matches!(body, RecipeBody::Raw(_))
             })
             .next();
 
@@ -614,10 +608,7 @@ impl<'a> RecipeBuilder<'a> {
                 "Unknown content type `{mime}` for body of recipe `{}`",
                 self.id
             );
-            Ok(RecipeBody::Raw {
-                body: Template::raw(format!("{body:#}")),
-                content_type: None,
-            })
+            Ok(RecipeBody::Raw(Template::raw(format!("{body:#}"))))
         }
     }
 }

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -28,6 +28,7 @@ persisted = "1.0.0"
 ratatui = {workspace = true, features = ["crossterm", "underline-color", "unstable-widget-ref"]}
 reqwest = {workspace = true}
 serde = {workspace = true}
+serde_json = {workspace = true}
 serde_yaml = {workspace = true}
 shell-words = "1.1.0"
 slumber_config = {workspace = true}
@@ -45,7 +46,6 @@ uuid = {workspace = true}
 [dev-dependencies]
 pretty_assertions = {workspace = true}
 rstest = {workspace = true}
-serde_json = {workspace = true}
 slumber_core = {workspace = true, features = ["test"]}
 wiremock = {workspace = true}
 

--- a/crates/tui/src/view/component/recipe_pane/persistence.rs
+++ b/crates/tui/src/view/component/recipe_pane/persistence.rs
@@ -101,10 +101,6 @@ impl RecipeTemplate {
         &self.0.preview
     }
 
-    pub fn content_type(&self) -> Option<ContentType> {
-        self.0.content_type
-    }
-
     pub fn is_overridden(&self) -> bool {
         self.0.override_template.is_some()
     }

--- a/crates/tui/src/view/component/recipe_pane/recipe.rs
+++ b/crates/tui/src/view/component/recipe_pane/recipe.rs
@@ -105,7 +105,7 @@ impl RecipeDisplay {
             .data()
             .as_ref()
             .and_then(|body| match body {
-                RecipeBodyDisplay::Raw(_) => None,
+                RecipeBodyDisplay::Raw(_) | RecipeBodyDisplay::Json(_) => None,
                 RecipeBodyDisplay::Form(form) => {
                     Some(form.data().to_build_overrides())
                 }

--- a/test_data/rest_http_bin.http
+++ b/test_data/rest_http_bin.http
@@ -14,7 +14,7 @@ GET {{ HOST}}/get HTTP/1.1
 POST {{HOST}}/post?hello=123 HTTP/1.1
 authorization: Basic Zm9vOmJhcg==
 content-type: application/json
-X-Http-Method-Override: PUT
+x-http-method-override: PUT
 
 {
     "data": "my data",


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Instead of stringifying JSON bodies during deserialization, store them natively as a JSON value, and stringify them post-render. This makes a lot of test assertions easier because we don't have to worry about formatting of the bodies.

Also refactored core http tests a bit to make them more readable.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

This trades complexity in the core lib for complexity in the TUI. I think it locates the complexity to more relevant locations though. There's some more work that needs to be done around handling errors in the body override.

## QA

_How did you test this?_

Added some tests

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
