### PR TITLE
Remove YAML tags, use saphyr as YAML parser

### DIFF
--- a/.rules
+++ b/.rules
@@ -1,0 +1,20 @@
+# Slumber Testing Rules and Commands
+
+This file contains comprehensive instructions for running tests in the Slumber project.
+
+## Project Structure
+
+Slumber is organized as a Rust workspace with all crates under `crates/*`
+
+## Quick Reference
+
+```bash
+# Run all tests
+cargo test
+
+# Run tests for a specific crate
+cargo test -p slumber_core
+
+# Run a specific test
+cargo test -p slumber_core -- test_regression
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,17 @@ slumber import v3 <old file> <new file>
 
 The new collection _should_ be equivalent to the old one, but you should keep your old version around just in case something broke. If you notice any differences, please [file a bug!](https://github.com/lucaspickering/slumber/issues/new).
 
+TODO write migration guide
+
 - Replace template chains with a more intuitive function syntax
   - Instead of defining chains separately then referencing them in templates, you can now call functions directly in templates: `{{ response('login') | jsonpath('$.token') }}`
   - TODO link to docs for this
+- Replace YAML `!tags` with an inner `type` field
+  - This change makes the format compatible with JSON Schema
+  - Impacts these collection nodes:
+    - Folder/request nodes
+    - Authentication
+    - Body
 - Represent query parameters as a map of `{parameter: value}` instead of a list of strings like `parameter=value`
   - The map format has been supported as well, but did not allow for multiple values for the same value, hence the need for the string format
   - To define multiple values for the same value, you can now use a list associated to the parameter: `{parameter: [value1, value2]}`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,6 +784,15 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "env-lock"
@@ -1837,6 +1852,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2c1f9f56e534ac6a9b8a4600bdf0f530fb393b5f393e7b4d03489c3cf0c3f01"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "os_pipe"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2565,6 +2589,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "saphyr"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3767dfe8889ebb55a21409df2b6f36e66abfbe1eb92d64ff76ae799d3f91016"
+dependencies = [
+ "arraydeque",
+ "encoding_rs",
+ "hashlink",
+ "ordered-float",
+ "saphyr-parser",
+]
+
+[[package]]
+name = "saphyr-parser"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb771b59f6b1985d1406325ec28f97cfb14256abcec4fdfb37b36a1766d6af7"
+dependencies = [
+ "arraydeque",
+ "hashlink",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2886,6 +2933,7 @@ dependencies = [
  "rstest",
  "rusqlite",
  "rusqlite_migration",
+ "saphyr",
  "serde",
  "serde_json",
  "serde_json_path",

--- a/crates/cli/src/commands/new.rs
+++ b/crates/cli/src/commands/new.rs
@@ -6,7 +6,7 @@ use std::{fs::OpenOptions, io::Write, path::PathBuf, process::ExitCode};
 /// We use a static source file, to get control of whitespace/comments.
 /// Generating a collection and serializing it would be like driving from the
 /// back seat with a broom stick.
-const SOURCE: &[u8] = include_bytes!("new.yml");
+const SOURCE: &str = include_str!("new.yml");
 const DEFAULT_PATH: &str = "slumber.yml";
 
 /// Generate a new Slumber collection file
@@ -36,7 +36,7 @@ impl Subcommand for NewCommand {
             .with_context(|| {
                 format!("Error opening file `{}`", path.display())
             })?;
-        file.write_all(SOURCE).with_context(|| {
+        file.write_all(SOURCE.as_bytes()).with_context(|| {
             format!("Error writing to file `{}`", path.display())
         })?;
 
@@ -89,7 +89,7 @@ mod tests {
         };
 
         command.execute(global_args).await.unwrap();
-        let contents = fs::read(&expected_created_path)
+        let contents = fs::read_to_string(&expected_created_path)
             .with_context(|| {
                 format!(
                     "Error reading results from expected output path \
@@ -104,7 +104,7 @@ mod tests {
     /// specific contents
     #[test]
     fn test_deserialize() {
-        let collection: Collection = serde_yaml::from_slice(SOURCE).unwrap();
+        let collection: Collection = Collection::parse(SOURCE).unwrap();
         let expected = Collection {
             profiles: by_id([Profile {
                 id: "example".into(),

--- a/crates/cli/src/commands/new.yml
+++ b/crates/cli/src/commands/new.yml
@@ -12,17 +12,21 @@ profiles:
       host: https://httpbin.org
 
 requests:
-  example1: !request
+  example1:
+    type: request
     name: Example Request 1
     method: GET
     url: "{{ host }}/anything"
 
-  example_folder: !folder
+  example_folder:
+    type: folder
     name: Example Folder
     requests:
-      example2: !request
+      example2:
+        type: request
         name: Example Request 2
         method: POST
         url: "{{ host }}/anything"
         body:
-          !json { "data": "{{ response('example1') | jsonpath('$.data') }}" }
+          type: json
+          data: { "data": "{{ response('example1') | jsonpath('$.data') }}" }

--- a/crates/cli/tests/slumber.yml
+++ b/crates/cli/tests/slumber.yml
@@ -14,15 +14,20 @@ profiles:
       username: username2
 
 requests:
-  getUser: !request
+  getUser:
+    type: request
     method: GET
     url: "{{ host }}/users/{{ username }}"
 
-  jsonBody: !request
+  jsonBody:
+    type: request
     method: POST
     url: "{{ host }}/json"
-    body: !json { "username": "{{ username }}", "name": "Frederick Smidgen" }
+    body:
+      type: json
+      data: { "username": "{{ username }}", "name": "Frederick Smidgen" }
 
-  chained: !request
+  chained:
+    type: request
     method: GET
     url: "{{ host }}/chained/{{ response('getUser', trigger='always') | jsonpath('$.username') }}"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -26,14 +26,14 @@ reqwest = {workspace = true, features = ["json", "multipart", "rustls-tls", "rus
 rstest = {workspace = true, optional = true}
 rusqlite = {version = "0.35.0", default-features = false, features = ["bundled", "chrono", "uuid"]}
 rusqlite_migration = "2.1.0"
+saphyr = "0.0.6"
 serde = {workspace = true, features = ["derive"]}
 serde_json = {workspace = true}
 serde_json_path = "0.7.1"
-serde_yaml = {workspace = true}
 slumber_config = {workspace = true}
+slumber_macros = {workspace = true}
 slumber_template = {workspace = true}
 slumber_util = {workspace = true}
-slumber_macros = {workspace = true}
 strum = {workspace = true, features = ["derive"]}
 thiserror = {workspace = true}
 tokio = {workspace = true, features = ["fs", "process"]}
@@ -49,6 +49,7 @@ proptest = "1.5.0"
 proptest-derive = "0.5.0"
 rstest = {workspace = true}
 serde_test = {workspace = true}
+serde_yaml = {workspace = true}
 slumber_template = {workspace = true, features = ["test"]}
 slumber_util = {workspace = true, features = ["test"]}
 wiremock = {workspace = true}

--- a/crates/core/src/collection.rs
+++ b/crates/core/src/collection.rs
@@ -146,7 +146,9 @@ mod tests {
     use pretty_assertions::assert_eq;
     use rstest::rstest;
     use serde_json::json;
-    use slumber_util::{Factory, TempDir, assert_err, temp_dir, test_data_dir};
+    use slumber_util::{
+        Factory, TempDir, assert_err, parse_yaml, temp_dir, test_data_dir,
+    };
     use std::{fs, fs::File};
 
     /// Test various cases of [CollectionFile::with_dir]
@@ -220,11 +222,58 @@ mod tests {
         );
     }
 
+    /// Test various error cases when deserializing a collection. Make sure
+    /// we get a useful error message for each one
+    #[rstest]
+    #[case::recipe_missing_type(
+        json!({
+            "requests": {
+                "r1": {
+                    "method": "GET",
+                    "url": "http://localhost",
+                }
+            }
+        }),
+        "requests.r1: missing field `type`"
+    )]
+    #[case::query(
+        json!({
+            "requests": {
+                "r1": {
+                    "type": "request",
+                    "method": "GET",
+                    "url": "http://localhost",
+                    "query": 3,
+                }
+            }
+        }),
+        "requests.r1.query: invalid type: integer `3`, expected a map"
+    )]
+    #[case::headers(
+        json!({
+            "requests": {
+                "r1": {
+                    "type": "request",
+                    "method": "GET",
+                    "url": "http://localhost",
+                    "headers": 3,
+                }
+            }
+        }),
+        "requests.r1.headers: invalid type: integer `3`, expected a map"
+    )]
+    fn test_deserialize_collection_error(
+        #[case] collection: serde_json::Value,
+        #[case] expected_error: &str,
+    ) {
+        let yaml = collection.to_string(); // JSON is valid YAML
+        assert_err!(parse_yaml::<Collection>(yaml.as_bytes()), expected_error);
+    }
+
     /// A catch-all regression test, to make sure we don't break anything in the
     /// collection format. This lives at the bottom because it's huge.
     #[rstest]
-    #[tokio::test]
-    async fn test_regression(test_data_dir: PathBuf) {
+    fn test_regression(test_data_dir: PathBuf) {
         let loaded =
             Collection::load(&test_data_dir.join("regression.yml")).unwrap();
         let expected = Collection {
@@ -247,7 +296,6 @@ mod tests {
                     default: true,
                     data: indexmap! {
                         "host".into() => "https://httpbin.org".into(),
-
                     },
                 },
             ]),
@@ -303,10 +351,10 @@ mod tests {
                                 )
                                 .unwrap(),
                             ),
-                            authentication: Some(Authentication::Bearer(
-                                "{{ response('login') | jsonpath('$.token') }}"
+                            authentication: Some(Authentication::Bearer {
+                                token: "{{ response('login') | jsonpath('$.token') }}"
                                     .into(),
-                            )),
+                            }),
                             headers: indexmap! {
                                 "accept".into() => "application/json".into(),
                             },

--- a/crates/core/src/collection.rs
+++ b/crates/core/src/collection.rs
@@ -141,14 +141,15 @@ fn detect_path(dir: &Path) -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{http::HttpMethod, test_util::by_id};
+    use crate::{
+        collection::cereal::deserialize_collection, http::HttpMethod,
+        test_util::by_id,
+    };
     use indexmap::indexmap;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
     use serde_json::json;
-    use slumber_util::{
-        Factory, TempDir, assert_err, parse_yaml, temp_dir, test_data_dir,
-    };
+    use slumber_util::{Factory, TempDir, assert_err, temp_dir, test_data_dir};
     use std::{fs, fs::File};
 
     /// Test various cases of [CollectionFile::with_dir]
@@ -226,48 +227,41 @@ mod tests {
     /// we get a useful error message for each one
     #[rstest]
     #[case::recipe_missing_type(
-        json!({
-            "requests": {
-                "r1": {
-                    "method": "GET",
-                    "url": "http://localhost",
-                }
-            }
-        }),
-        "requests.r1: missing field `type`"
+        r"
+        requests:
+          r1:
+            method: GET
+            url: http://localhost
+        ",
+        "Error at :4:12: Expected field `type` with one of \"request\", \"folder\""
     )]
     #[case::query(
-        json!({
-            "requests": {
-                "r1": {
-                    "type": "request",
-                    "method": "GET",
-                    "url": "http://localhost",
-                    "query": 3,
-                }
-            }
-        }),
-        "requests.r1.query: invalid type: integer `3`, expected a map"
+        r"
+        requests:
+          r1:
+            type: request
+            method: GET
+            url: http://localhost
+            query: 3
+        ",
+        "Error at :7:19: Expected mapping, received `3`"
     )]
     #[case::headers(
-        json!({
-            "requests": {
-                "r1": {
-                    "type": "request",
-                    "method": "GET",
-                    "url": "http://localhost",
-                    "headers": 3,
-                }
-            }
-        }),
-        "requests.r1.headers: invalid type: integer `3`, expected a map"
+        r"
+        requests:
+          r1:
+            type: request
+            method: GET
+            url: http://localhost
+            headers: 3
+        ",
+        "Error at :7:21: Expected mapping, received `3`"
     )]
     fn test_deserialize_collection_error(
-        #[case] collection: serde_json::Value,
+        #[case] yaml: &str,
         #[case] expected_error: &str,
     ) {
-        let yaml = collection.to_string(); // JSON is valid YAML
-        assert_err!(parse_yaml::<Collection>(yaml.as_bytes()), expected_error);
+        assert_err!(deserialize_collection(yaml, None), expected_error);
     }
 
     /// A catch-all regression test, to make sure we don't break anything in the
@@ -398,6 +392,16 @@ mod tests {
             ])
             .into(),
         };
-        assert_eq!(loaded, expected);
+        assert_eq!(loaded, expected, "Deserialization incorrect");
+
+        // Now that we know deserailization works, let's test serialization.
+        // We'll serialize then deserialize again and expect the same thing
+        let serialized = serde_yaml::to_string(&loaded).unwrap();
+        let loaded: Collection =
+            deserialize_collection(&serialized, None).unwrap();
+        assert_eq!(
+            loaded, expected,
+            "Serialized & re-deserialization incorrect"
+        );
     }
 }

--- a/crates/core/src/collection/cereal.rs
+++ b/crates/core/src/collection/cereal.rs
@@ -1,18 +1,867 @@
-//! Serialization/deserialization helpers for various types
+//! Deserialization helpers for collection types. This does *not* use serde,
+//! and instead relies on [saphyr] for YAML parsing and hand-written
+//! deserialization. This allows us to provide much better error messages, and
+//! also enables source span tracking.
+//!
+//! This module only provides deserialization; serialization is still handled
+//! by serde/serde_yaml, because there's no need for error messages and the
+//! derive macros are sufficient to generate the corresponding YAML.
 
-use crate::collection::{
-    Profile, ProfileId, Recipe, RecipeId, recipe_tree::RecipeNode,
+use crate::{
+    collection::{
+        Authentication, Collection, Folder, JsonTemplate, Profile, ProfileId,
+        QueryParameterValue, Recipe, RecipeBody, RecipeId, RecipeTree,
+        recipe_tree::RecipeNode,
+    },
+    http::HttpMethod,
 };
 use indexmap::IndexMap;
 use itertools::Itertools;
-use serde::{Deserialize, Deserializer, de};
+use saphyr::{
+    AnnotatedMapping, LoadableYamlNode, MarkedYaml, Marker, Scalar, ScanError,
+    YamlData,
+};
 use slumber_template::Template;
-use std::hash::Hash;
+use std::path::Path;
+use thiserror::Error;
+
+type Result<T> = std::result::Result<T, LocatedError>;
+
+/// Parse and deserialize a YAML string into a [Collection]
+///
+/// This uses [saphyr] to parse the string into a YAML document, then uses
+/// custom deserialization logic to deserialize the YAML into the collection
+/// data types. We do this rather than use serde_yaml because it provides:
+/// - Better error messages
+/// - Source span tracking
+///
+/// The given path is used only for error context. The data must already be
+/// loaded out of the file prior to calling.
+pub fn deserialize_collection(
+    yaml_input: &str,
+    path: Option<&Path>,
+) -> anyhow::Result<Collection> {
+    let mut documents = MarkedYaml::load_from_str(yaml_input)?;
+
+    // If the file is empty, pretend there's an empty mapping instead because
+    // that's functionally equivalent
+    let yaml = documents
+        .pop()
+        .unwrap_or(YamlData::Mapping(Default::default()).into());
+
+    Collection::deserialize(yaml).map_err(
+        |LocatedError {
+             error: kind,
+             location,
+         }| {
+            // Display the error with path and location
+            anyhow::Error::from(kind).context(format!(
+                "Error at {path}:{line}:{col}",
+                path = path.unwrap_or(Path::new("")).display(),
+                line = location.line(),
+                col = location.col(),
+            ))
+        },
+    )
+}
+
+/// Deserialize from YAML into the implementing type
+trait DeserializeYaml: Sized {
+    /// What kind of YAML value do we expect to see?
+    fn expected() -> Expected;
+
+    /// Deserialize the given YAML value into this type
+    fn deserialize(yaml: MarkedYaml) -> Result<Self>;
+}
+
+/// Implement [DeserializeYaml] for a type `T` via type `U`, where `T: From<U>,
+/// U: DeserializeYaml`
+macro_rules! impl_deserialize_from {
+    ($t:ty, $u:ty) => {
+        impl DeserializeYaml for $t {
+            fn expected() -> Expected {
+                <$u as DeserializeYaml>::expected()
+            }
+
+            fn deserialize(yaml: MarkedYaml) -> Result<Self> {
+                <$u as DeserializeYaml>::deserialize(yaml).map(<$t>::from)
+            }
+        }
+    };
+}
+
+/// Deserialize a YAML value as an internally tagged enum. The `type` field will
+/// contain the variant, and all other fields in the mapping will be
+/// deserialized using the given function.
+macro_rules! deserialize_enum {
+    ($yaml:expr, $($tag:literal => $f:expr),* $(,)?) => {
+            const EXPECTED: Expected =
+                Expected::OneOf(&[$(&Expected::Literal($tag),)*]);
+
+            // Find the enum variant based on the `type` field
+            let span = $yaml.span;
+            let mut mapping = $yaml.try_into_mapping()?;
+            let kind_yaml = mapping
+                .remove(&MarkedYaml::value_from_str("type"))
+                .ok_or(LocatedError {
+                    error: Error::MissingField {
+                        field: "type",
+                        expected: EXPECTED,
+                    },
+                    location: span.start,
+                })?;
+            let kind_location = kind_yaml.span.start;
+            let kind = kind_yaml.try_into_string()?;
+
+            // Deserialize the rest of the mapping as the specified enum variant
+            let yaml = MarkedYaml {
+                data: YamlData::Mapping(mapping),
+                span,
+            };
+            match kind.as_str() {
+                $($tag => $f(yaml),)*
+                // Unknown tag
+                _ => Err(LocatedError {
+                    error: Error::Unexpected {
+                        expected: EXPECTED,
+                        actual: format!("{kind:?}"),
+                    },
+                    location: kind_location,
+                }),
+            }
+    };
+}
+
+impl_deserialize_from!(ProfileId, String);
+impl_deserialize_from!(RecipeId, String);
+
+impl DeserializeYaml for Collection {
+    fn expected() -> Expected {
+        Expected::Mapping
+    }
+
+    fn deserialize(yaml: MarkedYaml) -> Result<Self> {
+        let mut deserializer = StructDeserializer::new(yaml)?;
+
+        // Drop all fields starting with `.`
+        deserializer.mapping.retain(|key, _| {
+            !key.data.as_str().is_some_and(|s| s.starts_with('.'))
+        });
+
+        let collection = Collection {
+            profiles: deserializer.get(Field::new("profiles").opt())?,
+            // Internally we call these recipes, but extensive market research
+            // shows that `requests` is more intuitive to the user
+            recipes: deserializer.get(Field::new("requests").opt())?,
+        };
+        deserializer.done()?;
+        Ok(collection)
+    }
+}
+
+/// Deserialize a map of profiles. This needs a custom implementation because:
+/// - To call [HasId::set_id] on each value
+/// - We have to enforce that at most one profile is set as default
+impl DeserializeYaml for IndexMap<ProfileId, Profile> {
+    fn expected() -> Expected {
+        Expected::Mapping
+    }
+
+    fn deserialize(yaml: MarkedYaml) -> Result<Self> {
+        // Enforce that only one profile can be the default
+        let mut default_profile: Option<ProfileId> = None;
+
+        yaml.try_into_mapping()?
+            .into_iter()
+            .map(|(k, v)| {
+                let value_location = v.span.start;
+                let key = ProfileId::deserialize(k)?;
+                let mut value = Profile::deserialize(v)?;
+                value.set_id(key.clone());
+
+                // Check if another profile is already the default
+                if value.default {
+                    if let Some(default) = default_profile.take() {
+                        return Err(LocatedError {
+                            error: Error::MultipleDefaultProfiles {
+                                first: default,
+                                second: key,
+                            },
+                            location: value_location,
+                        });
+                    }
+
+                    default_profile = Some(key.clone());
+                }
+
+                Ok((key, value))
+            })
+            .collect()
+    }
+}
+
+impl DeserializeYaml for Profile {
+    fn expected() -> Expected {
+        Expected::Mapping
+    }
+
+    fn deserialize(yaml: MarkedYaml) -> Result<Self> {
+        let mut deserializer = StructDeserializer::new(yaml)?;
+        let profile = Self {
+            id: ProfileId::default(), // Will be set by parent based on key
+            name: deserializer.get(Field::new("name").opt())?,
+            default: deserializer.get(Field::new("default").opt())?,
+            data: deserializer.get(Field::new("data").opt())?,
+        };
+        deserializer.done()?;
+        Ok(profile)
+    }
+}
+
+impl DeserializeYaml for RecipeTree {
+    fn expected() -> Expected {
+        Expected::Mapping
+    }
+
+    fn deserialize(yaml: MarkedYaml) -> Result<Self> {
+        let location = yaml.span.start;
+        let recipes = IndexMap::deserialize(yaml)?;
+        // Build a tree from the map
+        RecipeTree::new(recipes)
+            .map_err(|error| LocatedError::other(error, location))
+    }
+}
+
+/// Deserialize a map of profiles. This needs a custom implementation to call
+/// [HasId::set_id] on each value. This is used for both the root `requests`
+/// field and each inner folder.
+impl DeserializeYaml for IndexMap<RecipeId, RecipeNode> {
+    fn expected() -> Expected {
+        Expected::Mapping
+    }
+
+    fn deserialize(yaml: MarkedYaml) -> Result<Self> {
+        yaml.try_into_mapping()?
+            .into_iter()
+            .map(|(k, v)| {
+                let key = RecipeId::deserialize(k)?;
+                let mut value = RecipeNode::deserialize(v)?;
+                value.set_id(key.clone());
+                Ok((key, value))
+            })
+            .collect()
+    }
+}
+
+impl DeserializeYaml for RecipeNode {
+    fn expected() -> Expected {
+        Expected::Mapping
+    }
+
+    fn deserialize(yaml: MarkedYaml) -> Result<Self> {
+        deserialize_enum! {
+            yaml,
+            "request" => |yaml| {
+                Recipe::deserialize(yaml).map(RecipeNode::Recipe)
+            },
+            "folder" => |yaml| {
+                Folder::deserialize(yaml).map(RecipeNode::Folder)
+            },
+        }
+    }
+}
+
+impl DeserializeYaml for Recipe {
+    fn expected() -> Expected {
+        Expected::Mapping
+    }
+
+    fn deserialize(yaml: MarkedYaml) -> Result<Self> {
+        let mut deserializer = StructDeserializer::new(yaml)?;
+        let recipe = Recipe {
+            id: RecipeId::default(), // Will be set by parent based on key
+            name: deserializer.get(Field::new("name").opt())?,
+            persist: deserializer.get(Field::new("persist").or(true))?,
+            method: deserializer.get(Field::new("method"))?,
+            url: deserializer.get(Field::new("url"))?,
+            body: deserializer.get(Field::new("body").opt())?,
+            authentication: deserializer
+                .get(Field::new("authentication").opt())?,
+            query: deserializer.get(Field::new("query").opt())?,
+            // Lower-case all headers for consistency. HTTP/1.1 headers are
+            // case-insensitive and HTTP/2 enforces lower casing.
+            headers: deserializer
+                .get(Field::<IndexMap<String, Template>>::new("headers").opt())?
+                .into_iter()
+                .map(|(k, v)| (k.to_lowercase(), v))
+                .collect(),
+        };
+        deserializer.done()?;
+        Ok(recipe)
+    }
+}
+
+impl DeserializeYaml for Folder {
+    fn expected() -> Expected {
+        Expected::Mapping
+    }
+
+    fn deserialize(yaml: MarkedYaml) -> Result<Self> {
+        let mut deserializer = StructDeserializer::new(yaml)?;
+        let folder = Folder {
+            id: RecipeId::default(), // Will be set by parent based on key
+            name: deserializer.get(Field::new("name").opt())?,
+            // `requests` matches the root field name
+            children: deserializer.get(Field::new("requests").opt())?,
+        };
+        deserializer.done()?;
+        Ok(folder)
+    }
+}
+
+impl DeserializeYaml for HttpMethod {
+    fn expected() -> Expected {
+        Expected::String
+    }
+
+    fn deserialize(yaml: MarkedYaml) -> Result<Self> {
+        let marker = yaml.span.start;
+        let s = String::deserialize(yaml)?;
+        s.parse()
+            .map_err(|error| LocatedError::other(error, marker))
+    }
+}
+
+impl DeserializeYaml for QueryParameterValue {
+    fn expected() -> Expected {
+        Expected::OneOf(&[&Expected::String, &Expected::Sequence])
+    }
+
+    /// Deserialize from a single template or a list of templates
+    fn deserialize(yaml: MarkedYaml) -> Result<Self> {
+        if yaml.is_sequence() {
+            // Deserialize vec
+            DeserializeYaml::deserialize(yaml).map(Self::Many)
+        } else {
+            // Deserialize template
+            DeserializeYaml::deserialize(yaml).map(Self::One)
+        }
+    }
+}
+
+impl DeserializeYaml for Authentication {
+    fn expected() -> Expected {
+        Expected::Mapping
+    }
+
+    fn deserialize(yaml: MarkedYaml) -> Result<Self> {
+        deserialize_enum! {
+            yaml,
+            "basic" => |yaml: MarkedYaml| {
+                let mut deserializer = StructDeserializer::new(yaml)?;
+                Ok(Authentication::Basic {
+                    username: deserializer.get(Field::new("username"))?,
+                    password: deserializer.get(Field::new("password").opt())?,
+                })
+            },
+            "bearer" => |yaml: MarkedYaml| {
+                let mut deserializer = StructDeserializer::new(yaml)?;
+                Ok(Authentication::Bearer {
+                    token: deserializer.get(Field::new("token"))?,
+                })
+            },
+        }
+    }
+}
+
+impl DeserializeYaml for RecipeBody {
+    fn expected() -> Expected {
+        Expected::OneOf(&[&Expected::String, &Expected::Mapping])
+    }
+
+    fn deserialize(yaml: MarkedYaml) -> Result<Self> {
+        // Mapping deserializes as some sort of structured body. It should have
+        // a `type` and `data` field
+        if yaml.is_mapping() {
+            deserialize_enum! {
+                yaml,
+                "json" => |yaml| {
+                    let mut deserializer = StructDeserializer::new(yaml)?;
+                    let json = deserializer.get(Field::new("data"))?;
+                    deserializer.done()?;
+                    Ok(Self::Json(json))
+                },
+                "form_urlencoded" => |yaml| {
+                    let mut deserializer = StructDeserializer::new(yaml)?;
+                    let form = deserializer.get(Field::new("data"))?;
+                    deserializer.done()?;
+                    Ok(Self::FormUrlencoded(form))
+                },
+                "form_multipart" => |yaml| {
+                    let mut deserializer = StructDeserializer::new(yaml)?;
+                    let form = deserializer.get(Field::new("data"))?;
+                    deserializer.done()?;
+                    Ok(Self::FormMultipart(form))
+                },
+            }
+        } else {
+            // Otherwise it's a raw body - deserialize as a template
+            Template::deserialize(yaml).map(Self::Raw)
+        }
+    }
+}
+
+impl DeserializeYaml for JsonTemplate {
+    fn expected() -> Expected {
+        Expected::OneOf(&[
+            &Expected::Null,
+            &Expected::Boolean,
+            &Expected::Number,
+            &Expected::String,
+            &Expected::Sequence,
+            &Expected::Mapping,
+        ])
+    }
+
+    fn deserialize(yaml: MarkedYaml) -> Result<Self> {
+        match yaml.data {
+            YamlData::Representation(_, _, _)
+            | YamlData::BadValue
+            | YamlData::Alias(_) => {
+                // Impossible because saphyr is set to parse completely and
+                // will fail fast if there's a bad value anywhere. And aliases
+                // should be resolved during parsing.
+                unreachable!("Invalid or incomplete YAML data")
+            }
+            YamlData::Value(Scalar::Null) => Ok(Self::Null),
+            YamlData::Value(Scalar::Boolean(b)) => Ok(Self::Bool(b)),
+            YamlData::Value(Scalar::Integer(i)) => Ok(Self::Number(i.into())),
+            YamlData::Value(Scalar::FloatingPoint(f)) => {
+                Ok(Self::Number(serde_json::Number::from_f64(f.0).ok_or_else(
+                    || LocatedError {
+                        error: Error::InvalidJsonFloat(f.0),
+                        location: yaml.span.start,
+                    },
+                )?))
+            }
+            // Parse string as a template
+            YamlData::Value(Scalar::String(s)) => {
+                let template = s.parse::<Template>().map_err(|error| {
+                    LocatedError::other(error, yaml.span.start)
+                })?;
+                Ok(Self::String(template))
+            }
+            YamlData::Sequence(sequence) => {
+                let values = sequence
+                    .into_iter()
+                    .map(Self::deserialize)
+                    .collect::<Result<_>>()?;
+                Ok(Self::Array(values))
+            }
+            YamlData::Mapping(mapping) => {
+                let fields = mapping
+                    .into_iter()
+                    .map(|(key, value)| {
+                        let key = key.try_into_string()?;
+                        let value = Self::deserialize(value)?;
+                        Ok((key, value))
+                    })
+                    .collect::<Result<_>>()?;
+                Ok(Self::Object(fields))
+            }
+            YamlData::Tagged(_, _) => {
+                Err(LocatedError::unexpected(Self::expected(), yaml))
+            }
+        }
+    }
+}
+
+impl DeserializeYaml for Template {
+    fn expected() -> Expected {
+        Expected::OneOf(&[
+            &Expected::String,
+            &Expected::Null,
+            &Expected::Boolean,
+            &Expected::Number,
+        ])
+    }
+
+    fn deserialize(yaml: MarkedYaml) -> Result<Self> {
+        if let YamlData::Value(scalar) = yaml.data {
+            // Accept any scalar for a template. We'll treat everything as the
+            // equivalent string representation
+            match scalar {
+                Scalar::Null => "null".parse(),
+                Scalar::Boolean(b) => b.to_string().parse(),
+                Scalar::Integer(i) => i.to_string().parse(),
+                Scalar::FloatingPoint(f) => f.to_string().parse(),
+                Scalar::String(s) => s.parse(),
+            }
+            .map_err(|error| LocatedError::other(error, yaml.span.start))
+        } else {
+            Err(LocatedError::unexpected(Expected::String, yaml))
+        }
+    }
+}
+
+impl DeserializeYaml for bool {
+    fn expected() -> Expected {
+        Expected::Boolean
+    }
+
+    fn deserialize(yaml: MarkedYaml) -> Result<Self> {
+        yaml.try_into_bool()
+    }
+}
+
+impl DeserializeYaml for String {
+    fn expected() -> Expected {
+        Expected::String
+    }
+
+    fn deserialize(yaml: MarkedYaml) -> Result<Self> {
+        yaml.try_into_string()
+    }
+}
+
+impl<T: DeserializeYaml> DeserializeYaml for Option<T> {
+    fn expected() -> Expected {
+        // Techinically we should include `null` here too, but generally
+        // optional fields should just be omitted instead of being set to null.
+        // It also makes the lifetimes and type signatures on Expected much more
+        // complicated to dynamically build one that's not 'static
+        T::expected()
+    }
+
+    fn deserialize(yaml: MarkedYaml) -> Result<Self> {
+        if yaml.data.is_null() {
+            Ok(None)
+        } else {
+            T::deserialize(yaml).map(Some)
+        }
+    }
+}
+
+impl<T> DeserializeYaml for Vec<T>
+where
+    T: DeserializeYaml,
+{
+    fn expected() -> Expected {
+        Expected::Sequence
+    }
+
+    fn deserialize(yaml: MarkedYaml) -> Result<Self> {
+        let sequence = yaml.try_into_sequence()?;
+        sequence.into_iter().map(T::deserialize).collect()
+    }
+}
+
+/// Deserialize a plain map with string keys
+impl<V> DeserializeYaml for IndexMap<String, V>
+where
+    V: DeserializeYaml,
+{
+    fn expected() -> Expected {
+        Expected::Mapping
+    }
+
+    fn deserialize(yaml: MarkedYaml) -> Result<Self> {
+        yaml.try_into_mapping()?
+            .into_iter()
+            .map(|(k, v)| Ok((k.try_into_string()?, V::deserialize(v)?)))
+            .collect()
+    }
+}
+
+/// Extension trait to add fallible conversion methods to [MarkedYaml]
+trait MarkedYamlExt<'a>: Sized {
+    /// Unpack the YAML as a boolean
+    fn try_into_bool(self) -> Result<bool>;
+
+    /// Unpack the YAML as a string
+    fn try_into_string(self) -> Result<String>;
+
+    /// Unpack the YAML as a sequence
+    fn try_into_sequence(self) -> Result<Vec<Self>>;
+
+    /// Unpack the YAML as a mapping
+    fn try_into_mapping(self) -> Result<AnnotatedMapping<'a, Self>>;
+}
+
+impl<'a> MarkedYamlExt<'a> for MarkedYaml<'a> {
+    fn try_into_bool(self) -> Result<bool> {
+        if let YamlData::Value(Scalar::Boolean(b)) = self.data {
+            Ok(b)
+        } else {
+            Err(LocatedError::unexpected(Expected::Boolean, self))
+        }
+    }
+
+    fn try_into_string(self) -> Result<String> {
+        if let YamlData::Value(Scalar::String(s)) = self.data {
+            Ok(s.into_owned())
+        } else {
+            Err(LocatedError::unexpected(Expected::String, self))
+        }
+    }
+
+    fn try_into_sequence(self) -> Result<Vec<Self>> {
+        if let YamlData::Sequence(sequence) = self.data {
+            Ok(sequence)
+        } else {
+            Err(LocatedError::unexpected(Expected::Sequence, self))
+        }
+    }
+
+    fn try_into_mapping(self) -> Result<AnnotatedMapping<'a, Self>> {
+        if let YamlData::Mapping(mut mapping) = self.data {
+            // Saphyr doesn't merge << keys automatically so do it here
+            // TODO replace this with $ref and drop support
+            if let Some(inner) =
+                mapping.remove(&MarkedYaml::value_from_str("<<"))
+            {
+                let inner = inner.try_into_mapping()?;
+                mapping.extend(inner);
+            }
+            Ok(mapping)
+        } else {
+            Err(LocatedError::unexpected(Expected::Mapping, self))
+        }
+    }
+}
+
+/// An error paired with the source location in YAML where the error occurred
+///
+/// This type is internal to this module because there's no external application
+/// for it beyond stringification.
+#[derive(Debug, derive_more::Display)]
+#[display("{error}")]
+struct LocatedError {
+    /// Error that occurred
+    error: Error,
+    /// Location of the error within the YAML file
+    location: Marker,
+}
+
+impl LocatedError {
+    /// Create a new [Other](Self::Other) from any error type
+    fn other(
+        error: impl 'static + std::error::Error + Send + Sync,
+        location: Marker,
+    ) -> Self {
+        Self {
+            error: Error::Other(Box::new(error)),
+            location,
+        }
+    }
+
+    /// Create a new [UnexpectedType](Self::UnexpectedType) from the expected
+    /// type and actual value
+    fn unexpected(expected: Expected, actual: MarkedYaml) -> Self {
+        // Find a useful representation of the received value
+        let actual_string = match actual.data {
+            // Scalars are unlikely to be big so we can include the actual value
+            YamlData::Value(Scalar::Null) => "null".into(),
+            YamlData::Value(Scalar::Boolean(b)) => format!("`{b}`"),
+            YamlData::Value(Scalar::Integer(i)) => format!("`{i}`"),
+            YamlData::Value(Scalar::FloatingPoint(f)) => format!("`{f}`"),
+            // Use debug format to get wrapping quotes
+            YamlData::Value(Scalar::String(s)) => format!("{s:?}"),
+            YamlData::Tagged(tag, _) => format!("tag `{tag}`"),
+            // Collections could be large so just include the type
+            YamlData::Sequence(_) => "sequence".into(),
+            YamlData::Mapping(_) => "mapping".into(),
+            // Impossible because saphyr is set to parse completely and
+            // will fail fast if there's a bad value anywhere. And aliases
+            // should be resolved during parsing.
+            YamlData::Representation(_, _, _)
+            | YamlData::Alias(_)
+            | YamlData::BadValue => {
+                unreachable!("Invalid or incomplete YAML data")
+            }
+        };
+        Self {
+            location: actual.span.start,
+            error: Error::Unexpected {
+                expected,
+                actual: actual_string,
+            },
+        }
+    }
+}
+
+impl From<ScanError> for LocatedError {
+    fn from(error: ScanError) -> Self {
+        Self {
+            location: *error.marker(),
+            error: Error::Scan(error),
+        }
+    }
+}
+
+/// An error that can occur while deserializing a YAML value
+#[derive(Debug, Error)]
+enum Error {
+    /// JSON body contained a float value that isn't representable in JSON
+    #[error("Invalid float `{0}`; JSON does not support NaN or Infinity")]
+    InvalidJsonFloat(f64),
+
+    #[error("Expected field `{field}` with {expected}")]
+    MissingField {
+        field: &'static str,
+        expected: Expected,
+    },
+
+    #[error(
+        "Cannot set profile `{second}` as default; `{first}` is already default"
+    )]
+    MultipleDefaultProfiles { first: ProfileId, second: ProfileId },
+
+    /// External error type
+    #[error(transparent)]
+    Other(Box<dyn 'static + std::error::Error + Send + Sync>),
+
+    /// Error parsing YAML
+    #[error(transparent)]
+    Scan(saphyr::ScanError),
+
+    /// Expected a particular type or value, but received something else
+    #[error("Expected {expected}, received {actual}")]
+    Unexpected {
+        expected: Expected,
+        /// Pre-formatted "actual" value. Getting an owned YAML value from
+        /// is complicated so it's easier to store it as the presentation
+        /// string
+        actual: String,
+    },
+
+    #[error("Unexpected field `{0}`")]
+    UnexpectedField(String),
+}
+
+/// When a value is expected but is either incorrect or missing, this type
+/// allows the caller to declare what they expected to find
+#[derive(Debug, derive_more::Display)]
+enum Expected {
+    /// Expected null
+    #[display("null")]
+    Null,
+    /// Expected a string
+    #[display("string")]
+    String,
+    /// Expected a boolean
+    #[display("boolean")]
+    Boolean,
+    /// Expected a number
+    #[display("number")]
+    Number,
+    /// Expected a sequence
+    #[display("sequence")]
+    Sequence,
+    /// Expected a mapping
+    #[display("mapping")]
+    Mapping,
+    /// Expected a string literal
+    #[display("{_0:?}")]
+    Literal(&'static str),
+    /// Expected one of a static set of strings (for enum discriminants)
+    #[display("one of {}", _0.iter().format(", "))]
+    OneOf(&'static [&'static Self]),
+}
+
+/// Utility for deserializing a struct or enum variant from a YAML mapping.
+/// Initialize this struct with a YAML value, and it will:
+/// - Ensure the value is a mapping
+/// - Enable deserializing individual fields with [get](Self::get)
+/// - Ensure no unexpected fields were present with [done](Self::done)
+///     - NOTE: `done` needs to be called manually after deserialization!
+struct StructDeserializer<'a> {
+    mapping: AnnotatedMapping<'a, MarkedYaml<'a>>,
+    location: Marker,
+}
+
+impl<'a> StructDeserializer<'a> {
+    fn new(yaml: MarkedYaml<'a>) -> Result<Self> {
+        let location = yaml.span.start;
+        let mapping = yaml.try_into_mapping()?;
+        Ok(Self { mapping, location })
+    }
+
+    /// Deserialize a field from the mapping
+    fn get<T: DeserializeYaml>(&mut self, field: Field<T>) -> Result<T> {
+        if let Some(value) =
+            self.mapping.remove(&MarkedYaml::value_from_str(field.name))
+        {
+            T::deserialize(value)
+        } else if let Some(default) = field.default {
+            Ok(default)
+        } else {
+            Err(LocatedError {
+                error: Error::MissingField {
+                    field: field.name,
+                    expected: T::expected(),
+                },
+                location: self.location,
+            })
+        }
+    }
+
+    /// Check that no fields were unused
+    fn done(mut self) -> Result<()> {
+        if let Some((key, _)) = self.mapping.pop_front() {
+            let key_location = key.span.start;
+            // If the key isn't a string, it's reasonable to return a type error
+            let key = key.try_into_string()?;
+            Err(LocatedError {
+                error: Error::UnexpectedField(key),
+                location: key_location,
+            })
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// A single deserializable field in a struct or enum variant. The field has a
+/// static name, which corresponds to the name of the field *in the YAML*.
+/// Generally this matches the internal field name, but not always. Fields are
+/// required by default, but can be made optional with [opt](Self::opt) or
+/// [or](Self::or).
+struct Field<T> {
+    name: &'static str,
+    default: Option<T>,
+}
+
+impl<T> Field<T> {
+    fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            default: None,
+        }
+    }
+
+    /// Pre-populate this field with `T`'s default value. If the field is not
+    /// deserialized, the default value will be used instead.
+    fn opt(mut self) -> Self
+    where
+        T: Default,
+    {
+        self.default = Some(T::default());
+        self
+    }
+
+    /// Pre-populate this field with the given default value. If the field is
+    /// not deserialized, the default value will be used instead.
+    fn or(mut self, value: T) -> Self {
+        self.default = Some(value);
+        self
+    }
+}
 
 /// A type that has an `id` field. This is ripe for a derive macro, maybe a fun
 /// project some day?
 pub trait HasId {
-    type Id: Clone + Eq + Hash;
+    type Id;
 
     fn id(&self) -> &Self::Id;
 
@@ -61,140 +910,13 @@ impl HasId for Recipe {
     }
 }
 
-/// Default value generator for `Recipe::persist`. All recipes are persisted by
-/// default
-pub fn persist_default() -> bool {
-    true
-}
-
-/// Deserialize a map, and update each key so its `id` field matches its key in
-/// the map. Useful if you need to access the ID when you only have a value
-/// available, not the full entry.
-pub fn deserialize_id_map<'de, Map, V, D>(
-    deserializer: D,
-) -> Result<Map, D::Error>
-where
-    Map: Deserialize<'de>,
-    for<'m> &'m mut Map: IntoIterator<Item = (&'m V::Id, &'m mut V)>,
-    D: Deserializer<'de>,
-    V: Deserialize<'de> + HasId,
-    V::Id: Deserialize<'de>,
-{
-    let mut map: Map = Map::deserialize(deserializer)?;
-    // Update the ID on each value to match the key
-    for (k, v) in &mut map {
-        v.set_id(k.clone());
-    }
-    Ok(map)
-}
-
-/// Deserialize a profile mapping. This also enforces that only one profile is
-/// marked as default
-pub fn deserialize_profiles<'de, D>(
-    deserializer: D,
-) -> Result<IndexMap<ProfileId, Profile>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let profiles: IndexMap<ProfileId, Profile> =
-        deserialize_id_map(deserializer)?;
-
-    // Make sure at most one profile is the default
-    let is_default = |profile: &&Profile| profile.default;
-
-    if profiles.values().filter(is_default).count() > 1 {
-        return Err(de::Error::custom(format!(
-            "Only one profile can be the default, but multiple were: {}",
-            profiles
-                .values()
-                .filter(is_default)
-                .map(Profile::id)
-                .format(", ")
-        )));
-    }
-
-    Ok(profiles)
-}
-
-/// Deserialize a header map, lowercasing all header names. Headers are
-/// case-insensitive (and must be lowercase in HTTP/2+), so forcing the case
-/// makes lookups on the map easier.
-pub fn deserialize_headers<'de, D>(
-    deserializer: D,
-) -> Result<IndexMap<String, Template>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    // This involves an extra allocation, but it makes the logic a lot easier.
-    // These maps should be small anyway
-    let headers: IndexMap<String, Template> =
-        IndexMap::deserialize(deserializer)?;
-    Ok(headers
-        .into_iter()
-        .map(|(k, v)| (k.to_ascii_lowercase(), v))
-        .collect())
-}
-
-/*
- * TODO delete this
-/// Custom serialize/deserialize for RecipeBody. This can't be an impl directly
-/// on the type because we're just wrapping that type's impl to also support a
-/// bare value as a raw body. RecipeBody is only used in one place so adding
-/// this wrapper isn't a big deal.
-pub mod serde_recipe_body {
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
-    use slumber_template::Template;
-
-    use crate::collection::RecipeBody;
-
-    #[expect(clippy::ref_option)]
-    pub fn serialize<S>(
-        body: &Option<RecipeBody>,
-        serializer: S,
-    ) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        match body {
-            // Serialize a raw body as just the contained value
-            Some(RecipeBody::Raw(data)) => data.serialize(serializer),
-            // Serialize anything else as a tagged enum
-            Some(body) => body.serialize(serializer),
-            None => serializer.serialize_none(),
-        }
-    }
-
-    pub fn deserialize<'de, D>(
-        deserializer: D,
-    ) -> Result<Option<RecipeBody>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        #[serde(untagged, rename_all = "snake_case")]
-        enum RecipeBodyWrapper {
-            // The body variant must come first to give it higher priority,
-            // because the raw variant will accept any expression
-            RecipeBody(RecipeBody),
-            Raw(Template),
-        }
-
-        // Support internally tagged enums for any body type. Also support bare
-        // expressions for a raw body
-        let wrapper = RecipeBodyWrapper::deserialize(deserializer)?;
-        match wrapper {
-            RecipeBodyWrapper::RecipeBody(body) => Ok(Some(body)),
-            RecipeBodyWrapper::Raw(data) => Ok(Some(RecipeBody::Raw(data))),
-        }
-    }
-}
-*/
+#[cfg(test)]
+pub use tests::deserialize_recipe_tree;
 
 #[cfg(test)]
 mod tests {
-    use crate::collection::RecipeBody;
-
     use super::*;
+    use crate::collection::RecipeBody;
     use indexmap::indexmap;
     use rstest::rstest;
     use serde_json::json;
@@ -202,6 +924,7 @@ mod tests {
     use slumber_util::assert_err;
     use std::iter;
 
+    /// Test error cases for deserializing a profile map
     #[rstest]
     #[case::multiple_default(
         mapping([
@@ -214,23 +937,16 @@ mod tests {
                 ("data", mapping([("a", "2")]))
             ])),
         ]),
-        "Only one profile can be the default, but multiple were: \
-        profile1, profile2",
+        "Cannot set profile `profile2` as default; `profile1` is already default",
     )]
     fn test_deserialize_profiles_error(
         #[case] yaml: impl Into<serde_yaml::Value>,
         #[case] expected_error: &str,
     ) {
-        #[derive(Debug, Deserialize)]
-        #[serde(transparent)]
-        struct Wrap(
-            #[expect(dead_code)]
-            #[serde(deserialize_with = "deserialize_profiles")]
-            IndexMap<ProfileId, Profile>,
+        assert_err!(
+            deserialize_yaml::<IndexMap<ProfileId, Profile>>(yaml.into()),
+            expected_error
         );
-
-        let yaml = yaml.into();
-        assert_err!(serde_yaml::from_value::<Wrap>(yaml), expected_error);
     }
 
     /// Test serializing and deserializing recipe bodies. Round trips should all
@@ -270,7 +986,7 @@ mod tests {
             "Serialization mismatch"
         );
         assert_eq!(
-            serde_yaml::from_value::<RecipeBody>(yaml).unwrap(),
+            deserialize_yaml::<RecipeBody>(yaml).unwrap(),
             body,
             "Deserialization mismatch"
         );
@@ -282,30 +998,58 @@ mod tests {
     #[rstest]
     #[case::array(
         Vec::<i32>::new(),
-        "invalid type: sequence, expected string, boolean, or number"
+        "Expected string, received sequence"
     )]
     #[case::map(
         Mapping::default(),
-        "invalid type: map, expected string, boolean, or number"
+        "Expected field `type` with one of \
+        \"json\", \"form_urlencoded\", \"form_multipart\""
     )]
     // `Raw` variant is *not* accessible by tag
     #[case::raw_tag(
         yaml_enum("raw", [("data", "data")]),
-        "unknown variant `raw`, expected one of \
-        `json`, `form_urlencoded`, `form_multipart`",
+        "Expected one of \"json\", \"form_urlencoded\", \"form_multipart\", \
+        received \"raw\"",
     )]
     #[case::form_urlencoded_missing_data(
         yaml_enum("form_urlencoded", [] as [(_, serde_yaml::Value); 0]),
-        "TODO"
+        "Expected field `data` with mapping"
     )]
-    fn test_deserialize_recipe_error(
+    fn test_deserialize_recipe_body_error(
         #[case] yaml: impl Into<serde_yaml::Value>,
         #[case] expected_error: &str,
     ) {
         assert_err!(
-            serde_yaml::from_value::<RecipeBody>(yaml.into()),
+            deserialize_yaml::<RecipeBody>(yaml.into()),
             expected_error
         );
+    }
+
+    /// Test deserializing an empty file. It should return an empty collection
+    #[test]
+    fn test_deserialize_empty() {
+        assert_eq!(
+            deserialize_collection("", None).unwrap(),
+            Collection::default()
+        );
+    }
+
+    /// Deserialize a [serde_yaml::Value] using saphyr. Serde values are easier
+    /// to construct than saphyr values
+    fn deserialize_yaml<T: DeserializeYaml>(
+        yaml: serde_yaml::Value,
+    ) -> Result<T> {
+        let yaml_input = serde_yaml::to_string(&yaml).unwrap();
+        let mut documents = MarkedYaml::load_from_str(&yaml_input)?;
+        let yaml = documents.pop().unwrap();
+        T::deserialize(yaml)
+    }
+
+    /// Helper for deserializing in RecipeTree's tests. We export this
+    pub fn deserialize_recipe_tree(
+        yaml: serde_yaml::Value,
+    ) -> anyhow::Result<RecipeTree> {
+        deserialize_yaml(yaml).map_err(|error| error.error.into())
     }
 
     /// Build a YAML mapping

--- a/crates/core/src/collection/json.rs
+++ b/crates/core/src/collection/json.rs
@@ -3,15 +3,15 @@
 use crate::render::TemplateContext;
 use futures::future;
 use indexmap::IndexMap;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use slumber_template::{RenderError, Template, TemplateParseError};
 use std::str::FromStr;
 use thiserror::Error;
 
 /// A JSON value like [serde_json::Value], but all strings are templates
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize)]
 #[cfg_attr(any(test, feature = "test"), derive(PartialEq))]
-#[serde(untagged, expecting = "JSON value")]
+#[serde(untagged)]
 pub enum JsonTemplate {
     Null,
     Bool(bool),

--- a/crates/core/src/collection/json.rs
+++ b/crates/core/src/collection/json.rs
@@ -1,16 +1,17 @@
 //! Utilities for working with templated JSON
 
+use crate::render::TemplateContext;
 use futures::future;
 use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
 use slumber_template::{RenderError, Template, TemplateParseError};
 use std::str::FromStr;
 use thiserror::Error;
 
-use crate::render::TemplateContext;
-
 /// A JSON value like [serde_json::Value], but all strings are templates
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "test"), derive(PartialEq))]
+#[serde(untagged, expecting = "JSON value")]
 pub enum JsonTemplate {
     Null,
     Bool(bool),

--- a/crates/core/src/http.rs
+++ b/crates/core/src/http.rs
@@ -601,12 +601,12 @@ impl Recipe {
                 Ok(Some(Authentication::Basic { username, password }))
             }
 
-            Some(Authentication::Bearer(token)) => {
+            Some(Authentication::Bearer { token }) => {
                 let token = token
                     .render_string(template_context)
                     .await
                     .context("Rendering bearer token")?;
-                Ok(Some(Authentication::Bearer(token)))
+                Ok(Some(Authentication::Bearer { token }))
             }
             None => Ok(None),
         }
@@ -683,7 +683,7 @@ impl Authentication<String> {
             Authentication::Basic { username, password } => {
                 builder.basic_auth(username, password)
             }
-            Authentication::Bearer(token) => builder.bearer_auth(token),
+            Authentication::Bearer { token } => builder.bearer_auth(token),
         }
     }
 }

--- a/crates/core/src/http/curl.rs
+++ b/crates/core/src/http/curl.rs
@@ -68,7 +68,7 @@ impl CurlBuilder {
                 .unwrap();
                 self
             }
-            Authentication::Bearer(token) => self
+            Authentication::Bearer { token } => self
                 .header(
                     &header::AUTHORIZATION,
                     // The token is base64-encoded so we know it's valid

--- a/crates/core/src/http/tests.rs
+++ b/crates/core/src/http/tests.rs
@@ -226,7 +226,7 @@ async fn test_build_body(
     },
     "Basic dXNlcjo="
 )]
-#[case::bearer(Authentication::Bearer("{{ token }}".into()), "Bearer tokenzzz")]
+#[case::bearer(Authentication::Bearer { token: "{{ token }}".into() }, "Bearer tokenzzz")]
 #[tokio::test]
 async fn test_authentication(
     http_engine: HttpEngine,
@@ -791,7 +791,7 @@ async fn test_build_curl(http_engine: HttpEngine) {
     "--user 'user:'",
 )]
 #[case::bearer(
-    Authentication::Bearer("{{ token }}".into()),
+    Authentication::Bearer { token: "{{ token }}".into() },
     "--header 'authorization: Bearer tokenzzz'",
 )]
 #[tokio::test]

--- a/crates/core/src/render/functions.rs
+++ b/crates/core/src/render/functions.rs
@@ -11,6 +11,7 @@ use serde::{
 };
 use serde_json_path::{JsonPath, NodeList};
 use slumber_macros::template;
+use slumber_template::TryFromValue;
 use slumber_util::TimeSpan;
 use std::{env, fmt::Debug, process::Stdio, sync::Arc};
 use tokio::{fs, io::AsyncWriteExt, process::Command, sync::oneshot};
@@ -186,7 +187,7 @@ pub async fn prompt(
 #[template(TemplateContext)]
 pub async fn response(
     #[context] context: &TemplateContext,
-    #[serde] recipe_id: RecipeId,
+    recipe_id: RecipeId,
     #[kwarg]
     #[serde]
     trigger: RequestTrigger,
@@ -204,7 +205,7 @@ pub async fn response(
 #[template(TemplateContext)]
 pub async fn response_header(
     #[context] context: &TemplateContext,
-    #[serde] recipe_id: RecipeId,
+    recipe_id: RecipeId,
     header: String,
     #[kwarg]
     #[serde]
@@ -346,4 +347,12 @@ pub enum TrimMode {
     /// Trim the start and end of the output
     #[default]
     Both,
+}
+
+impl TryFromValue for RecipeId {
+    fn try_from_value(
+        value: slumber_template::Value,
+    ) -> Result<Self, slumber_template::RenderError> {
+        String::try_from_value(value).map(RecipeId::from)
+    }
 }

--- a/crates/core/src/test_util.rs
+++ b/crates/core/src/test_util.rs
@@ -12,7 +12,10 @@ use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use rstest::fixture;
 use slumber_config::HttpEngineConfig;
 use slumber_template::Template;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::{
+    hash::Hash,
+    sync::atomic::{AtomicUsize, Ordering},
+};
 
 /// A template that spits out bytes that are *not* valid UTF-8
 pub fn invalid_utf8() -> Template {
@@ -145,9 +148,11 @@ impl Prompter for TestSelectPrompter {
 }
 
 /// Construct a map of values keyed by their ID
-pub fn by_id<T: HasId>(
-    values: impl IntoIterator<Item = T>,
-) -> IndexMap<T::Id, T> {
+pub fn by_id<T>(values: impl IntoIterator<Item = T>) -> IndexMap<T::Id, T>
+where
+    T: HasId,
+    T::Id: Clone + Eq + Hash,
+{
     values
         .into_iter()
         .map(|value| (value.id().clone(), value))

--- a/crates/import/src/insomnia.rs
+++ b/crates/import/src/insomnia.rs
@@ -409,7 +409,9 @@ impl TryFrom<Authentication> for collection::Authentication {
                 })
             }
             Authentication::Bearer { token } => {
-                Ok(collection::Authentication::Bearer(Template::raw(token)))
+                Ok(collection::Authentication::Bearer {
+                    token: Template::raw(token),
+                })
             }
             // Caller should print a warning for this
             Authentication::Other { kind } => Err(kind),

--- a/crates/import/src/openapi/v3_0.rs
+++ b/crates/import/src/openapi/v3_0.rs
@@ -384,7 +384,7 @@ impl<'a> RecipeBuilder<'a> {
                             .map(Template::raw)
                             .unwrap_or_default();
                         self.authentication =
-                            Some(Authentication::Bearer(template));
+                            Some(Authentication::Bearer { token: template });
                     }
                     unsupported => {
                         error!(

--- a/crates/import/src/openapi/v3_1.rs
+++ b/crates/import/src/openapi/v3_1.rs
@@ -356,9 +356,9 @@ impl<'a> RecipeBuilder<'a> {
                     });
                 }
                 "bearer" => {
-                    self.authentication = Some(Authentication::Bearer(
-                        Template::from_field("api_token"),
-                    ));
+                    self.authentication = Some(Authentication::Bearer {
+                        token: Template::from_field("api_token"),
+                    });
                 }
                 _ => {
                     error!("Unsupported HTTP authentication scheme `{scheme}`");

--- a/crates/import/src/rest.rs
+++ b/crates/import/src/rest.rs
@@ -65,9 +65,9 @@ fn build_slumber_templates(
 /// Convert REST Authentication to Slumber Authentication
 fn build_authentication(r_auth: RestAuthorization) -> Authentication {
     match r_auth {
-        RestAuthorization::Bearer(bearer) => {
-            Authentication::Bearer(Template::raw(bearer))
-        }
+        RestAuthorization::Bearer(bearer) => Authentication::Bearer {
+            token: Template::raw(bearer),
+        },
         RestAuthorization::Basic { username, password } => {
             Authentication::Basic {
                 username: Template::raw(username),

--- a/crates/tui/src/state.rs
+++ b/crates/tui/src/state.rs
@@ -726,7 +726,8 @@ mod tests {
             file.path(),
             r#"
 requests:
-    test: !request
+    test:
+        type: "request"
         method: "GET"
         url: "test"
 "#,

--- a/crates/tui/src/view/component/recipe_pane/authentication.rs
+++ b/crates/tui/src/view/component/recipe_pane/authentication.rs
@@ -60,7 +60,7 @@ impl AuthenticationDisplay {
                     selected_field: Default::default(),
                 }
             }
-            Authentication::Bearer(token) => State::Bearer {
+            Authentication::Bearer { token } => State::Bearer {
                 token: RecipeTemplate::new(
                     RecipeOverrideKey::auth_bearer_token(recipe_id.clone()),
                     token,
@@ -87,9 +87,9 @@ impl AuthenticationDisplay {
                     // See note on field def for why we always use Some
                     password: Some(password.template().clone()),
                 },
-                State::Bearer { token, .. } => {
-                    Authentication::Bearer(token.template().clone())
-                }
+                State::Bearer { token, .. } => Authentication::Bearer {
+                    token: token.template().clone(),
+                },
             })
         } else {
             None
@@ -445,7 +445,9 @@ mod tests {
 
     #[rstest]
     fn test_edit_bearer(harness: TestHarness, terminal: TestTerminal) {
-        let authentication = Authentication::Bearer("i am a token".into());
+        let authentication = Authentication::Bearer {
+            token: "i am a token".into(),
+        };
         let mut component = TestComponent::new(
             &harness,
             &terminal,
@@ -464,7 +466,9 @@ mod tests {
             .assert_empty();
         assert_eq!(
             component.data().override_value(),
-            Some(Authentication::Bearer("i am a token!!!".into()))
+            Some(Authentication::Bearer {
+                token: "i am a token!!!".into()
+            })
         );
 
         // Reset token
@@ -475,7 +479,9 @@ mod tests {
     /// Test edit menu action
     #[rstest]
     fn test_edit_action(harness: TestHarness, terminal: TestTerminal) {
-        let authentication = Authentication::Bearer("i am a token".into());
+        let authentication = Authentication::Bearer {
+            token: "i am a token".into(),
+        };
         let mut component = TestComponent::new(
             &harness,
             &terminal,
@@ -489,7 +495,9 @@ mod tests {
             .assert_empty();
         assert_eq!(
             component.data().override_value(),
-            Some(Authentication::Bearer("i am a token!".into()))
+            Some(Authentication::Bearer {
+                token: "i am a token!".into()
+            })
         );
     }
 
@@ -535,7 +543,7 @@ mod tests {
             &RecipeOverrideKey::auth_bearer_token(recipe_id.clone()),
             &RecipeOverrideValue::Override("token".into()),
         );
-        let authentication = Authentication::Bearer("".into());
+        let authentication = Authentication::Bearer { token: "".into() };
         let component = TestComponent::new(
             &harness,
             &terminal,
@@ -544,7 +552,9 @@ mod tests {
 
         assert_eq!(
             component.data().override_value(),
-            Some(Authentication::Bearer("token".into()))
+            Some(Authentication::Bearer {
+                token: "token".into()
+            })
         );
     }
 }

--- a/crates/tui/src/view/state/select.rs
+++ b/crates/tui/src/view/state/select.rs
@@ -384,7 +384,8 @@ where
 impl<Item, State> PersistedContainer for SelectState<Item, State>
 where
     Item: HasId,
-    Item::Id: PartialEq<Item>, // Bound needed so we can select items by ID
+    // PartialEq needed so we can select items by ID
+    Item::Id: Clone + PartialEq<Item>,
     State: SelectStateData,
 {
     type Value = Option<Item::Id>;

--- a/slumber.yml
+++ b/slumber.yml
@@ -6,6 +6,7 @@
   username: xX{{ command(['whoami']) | trim() | sensitive() }}Xx
   user_guid: abc123
 .base_request: &base_request
+  type: request
   headers:
     Accept: application/json
 
@@ -32,9 +33,10 @@ profiles:
       host: http://localhost:5000
 
 requests:
-  authentication: !folder
+  authentication:
+    type: folder
     requests:
-      login: !request
+      login:
         <<: *base_request
         method: POST
         url: "{{ host }}/anything/login"
@@ -42,16 +44,19 @@ requests:
         query:
           sudo: yes_please
           fast: [no_thanks, actually_maybe]
-        body: !form_urlencoded
-          username: "{{ username }}"
-          password: "{{ prompt(message='Password', sensitive=true) }}"
+        body:
+          type: form_urlencoded
+          data:
+            username: "{{ username }}"
+            password: "{{ prompt(message='Password', sensitive=true) }}"
 
-      basic_auth: !request
+      basic_auth:
         <<: *base_request
         method: POST
         url: "{{ host }}/anything/login"
         persist: false
-        authentication: !basic
+        authentication:
+          type: basic
           username: "{{ username }}"
           password: "{{ prompt(message='Password') }}"
         query:
@@ -60,28 +65,31 @@ requests:
         headers:
           Accept: application/json
 
-      bearer_auth: !request
+      bearer_auth:
         <<: *base_request
         method: POST
         url: "{{ host }}/anything/login"
         persist: false
-        authentication: !bearer "{{ response('login', trigger='12h') | jsonpath('$.form') }}"
+        authentication:
+          type: bearer
+          token: "{{ response('login', trigger='12h') | jsonpath('$.form') }}"
         query:
           sudo: yes_please
           fast: [no_thanks, actually_maybe]
         headers:
           Accept: application/json
 
-  users: !folder
+  users:
+    type: folder
     name: Users
     requests:
-      get_users: !request
+      get_users:
         <<: *base_request
         name: Get Users
         method: GET
         url: "{{ host }}/get"
 
-      get_user: !request
+      get_user:
         <<: *base_request
         name: Get User
         method: GET
@@ -94,44 +102,49 @@ requests:
             ) }}"
           select_dynamic: "{{ response('get_users') | jsonpath('$.headers') | select() }}"
 
-      modify_user: !request
+      modify_user:
         <<: *base_request
         name: Modify User
         method: PUT
         url: "{{ host }}/anything/{{ user_guid }}"
         body:
-          !json {
-            "new_username": "user formerly known as {{ username }}",
-            "number": 3,
-            "bool": true,
-            "null": null,
-            "array": [1, 2, false, 3.3, "www.www"],
-          }
+          type: json
+          data:
+            {
+              "new_username": "user formerly known as {{ username }}",
+              "number": 3,
+              "bool": true,
+              "null": null,
+              "array": [1, 2, false, 3.3, "www.www"],
+            }
 
-  get_image: !request
+  get_image:
+    type: request
     headers:
       Accept: image/png
     name: Get Image
     method: GET
     url: "{{ host }}/image"
 
-  upload_image: !request
+  upload_image:
     <<: *base_request
     name: Upload Image
     method: POST
     url: "{{ host }}/anything/image"
-    body: !form_multipart
-      filename: "logo.png"
-      image: "{{ file('static/slumber.png') }}"
+    body:
+      type: form_multipart
+      data:
+        filename: "logo.png"
+        image: "{{ file('static/slumber.png') }}"
 
-  big_file: !request
+  big_file:
     <<: *base_request
     name: Big File
     method: POST
     url: "{{ host }}/anything"
     body: "{{ file('Cargo.lock') }}"
 
-  raw_json: !request
+  raw_json:
     <<: *base_request
     name: Raw JSON
     method: POST
@@ -144,19 +157,20 @@ requests:
         "size": "HUGE"
       }
 
-  delay: !request
+  delay:
     <<: *base_request
     name: Delay
     method: GET
     url: "{{ host }}/delay/5"
 
-  dynamic_response_type: !request
+  dynamic_response_type:
     <<: *base_request
     name: Dynamic Response Type
     method: GET
     url: "{{ host }}/{{ select(['json', 'html', 'xml']) }}"
 
-  redirect: !request
+  redirect:
+    <<: *base_request
     name: Redirect
     method: GET
     url: "{{host}}/redirect-to?url={{host}}/get"

--- a/test_data/insomnia_imported.yml
+++ b/test_data/insomnia_imported.yml
@@ -14,22 +14,28 @@ profiles:
       greeting: howdy
 
 requests:
-  fld_9a7332db608943b093c929a82c81df50: !folder
+  fld_9a7332db608943b093c929a82c81df50:
+    type: folder
     name: My Folder
     requests:
-      fld_8077c48f5a89436bbe4b3a53c06471f5: !folder
+      fld_8077c48f5a89436bbe4b3a53c06471f5:
+        type: folder
         name: Inner Folder
         requests:
-          req_2ec3dc9ff6774ac78248777e75984831: !request
+          req_2ec3dc9ff6774ac78248777e75984831:
+            type: request
             name: Bearer Auth
             method: GET
             url: https://httpbin.org/get
             body: null
-            authentication: !bearer " {% response 'body', 'req_3bc2de939f1a4d1ebc00835cbefd6b5d', 'b64::JC5oZWFkZXJzLkhvc3Q=::46b', 'when-expired', 60 %}"
+            authentication:
+              type: bearer
+              token: " {% response 'body', 'req_3bc2de939f1a4d1ebc00835cbefd6b5d', 'b64::JC5oZWFkZXJzLkhvc3Q=::46b', 'when-expired', 60 %}"
             query: {}
             headers: {}
 
-          req_b08ee35904784b5f9af598f9b7fd7ca0: !request
+          req_b08ee35904784b5f9af598f9b7fd7ca0:
+            type: request
             name: Digest Auth (Unsupported)
             method: GET
             url: https://httpbin.org/get
@@ -38,18 +44,21 @@ requests:
             query: {}
             headers: {}
 
-          req_284e0d90f0d647b483f863af5ee79c23: !request
+          req_284e0d90f0d647b483f863af5ee79c23:
+            type: request
             name: Basic Auth
             method: GET
             url: https://httpbin.org/get
             body: null
-            authentication: !basic
+            authentication:
+              type: basic
               username: user
               password: pass
             query: {}
             headers: {}
 
-          req_814a5e9b63a7482da1d8261311bc6c84: !request
+          req_814a5e9b63a7482da1d8261311bc6c84:
+            type: request
             name: No Auth
             method: GET
             url: https://httpbin.org/get
@@ -58,7 +67,8 @@ requests:
             query: {}
             headers: {}
 
-      req_583c296a600247d6b0c28a0afcefdb89: !request
+      req_583c296a600247d6b0c28a0afcefdb89:
+        type: request
         name: With Text Body
         method: POST
         url: https://httpbin.org/post
@@ -68,7 +78,8 @@ requests:
           content-type: text/plain
         body: "hello!"
 
-      req_1419670d20eb4964956df954e1eb7c4b: !request
+      req_1419670d20eb4964956df954e1eb7c4b:
+        type: request
         name: With JSON Body
         method: POST
         url: https://httpbin.org/post
@@ -78,9 +89,12 @@ requests:
           # This is redundant with the body type, but it's more effort than
           # it's worth to remove it
           content-type: application/json
-        body: !json { "message": "hello!" }
+        body:
+          type: json
+          data: { "message": "hello!" }
 
-      req_a01b6de924274654bda0835e2a073bd0: !request
+      req_a01b6de924274654bda0835e2a073bd0:
+        type: request
         name: With Multipart Body
         method: POST
         url: https://httpbin.org/post
@@ -90,17 +104,22 @@ requests:
           # This is redundant with the body type, but it's more effort than
           # it's worth to remove it
           content-type: multipart/form-data
-        body: !form_multipart
-          username: user
-          image: "{{ file('./public/slumber.png') }}"
+        body:
+          type: form_multipart
+          data:
+            username: user
+            image: "{{ file('./public/slumber.png') }}"
 
-  req_a345faa530a7453e83ee967d18555712: !request
+  req_a345faa530a7453e83ee967d18555712:
+    type: request
     name: Login
     method: POST
     url: https://httpbin.org/anything/login
-    body: !form_urlencoded
-      username: user
-      password: pass
+    body:
+      type: form_urlencoded
+      data:
+        username: user
+        password: pass
     authentication: null
     query: {}
     headers:

--- a/test_data/openapi_v3_0_petstore_imported.yml
+++ b/test_data/openapi_v3_0_petstore_imported.yml
@@ -5,128 +5,197 @@ profiles:
       host: /v3
 
 requests:
-  tag/pet: !folder
+  tag/pet:
+    type: folder
     name: pet
     requests:
-      addPet: !request
+      addPet:
+        type: request
         name: Add a new pet to the store
         method: POST
         url: "{{ host }}/pet"
         body:
-          !json {
-            "id": 10,
-            "name": "doggie",
-            "category": { "id": 1, "name": "Dogs" },
-            "photoUrls": [""],
-            "tags": [{ "id": 0, "name": "" }],
-            "status": "available",
-          }
-      updatePet: !request
+          type: json
+          data:
+            {
+              "id": 10,
+              "name": "doggie",
+              "category": { "id": 1, "name": "Dogs" },
+              "photoUrls": [""],
+              "tags": [{ "id": 0, "name": "" }],
+              "status": "available",
+            }
+      updatePet:
+        type: request
         name: Update an existing pet
         method: PUT
         url: "{{ host }}/pet"
         body:
-          !json {
-            "id": 10,
-            "name": "doggie",
-            "category": { "id": 1, "name": "Dogs" },
-            "photoUrls": [""],
-            "tags": [{ "id": 0, "name": "" }],
-            "status": "available",
-          }
-      findPetsByStatus: !request
+          type: json
+          data:
+            {
+              "id": 10,
+              "name": "doggie",
+              "category": { "id": 1, "name": "Dogs" },
+              "photoUrls": [""],
+              "tags": [{ "id": 0, "name": "" }],
+              "status": "available",
+            }
+      findPetsByStatus:
+        type: request
         name: Finds Pets by status
         method: GET
         url: "{{ host }}/pet/findByStatus"
         query:
           status: ""
-      findPetsByTags: !request
+      findPetsByTags:
+        type: request
         name: Finds Pets by tags
         method: GET
         url: "{{ host }}/pet/findByTags"
         query:
           tags: ""
-      deletePet: !request
+      deletePet:
+        type: request
         name: Deletes a pet
         method: DELETE
         url: "{{ host }}/pet/{{petId}}"
         headers:
           api_key: ""
-      getPetById: !request
+      getPetById:
+        type: request
         name: Find pet by ID
         method: GET
         url: "{{ host }}/pet/{{petId}}"
         headers:
           api_key: "{{api_key}}"
-      updatePetWithForm: !request
+      updatePetWithForm:
+        type: request
         name: Updates a pet in the store with form data
         method: POST
         url: "{{ host }}/pet/{{petId}}"
         query:
           name: ""
           status: ""
-      uploadFile: !request
+      uploadFile:
+        type: request
         name: uploads an image
         method: POST
         url: "{{ host }}/pet/{{petId}}/uploadImage"
         query:
           additionalMetadata: ""
         body: '""'
-  tag/store: !folder
+  tag/store:
+    type: folder
     name: store
     requests:
-      getInventory: !request
+      getInventory:
+        type: request
         name: Returns pet inventories by status
         method: GET
         url: "{{ host }}/store/inventory"
         headers:
           api_key: "{{api_key}}"
-      placeOrder: !request
+      placeOrder:
+        type: request
         name: Place an order for a pet
         method: POST
         url: "{{ host }}/store/order"
         body:
-          !json {
-            id: 10,
-            petId: 198772,
-            quantity: 7,
-            shipDate: "",
-            status: "approved",
-            complete: false,
-          }
-      deleteOrder: !request
+          type: json
+          data:
+            {
+              id: 10,
+              petId: 198772,
+              quantity: 7,
+              shipDate: "",
+              status: "approved",
+              complete: false,
+            }
+      deleteOrder:
+        type: request
         name: Delete purchase order by ID
         method: DELETE
         url: "{{ host }}/store/order/{{orderId}}"
-      getOrderById: !request
+      getOrderById:
+        type: request
         name: Find purchase order by ID
         method: GET
         url: "{{ host }}/store/order/{{orderId}}"
-  tag/user: !folder
+  tag/user:
+    type: folder
     name: user
     requests:
-      createUser: !request
+      createUser:
+        type: request
         name: Create user
         method: POST
         url: "{{ host }}/user"
-        body: !json {
-            id: 10,
-            username: "theUser",
-            firstName: "John",
-            lastName: "James",
-            email: "john@email.com",
-            # The schema says these are string fields, but the example values
-            # in the spec are numbers, so we just use the examples
-            password: 12345,
-            phone: 12345,
-            userStatus: 1,
-          }
-      createUsersWithListInput: !request
+        body:
+          type: json
+          data: {
+              id: 10,
+              username: "theUser",
+              firstName: "John",
+              lastName: "James",
+              email: "john@email.com",
+              # The schema says these are string fields, but the example values
+              # in the spec are numbers, so we just use the examples
+              password: 12345,
+              phone: 12345,
+              userStatus: 1,
+            }
+      createUsersWithListInput:
+        type: request
         name: Creates list of users with given input array
         method: POST
         url: "{{ host }}/user/createWithList"
         body:
-          !json [
+          type: json
+          data:
+            [
+              {
+                id: 10,
+                username: "theUser",
+                firstName: "John",
+                lastName: "James",
+                email: "john@email.com",
+                password: 12345,
+                phone: 12345,
+                userStatus: 1,
+              },
+            ]
+      loginUser:
+        type: request
+        name: Logs user into the system
+        method: GET
+        url: "{{ host }}/user/login"
+        query:
+          username: ""
+          password: ""
+      logoutUser:
+        type: request
+        name: Logs out current logged in user session
+        method: GET
+        url: "{{ host }}/user/logout"
+      deleteUser:
+        type: request
+        name: Delete user
+        method: DELETE
+        url: "{{ host }}/user/{{ username }}"
+      getUserByName:
+        type: request
+        name: Get user by user name
+        method: GET
+        url: "{{ host }}/user/{{ username }}"
+      updateUser:
+        type: request
+        name: Update user
+        method: PUT
+        url: "{{ host }}/user/{{ username }}"
+        body:
+          type: json
+          data:
             {
               id: 10,
               username: "theUser",
@@ -136,39 +205,4 @@ requests:
               password: 12345,
               phone: 12345,
               userStatus: 1,
-            },
-          ]
-      loginUser: !request
-        name: Logs user into the system
-        method: GET
-        url: "{{ host }}/user/login"
-        query:
-          username: ""
-          password: ""
-      logoutUser: !request
-        name: Logs out current logged in user session
-        method: GET
-        url: "{{ host }}/user/logout"
-      deleteUser: !request
-        name: Delete user
-        method: DELETE
-        url: "{{ host }}/user/{{ username }}"
-      getUserByName: !request
-        name: Get user by user name
-        method: GET
-        url: "{{ host }}/user/{{ username }}"
-      updateUser: !request
-        name: Update user
-        method: PUT
-        url: "{{ host }}/user/{{ username }}"
-        body:
-          !json {
-            id: 10,
-            username: "theUser",
-            firstName: "John",
-            lastName: "James",
-            email: "john@email.com",
-            password: 12345,
-            phone: 12345,
-            userStatus: 1,
-          }
+            }

--- a/test_data/openapi_v3_1_petstore_imported.yml
+++ b/test_data/openapi_v3_1_petstore_imported.yml
@@ -5,125 +5,135 @@ profiles:
       host: http://petstore.swagger.io/v2
 
 requests:
-  tag/pet: !folder
+  tag/pet:
+    type: folder
     name: pet
     requests:
-      addPet: !request
+      addPet:
+        type: request
         name: Add a new pet to the store
         method: POST
         url: "{{host}}/pet"
         body:
-          !json {
-            "category": { "id": 0, "name": "" },
-            "id": 0,
-            "name": "doggie",
-            "photoUrls": [""],
-            "status": "available",
-            "tags": [{ "id": 0, "name": "" }],
-          }
-      updatePet: !request
+          type: json
+          data:
+            {
+              "category": { "id": 0, "name": "" },
+              "id": 0,
+              "name": "doggie",
+              "photoUrls": [""],
+              "status": "available",
+              "tags": [{ "id": 0, "name": "" }],
+            }
+      updatePet:
+        type: request
         name: Update an existing pet
         method: PUT
         url: "{{host}}/pet"
         body:
-          !json {
-            "category": { "id": 0, "name": "" },
-            "id": 0,
-            "name": "doggie",
-            "photoUrls": [""],
-            "status": "available",
-            "tags": [{ "id": 0, "name": "" }],
-          }
-      findPetsByStatus: !request
+          type: json
+          data:
+            {
+              "category": { "id": 0, "name": "" },
+              "id": 0,
+              "name": "doggie",
+              "photoUrls": [""],
+              "status": "available",
+              "tags": [{ "id": 0, "name": "" }],
+            }
+      findPetsByStatus:
+        type: request
         name: Finds Pets by status
         method: GET
         url: "{{host}}/pet/findByStatus"
         query:
           status: ""
-      findPetsByTags: !request
+      findPetsByTags:
+        type: request
         name: Finds Pets by tags
         method: GET
         url: "{{host}}/pet/findByTags"
         query:
           tags: ""
-      deletePet: !request
+      deletePet:
+        type: request
         name: Deletes a pet
         method: DELETE
         url: "{{host}}/pet/{{petId}}"
         headers:
           api_key: ""
-      getPetById: !request
+      getPetById:
+        type: request
         name: Find pet by ID
         method: GET
         url: "{{host}}/pet/{{petId}}"
         headers:
           api_key: "{{api_key}}"
-      updatePetWithForm: !request
+      updatePetWithForm:
+        type: request
         name: Updates a pet in the store with form data
         method: POST
         url: "{{host}}/pet/{{petId}}"
-        body: !form_urlencoded
-          name: ""
-          status: ""
-      uploadFile: !request
+        body:
+          type: form_urlencoded
+          data:
+            name: ""
+            status: ""
+      uploadFile:
+        type: request
         name: uploads an image
         method: POST
         url: "{{host}}/pet/{{petId}}/uploadImage"
         body: '""'
-  tag/store: !folder
+  tag/store:
+    type: folder
     name: store
     requests:
-      getInventory: !request
+      getInventory:
+        type: request
         name: Returns pet inventories by status
         method: GET
         url: "{{host}}/store/inventory"
         headers:
           api_key: "{{api_key}}"
-      placeOrder: !request
+      placeOrder:
+        type: request
         name: Place an order for a pet
         method: POST
         url: "{{host}}/store/order"
         body:
-          !json {
-            complete: false,
-            id: 0,
-            petId: 0,
-            quantity: 0,
-            shipDate: "",
-            status: "placed",
-          }
-      deleteOrder: !request
+          type: json
+          data:
+            {
+              complete: false,
+              id: 0,
+              petId: 0,
+              quantity: 0,
+              shipDate: "",
+              status: "placed",
+            }
+      deleteOrder:
+        type: request
         name: Delete purchase order by ID
         method: DELETE
         url: "{{host}}/store/order/{{orderId}}"
-      getOrderById: !request
+      getOrderById:
+        type: request
         name: Find purchase order by ID
         method: GET
         url: "{{host}}/store/order/{{orderId}}"
-  tag/user: !folder
+  tag/user:
+    type: folder
     name: user
     requests:
-      createUser: !request
+      createUser:
+        type: request
         name: Create user
         method: POST
         url: "{{host}}/user"
         body:
-          !json {
-            email: "",
-            firstName: "",
-            id: 0,
-            lastName: "",
-            password: "",
-            phone: "",
-            userStatus: 0,
-            username: "",
-          }
-      createUsersWithListInput: !request
-        name: Creates list of users with given input array
-        method: POST
-        url: "{{host}}/user/createWithList"
-        body:
-          !json [
+          type: json
+          data:
             {
               email: "",
               firstName: "",
@@ -133,39 +143,65 @@ requests:
               phone: "",
               userStatus: 0,
               username: "",
-            },
-          ]
-      loginUser: !request
+            }
+      createUsersWithListInput:
+        type: request
+        name: Creates list of users with given input array
+        method: POST
+        url: "{{host}}/user/createWithList"
+        body:
+          type: json
+          data:
+            [
+              {
+                email: "",
+                firstName: "",
+                id: 0,
+                lastName: "",
+                password: "",
+                phone: "",
+                userStatus: 0,
+                username: "",
+              },
+            ]
+      loginUser:
+        type: request
         name: Logs user into the system
         method: GET
         url: "{{host}}/user/login"
         query:
           username: ""
           password: ""
-      logoutUser: !request
+      logoutUser:
+        type: request
         name: Logs out current logged in user session
         method: GET
         url: "{{host}}/user/logout"
-      deleteUser: !request
+      deleteUser:
+        type: request
         name: Delete user
         method: DELETE
         url: "{{host}}/user/{{username}}"
-      getUserByName: !request
+      getUserByName:
+        type: request
         name: Get user by user name
         method: GET
         url: "{{host}}/user/{{username}}"
-      updateUser: !request
+      updateUser:
+        type: request
         name: Updated user
         method: PUT
         url: "{{host}}/user/{{username}}"
         body:
-          !json {
-            email: "",
-            firstName: "",
-            id: 0,
-            lastName: "",
-            password: "",
-            phone: "",
-            userStatus: 0,
-            username: "",
-          }
+          type: json
+          data:
+            {
+              email: "",
+              firstName: "",
+              id: 0,
+              lastName: "",
+              password: "",
+              phone: "",
+              userStatus: 0,
+              username: "",
+            }

--- a/test_data/regression.yml
+++ b/test_data/regression.yml
@@ -22,7 +22,8 @@ profiles:
       <<: *base_profile_data
 
 requests:
-  text_body: !request
+  text_body:
+    type: request
     method: POST
     # Missing name
     url: "{{ host }}/anything/login"
@@ -35,10 +36,12 @@ requests:
     body: >-
       {"username":"{{ username }}","password":"{{ prompt('Password', sensitive=true) }}"}
 
-  users: !folder
+  users:
+    type: folder
     name: Users
     requests:
-      simple: !request
+      simple:
+        type: request
         name: Simple
         method: GET
         # No headers or authentication
@@ -46,29 +49,38 @@ requests:
         query:
           one: "{{ field1 }}"
           many: ["{{ field1 }}", "{{ field2 }}"]
-        headers: # Should parse as an empty map
 
-      json_body: !request
+      json_body:
+        type: request
         <<: *base_recipe
         method: PUT
         url: "{{ host }}/anything/{{ user_guid }}"
-        authentication: !bearer "{{ response('login') | jsonpath('$.token') }}"
-        body: !json { "username": "new username" }
-        query: # Should parse as an empty map
+        authentication:
+          type: bearer
+          token: "{{ response('login') | jsonpath('$.token') }}"
+        body:
+          type: json
+          data: { "username": "new username" }
 
-      json_body_but_not: !request
+      json_body_but_not:
+        type: request
         <<: *base_recipe
         method: PUT
         url: "{{ host }}/anything/{{ user_guid }}"
-        authentication: !basic
+        authentication:
+          type: basic
           username: "{{ username }}"
           password: "{{password}}"
-        # Nested JSON is *not* parsed
-        body: !json '{"warning": "NOT an object"}'
+        body:
+          type: json
+          data: '{"warning": "NOT an object"}'
 
-      form_urlencoded_body: !request
+      form_urlencoded_body:
+        type: request
         <<: *base_recipe
         method: PUT
         url: "{{ host }}/anything/{{ user_guid }}"
-        body: !form_urlencoded
-          username: "new username"
+        body:
+          type: form_urlencoded
+          data:
+            username: "new username"

--- a/test_data/rest_imported.yml
+++ b/test_data/rest_imported.yml
@@ -10,7 +10,8 @@ profiles:
       ENDPOINT: post
 
 requests:
-  SimpleGet_0: !request
+  SimpleGet_0:
+    type: request
     name: SimpleGet
     method: GET
     url: "{{ HOST }}/get"
@@ -18,14 +19,18 @@ requests:
     authentication: null
     query: {}
     headers: {}
-  JsonPost_1: !request
+  JsonPost_1:
+    type: request
     name: JsonPost
     method: POST
     url: "{{ HOST }}/post"
-    body: !json
-      data: my data
-      name: "{{ FULL }}"
-    authentication: !basic
+    body:
+      type: json
+      data:
+        data: my data
+        name: "{{ FULL }}"
+    authentication:
+      type: basic
       username: foo
       password: bar
     query:
@@ -33,18 +38,22 @@ requests:
     headers:
       Content-Type: application/json
       X-Http-Method-Override: PUT
-  Request_2: !request
+  Request_2:
+    type: request
     name: Request
     method: POST
     url: https://httpbin.org/{{ ENDPOINT }}
     body: first={{ FIRST }}&last={{ LAST }}&full={{ FULL }}
-    authentication: !bearer efaxijasdfjasdfa
+    authentication:
+      type: bearer
+      token: efaxijasdfjasdfa
     query: {}
     headers:
       Content-Type: application/x-www-form-urlencoded
       My-Header: hello
       Other-Header: goodbye
-  Pet_json_3: !request
+  Pet_json_3:
+    type: request
     name: Pet.json
     method: POST
     url: "{{ HOST }}/post"


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

- Remove YAML `!tag` syntax in favor of internally tagged enums under the `type` field
  - This enables the usage of JSON Schema, to come later
- Replace `serde_yaml` with `saphyr` for deserialization only
  - `saphyr` does the parsing, then we deserialize manually. This provides much better errors than serde would, and also enables source span tracking which will be very handy in the future.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Hand-writing deserialization is much more tedious and error prone. Mitigated a bit with some common utilities.

## QA

_How did you test this?_

Existing tests were pretty thorough, added some new ones too.

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
