### PR TITLE
adds support for .env file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Add support to load environment variables from `.env` file using the `dotenv` crate.
+
 ## [3.2.0] - 2025-06-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,6 +753,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2801,6 +2807,7 @@ version = "3.2.0"
 dependencies = [
  "anyhow",
  "console-subscriber",
+ "dotenv",
  "slumber_cli",
  "slumber_tui",
  "slumber_util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-authors = {workspace = true}
+authors = { workspace = true }
 description = "Terminal-based HTTP client"
-edition = {workspace = true}
-homepage = {workspace = true}
-keywords = {workspace = true}
-license = {workspace = true}
+edition = { workspace = true }
+homepage = { workspace = true }
+keywords = { workspace = true }
+license = { workspace = true }
 name = "slumber"
-repository = {workspace = true}
-rust-version = {workspace = true}
-version = {workspace = true}
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 
 [workspace]
 members = ["crates/*"]
@@ -28,46 +28,50 @@ rust-version = "1.86.0"
 [workspace.dependencies]
 anyhow = "1.0.0"
 async-trait = "0.1.81"
-bytes = {version = "1.6.1", default-features = false}
-chrono = {version = "0.4.31", default-features = false}
-crossterm = {version = "0.28.0", default-features = false, features = ["events"]}
-derive_more = {version = "1.0.0", default-features = false}
-dialoguer = {version = "0.11.0", default-features = false}
+bytes = { version = "1.6.1", default-features = false }
+chrono = { version = "0.4.31", default-features = false }
+crossterm = { version = "0.28.0", default-features = false, features = [
+  "events",
+] }
+derive_more = { version = "1.0.0", default-features = false }
+dialoguer = { version = "0.11.0", default-features = false }
 dirs = "5.0.1"
 env-lock = "0.1.0"
 futures = "0.3.28"
-indexmap = {version = "2.0.0", default-features = false}
+indexmap = { version = "2.0.0", default-features = false }
 itertools = "0.13.0"
 mime = "0.3.17"
 pretty_assertions = "1.4.0"
-ratatui = {version = "0.28.0", default-features = false}
-reqwest = {version = "0.12.5", default-features = false}
-rstest = {version = "0.24.0", default-features = false}
-serde = {version = "1.0.204", default-features = false}
-serde_json = {version = "1.0.120", default-features = false, features = ["preserve_order"]}
+ratatui = { version = "0.28.0", default-features = false }
+reqwest = { version = "0.12.5", default-features = false }
+rstest = { version = "0.24.0", default-features = false }
+serde = { version = "1.0.204", default-features = false }
+serde_json = { version = "1.0.120", default-features = false, features = [
+  "preserve_order",
+] }
 serde_test = "1.0.176"
-serde_yaml = {version = "0.9.0", default-features = false}
-slumber_cli = {path = "./crates/cli", version = "3.2.0" }
-slumber_config = {path = "./crates/config", version = "3.2.0" }
-slumber_core = {path = "./crates/core", version = "3.2.0" }
-slumber_import = {path = "./crates/import", version = "3.2.0" }
-slumber_tui = {path = "./crates/tui", version = "3.2.0" }
-slumber_util = {path = "./crates/util", version = "3.2.0" }
-strum = {version = "0.26.3", default-features = false}
+serde_yaml = { version = "0.9.0", default-features = false }
+slumber_cli = { path = "./crates/cli", version = "3.2.0" }
+slumber_config = { path = "./crates/config", version = "3.2.0" }
+slumber_core = { path = "./crates/core", version = "3.2.0" }
+slumber_import = { path = "./crates/import", version = "3.2.0" }
+slumber_tui = { path = "./crates/tui", version = "3.2.0" }
+slumber_util = { path = "./crates/util", version = "3.2.0" }
+strum = { version = "0.26.3", default-features = false }
 thiserror = "2.0.12"
-tokio = {version = "1.39.2", default-features = false}
+tokio = { version = "1.39.2", default-features = false }
 tracing = "0.1.40"
 url = "2.0.0"
-uuid = {version = "1.10.0", default-features = false}
+uuid = { version = "1.10.0", default-features = false }
 winnow = "0.6.16"
-wiremock = {version = "0.6.1", default-features = false}
+wiremock = { version = "0.6.1", default-features = false }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"
 
 [workspace.lints.clippy]
-all = {level = "deny", priority = -1}
-pedantic = {level = "warn", priority = -1}
+all = { level = "deny", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
 
 allow_attributes = "deny"
 cast_possible_truncation = "allow"
@@ -90,14 +94,19 @@ unused_self = "allow"
 used_underscore_binding = "allow"
 
 [dependencies]
-anyhow = {workspace = true, features = ["backtrace"]}
-console-subscriber = {version = "0.4.1", default-features = false, optional = true}
-slumber_cli = {workspace = true, optional = true}
-slumber_tui = {workspace = true, optional = true}
-slumber_util = {workspace = true}
-tokio = {workspace = true, features = ["macros", "rt", "tracing"]}
-tracing = {workspace = true}
-tracing-subscriber = {version = "0.3.17", default-features = false, features = ["ansi", "fmt", "registry"]}
+anyhow = { workspace = true, features = ["backtrace"] }
+console-subscriber = { version = "0.4.1", default-features = false, optional = true }
+dotenv = "0.15.0"
+slumber_cli = { workspace = true, optional = true }
+slumber_tui = { workspace = true, optional = true }
+slumber_util = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "tracing"] }
+tracing = { workspace = true }
+tracing-subscriber = { version = "0.3.17", default-features = false, features = [
+  "ansi",
+  "fmt",
+  "registry",
+] }
 
 [features]
 default = ["cli", "tui"]
@@ -115,7 +124,7 @@ lto = "thin"
 [package.metadata.release]
 pre-release-hook = ["python", "./gifs.py", "--check"]
 pre-release-replacements = [
-    {file = "CHANGELOG.md", search = "## \\[Unreleased\\] - ReleaseDate", replace = "## [Unreleased] - ReleaseDate\n\n## [{{version}}] - {{date}}"},
+  { file = "CHANGELOG.md", search = "## \\[Unreleased\\] - ReleaseDate", replace = "## [Unreleased] - ReleaseDate\n\n## [{{version}}] - {{date}}" },
 ]
 
 # Config for 'dist'
@@ -129,7 +138,13 @@ installers = ["shell", "powershell", "homebrew"]
 # A GitHub repo to push Homebrew formulas to
 tap = "LucasPickering/homebrew-tap"
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
+targets = [
+  "aarch64-apple-darwin",
+  "x86_64-apple-darwin",
+  "x86_64-unknown-linux-gnu",
+  "x86_64-unknown-linux-musl",
+  "x86_64-pc-windows-msvc",
+]
 # Publish jobs to run in CI
 publish-jobs = ["homebrew"]
 # Which actions to run on pull requests

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use anyhow::Context;
+use dotenv::dotenv;
 use slumber_util::{ResultTraced, paths};
 use std::{
     fs::{self, File, OpenOptions},
@@ -14,6 +15,7 @@ use tracing_subscriber::{filter::Targets, fmt::format::FmtSpan, prelude::*};
 async fn main() -> anyhow::Result<std::process::ExitCode> {
     use slumber_cli::Args;
     use std::process::ExitCode;
+    dotenv().ok();
 
     // Global initialization
     Args::complete(); // If COMPLETE var is enabled, process will stop here


### PR DESCRIPTION
## Description

Simply adds dotenv to read .env file automatically.
Pretty handy to load variables from it without having to pass them manually.

Thanks for the tool, it's nice 👍🏼 

## Known Risks

No breaking change, takes the passed variable in priority if not found takes it from .env if existing. If no .env file does nothing.

## QA

Tested on a personal project where I use slumber, works well.

## Checklist

- [X] Have you read `CONTRIBUTING.md` already?
- [X] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [X] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
