### PR TITLE
Add collection switcher modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Add collection switcher modal [#536](https://github.com/LucasPickering/slumber/issues/536)
+  - You can now switch between any collection that you've opened in the past without having to close Slumber
+
 ### Changed
 
 - Update to Rust 1.88

--- a/crates/config/src/input.rs
+++ b/crates/config/src/input.rs
@@ -169,6 +169,9 @@ pub enum Action {
     #[display("Help")]
     /// Open the help modal
     OpenHelp,
+    /// Open collection selection modal (unbound by default)
+    #[display("Select Collection")]
+    SelectCollection,
     /// Select profile list pane
     SelectProfileList,
     /// Select recipe list pane

--- a/crates/core/src/database.rs
+++ b/crates/core/src/database.rs
@@ -277,6 +277,11 @@ impl CollectionDatabase {
             .map(PathBuf::from)
     }
 
+    /// Get the root database, which has access to all collections
+    pub fn root(&self) -> &Database {
+        &self.database
+    }
+
     /// Get a request by ID, or `None` if it does not exist in history.
     pub fn get_request(
         &self,

--- a/crates/tui/src/input.rs
+++ b/crates/tui/src/input.rs
@@ -180,6 +180,7 @@ impl Default for InputEngine {
                 Action::Edit => KeyCode::Char('e').into(),
                 Action::Reset => KeyCode::Char('z').into(),
                 Action::View => KeyCode::Char('v').into(),
+                Action::SelectCollection => KeyCode::F(3).into(),
                 Action::SelectProfileList => KeyCode::Char('p').into(),
                 Action::SelectRecipeList => KeyCode::Char('l').into(),
                 Action::SelectRecipe => KeyCode::Char('c').into(),

--- a/crates/tui/src/message.rs
+++ b/crates/tui/src/message.rs
@@ -15,7 +15,7 @@ use slumber_core::{
     template::{Prompt, ResponseChannel, Select, Template, TemplateChunk},
 };
 use slumber_util::ResultTraced;
-use std::{fmt::Debug, sync::Arc};
+use std::{fmt::Debug, path::PathBuf, sync::Arc};
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::trace;
 
@@ -55,6 +55,9 @@ pub enum Message {
     CollectionEndReload(Collection),
     /// Open the collection in the user's editor
     CollectionEdit,
+    /// Switch to a different collection file. This will start an entirely new
+    /// TUI session for the new collection
+    CollectionSelect(PathBuf),
 
     /// Show a yes/no confirmation to the user. Use the included channel to
     /// return the value.

--- a/crates/tui/src/state.rs
+++ b/crates/tui/src/state.rs
@@ -425,10 +425,7 @@ impl LoadedState {
             self.database.clone(),
             self.messages_tx(),
         );
-        self.view.notify(format!(
-            "Reloaded collection from {}",
-            self.collection_file.path().to_string_lossy()
-        ));
+        self.view.notify("Reloaded collection");
     }
     /// Render URL for a request, then copy it to the clipboard
     fn copy_request_url(&self) -> anyhow::Result<()> {

--- a/crates/tui/src/view/common.rs
+++ b/crates/tui/src/view/common.rs
@@ -17,11 +17,10 @@ use crate::{
     context::TuiContext,
     view::{
         draw::Generate,
-        state::Notification,
         util::{format_duration, format_time},
     },
 };
-use chrono::{DateTime, Duration, Local, Utc};
+use chrono::{DateTime, Duration, Utc};
 use itertools::{Itertools, Position};
 use ratatui::{
     text::{Line, Span, Text},
@@ -118,25 +117,6 @@ impl Generate for &Profile {
         Self: 'this,
     {
         self.name().to_owned().into()
-    }
-}
-
-impl Generate for &Notification {
-    type Output<'this>
-        = Span<'this>
-    where
-        Self: 'this;
-
-    fn generate<'this>(self) -> Self::Output<'this>
-    where
-        Self: 'this,
-    {
-        format!(
-            "[{}] {}",
-            self.timestamp.with_timezone(&Local).format("%H:%M:%S"),
-            self.message
-        )
-        .into()
     }
 }
 

--- a/crates/tui/src/view/component.rs
+++ b/crates/tui/src/view/component.rs
@@ -1,5 +1,6 @@
 mod collection_select;
 mod exchange_pane;
+mod footer;
 mod help;
 mod history;
 mod internal;

--- a/crates/tui/src/view/component.rs
+++ b/crates/tui/src/view/component.rs
@@ -1,3 +1,4 @@
+mod collection_select;
 mod exchange_pane;
 mod help;
 mod history;

--- a/crates/tui/src/view/component/collection_select.rs
+++ b/crates/tui/src/view/component/collection_select.rs
@@ -1,0 +1,129 @@
+use super::Component;
+use crate::{
+    context::TuiContext,
+    message::Message,
+    util::ResultReported,
+    view::{
+        UpdateContext, ViewContext,
+        common::{list::List, modal::Modal},
+        draw::{Draw, DrawMetadata, ToStringGenerate},
+        event::{Child, Event, EventHandler, OptionEvent, ToEmitter},
+        state::select::{SelectState, SelectStateEvent, SelectStateEventType},
+    },
+};
+use ratatui::{
+    Frame,
+    layout::Layout,
+    prelude::{Constraint, Line},
+    text::Text,
+};
+use slumber_core::database::CollectionDatabase;
+use slumber_util::ResultTraced;
+use std::path::PathBuf;
+
+/// A modal to list all collections in the DB, allowing the user to switch to a
+/// different one
+#[derive(Debug)]
+pub struct CollectionSelect {
+    select: Component<SelectState<CollectionSelectItem>>,
+}
+
+impl CollectionSelect {
+    pub fn new() -> Self {
+        // Build the collection list from the DB's collections table. Preselect
+        // the current collection
+        let collections =
+            ViewContext::with_database(|db| db.root().collections())
+                .reported(&ViewContext::messages_tx())
+                .unwrap_or_default();
+        let current_collection =
+            ViewContext::with_database(CollectionDatabase::collection_path)
+                .traced()
+                .ok();
+
+        let select = SelectState::builder(
+            collections
+                .into_iter()
+                .map(|path| CollectionSelectItem { path })
+                .collect(),
+        )
+        .preselect_opt(current_collection.as_ref())
+        .subscribe([SelectStateEventType::Submit])
+        .build();
+
+        Self {
+            select: select.into(),
+        }
+    }
+}
+
+impl Modal for CollectionSelect {
+    fn title(&self) -> Line<'_> {
+        "Collections".into()
+    }
+
+    fn dimensions(&self) -> (Constraint, Constraint) {
+        let footer_height = 2;
+        let height =
+            u16::min(self.select.data().len() as u16 + footer_height, 10);
+        (Constraint::Percentage(60), Constraint::Length(height))
+    }
+}
+
+impl EventHandler for CollectionSelect {
+    fn update(&mut self, _: &mut UpdateContext, event: Event) -> Option<Event> {
+        event.opt().emitted(self.select.to_emitter(), |event| {
+            // The ol' Tennessee Switcharoo
+            if let SelectStateEvent::Submit(index) = event {
+                let item = &self.select.data()[index];
+                self.close(true);
+                ViewContext::send_message(Message::CollectionSelect(
+                    item.path.clone(),
+                ));
+            }
+        })
+    }
+
+    fn children(&mut self) -> Vec<Component<Child<'_>>> {
+        vec![self.select.to_child_mut()]
+    }
+}
+
+impl Draw for CollectionSelect {
+    fn draw(&self, frame: &mut Frame, (): (), metadata: DrawMetadata) {
+        let styles = &TuiContext::get().styles;
+        let [select_area, _, footer_area] = Layout::vertical([
+            Constraint::Min(0),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
+        .areas(metadata.area());
+        self.select.draw(
+            frame,
+            List::from(self.select.data()),
+            select_area,
+            true,
+        );
+        frame.render_widget(
+            Text::from(
+                "Only collections that have been opened before are shown",
+            )
+            .style(styles.text.note),
+            footer_area,
+        );
+    }
+}
+
+#[derive(Debug, derive_more::Display)]
+#[display("{}", path.display())]
+struct CollectionSelectItem {
+    path: PathBuf,
+}
+
+impl PartialEq<CollectionSelectItem> for PathBuf {
+    fn eq(&self, other: &CollectionSelectItem) -> bool {
+        self == &other.path
+    }
+}
+
+impl ToStringGenerate for CollectionSelectItem {}

--- a/crates/tui/src/view/component/footer.rs
+++ b/crates/tui/src/view/component/footer.rs
@@ -1,0 +1,95 @@
+use crate::{
+    context::TuiContext,
+    util,
+    view::{
+        UpdateContext, ViewContext,
+        component::help::HelpFooter,
+        draw::{Draw, DrawMetadata, Generate},
+        event::{Event, EventHandler, OptionEvent},
+        state::Notification,
+    },
+};
+use ratatui::{
+    Frame,
+    layout::{Constraint, Layout},
+    text::Span,
+};
+use slumber_config::Action;
+use slumber_core::database::CollectionDatabase;
+use slumber_util::ResultTraced;
+use tokio::time;
+
+/// Component at the bottom
+#[derive(Debug, Default)]
+pub struct Footer {
+    notification: Option<Notification>,
+}
+
+impl EventHandler for Footer {
+    fn update(&mut self, _: &mut UpdateContext, event: Event) -> Option<Event> {
+        event.opt().any(|event| match event {
+            Event::Notify(notification) => {
+                let id = notification.id;
+                self.notification = Some(notification);
+                // Spawn a task to clear the notification
+                util::spawn(async move {
+                    time::sleep(Notification::DURATION).await;
+                    ViewContext::push_event(Event::NotifyClear(id));
+                });
+                None
+            }
+            Event::NotifyClear(id) => {
+                // Clear the notification only if the clear message matches what
+                // we have. This prevents early clears when multiple
+                // notifcations are send in quick succession
+                if let Some(notification) = &self.notification
+                    && notification.id == id
+                {
+                    self.notification = None;
+                }
+                None
+            }
+
+            _ => Some(event),
+        })
+    }
+}
+
+impl Draw for Footer {
+    fn draw(&self, frame: &mut Frame, (): (), metadata: DrawMetadata) {
+        // If a notification is present, it gets the entire footer.
+        // Notifications are auto-cleared so it's ok to hide other stuff
+        // temporarily
+        if let Some(notification) = &self.notification {
+            frame.render_widget(&notification.message, metadata.area());
+            return;
+        }
+
+        // No notification - show help dialog and current collection path
+        let input_engine = &TuiContext::get().input_engine;
+        let styles = &TuiContext::get().styles;
+
+        let collection_path =
+            ViewContext::with_database(CollectionDatabase::collection_path)
+                .traced()
+                .unwrap_or_default();
+        let collection_path_text = Span::styled(
+            input_engine
+                .add_hint(collection_path.display(), Action::SelectCollection),
+            styles.text.highlight,
+        );
+
+        let help = HelpFooter.generate();
+        let [help_area, collection_area] = Layout::horizontal([
+            Constraint::Min(help.width() as u16),
+            Constraint::Length(collection_path_text.content.len() as u16),
+        ])
+        .areas(metadata.area());
+
+        frame.render_widget(help, help_area);
+        frame.render_widget(
+            collection_path_text.into_right_aligned_line(),
+            collection_area,
+        );
+    }
+}

--- a/crates/tui/src/view/component/help.rs
+++ b/crates/tui/src/view/component/help.rs
@@ -11,7 +11,7 @@ use itertools::Itertools;
 use ratatui::{
     Frame,
     layout::{Alignment, Constraint, Layout},
-    text::{Line, Text},
+    text::{Line, Span},
 };
 use slumber_config::{Action, Config, InputBinding};
 use slumber_util::{doc_link, paths};
@@ -24,7 +24,7 @@ pub struct HelpFooter;
 
 impl Generate for HelpFooter {
     type Output<'this>
-        = Text<'this>
+        = Span<'this>
     where
         Self: 'this;
 
@@ -44,7 +44,7 @@ impl Generate for HelpFooter {
             })
             .join(" / ");
 
-        Text::styled(text, tui_context.styles.text.highlight)
+        Span::styled(text, tui_context.styles.text.highlight)
     }
 }
 

--- a/crates/tui/src/view/component/misc.rs
+++ b/crates/tui/src/view/component/misc.rs
@@ -15,10 +15,7 @@ use crate::{
         context::UpdateContext,
         draw::{Draw, DrawMetadata, Generate},
         event::{Child, Event, EventHandler, OptionEvent, ToEmitter},
-        state::{
-            Notification,
-            select::{SelectState, SelectStateEvent, SelectStateEventType},
-        },
+        state::select::{SelectState, SelectStateEvent, SelectStateEventType},
     },
 };
 use derive_more::Display;
@@ -26,7 +23,6 @@ use ratatui::{
     Frame,
     prelude::Constraint,
     text::{Line, Text},
-    widgets::Paragraph,
 };
 use slumber_core::{
     collection::{ProfileId, RecipeId},
@@ -511,25 +507,4 @@ enum DeleteRecipeRequestsButton {
     /// Delete all requests for all profiles
     #[display("For all profiles")]
     All,
-}
-
-/// Show most recent notification with timestamp
-#[derive(Debug)]
-pub struct NotificationText {
-    notification: Notification,
-}
-
-impl NotificationText {
-    pub fn new(notification: Notification) -> Self {
-        Self { notification }
-    }
-}
-
-impl Draw for NotificationText {
-    fn draw(&self, frame: &mut Frame, (): (), metadata: DrawMetadata) {
-        frame.render_widget(
-            Paragraph::new(self.notification.generate()),
-            metadata.area(),
-        );
-    }
 }

--- a/crates/tui/src/view/component/primary.rs
+++ b/crates/tui/src/view/component/primary.rs
@@ -323,9 +323,6 @@ impl EventHandler for PrimaryView {
                     GlobalMenuAction::EditCollection => {
                         ViewContext::send_message(Message::CollectionEdit);
                     }
-                    GlobalMenuAction::SwitchCollection => {
-                        CollectionSelect::new().open();
-                    }
                 }
             })
     }
@@ -469,21 +466,9 @@ enum GlobalMenuAction {
     /// Open the current collection file in an external editor
     #[display("Edit Collection")]
     EditCollection,
-    /// Open a modal to swich to a different collection
-    #[display("Switch Collection")]
-    SwitchCollection,
 }
 
-impl IntoMenuAction<PrimaryView> for GlobalMenuAction {
-    fn shortcut(&self, _: &PrimaryView) -> Option<Action> {
-        match self {
-            GlobalMenuAction::EditCollection => None,
-            GlobalMenuAction::SwitchCollection => {
-                Some(Action::SelectCollection)
-            }
-        }
-    }
-}
+impl IntoMenuAction<PrimaryView> for GlobalMenuAction {}
 
 /// Helper for adjusting pane behavior according to state
 struct Panes {
@@ -596,7 +581,7 @@ mod tests {
             .send_key(KeyCode::Char('l')) // Select recipe list
             .open_actions()
             // Copy URL
-            .send_keys([KeyCode::Down, KeyCode::Down, KeyCode::Enter])
+            .send_keys([KeyCode::Down, KeyCode::Enter])
             .assert_empty();
 
         assert_matches!(harness.pop_message_now(), Message::CopyRequestUrl);
@@ -613,12 +598,7 @@ mod tests {
             .send_key(KeyCode::Char('l')) // Select recipe list
             .open_actions()
             // Copy as cURL
-            .send_keys([
-                KeyCode::Down,
-                KeyCode::Down,
-                KeyCode::Down,
-                KeyCode::Enter,
-            ])
+            .send_keys([KeyCode::Down, KeyCode::Down, KeyCode::Enter])
             .assert_empty();
 
         assert_matches!(harness.pop_message_now(), Message::CopyRequestCurl);

--- a/crates/tui/src/view/component/primary.rs
+++ b/crates/tui/src/view/component/primary.rs
@@ -11,6 +11,7 @@ use crate::{
             modal::Modal,
         },
         component::{
+            collection_select::CollectionSelect,
             exchange_pane::{ExchangePane, ExchangePaneEvent},
             help::HelpModal,
             misc::DeleteRecipeRequestsModal,
@@ -261,6 +262,7 @@ impl EventHandler for PrimaryView {
                 Action::SelectResponse => {
                     self.selected_pane.get_mut().select(&PrimaryPane::Exchange);
                 }
+                Action::SelectCollection => CollectionSelect::new().open(),
 
                 // Toggle fullscreen
                 Action::Fullscreen => {
@@ -320,6 +322,9 @@ impl EventHandler for PrimaryView {
                 match menu_action {
                     GlobalMenuAction::EditCollection => {
                         ViewContext::send_message(Message::CollectionEdit);
+                    }
+                    GlobalMenuAction::SwitchCollection => {
+                        CollectionSelect::new().open();
                     }
                 }
             })
@@ -461,11 +466,24 @@ enum FullscreenMode {
 /// Menu actions available in all contexts
 #[derive(Copy, Clone, Debug, Display, EnumIter)]
 enum GlobalMenuAction {
+    /// Open the current collection file in an external editor
     #[display("Edit Collection")]
     EditCollection,
+    /// Open a modal to swich to a different collection
+    #[display("Switch Collection")]
+    SwitchCollection,
 }
 
-impl IntoMenuAction<PrimaryView> for GlobalMenuAction {}
+impl IntoMenuAction<PrimaryView> for GlobalMenuAction {
+    fn shortcut(&self, _: &PrimaryView) -> Option<Action> {
+        match self {
+            GlobalMenuAction::EditCollection => None,
+            GlobalMenuAction::SwitchCollection => {
+                Some(Action::SelectCollection)
+            }
+        }
+    }
+}
 
 /// Helper for adjusting pane behavior according to state
 struct Panes {
@@ -578,7 +596,7 @@ mod tests {
             .send_key(KeyCode::Char('l')) // Select recipe list
             .open_actions()
             // Copy URL
-            .send_keys([KeyCode::Down, KeyCode::Enter])
+            .send_keys([KeyCode::Down, KeyCode::Down, KeyCode::Enter])
             .assert_empty();
 
         assert_matches!(harness.pop_message_now(), Message::CopyRequestUrl);
@@ -595,7 +613,12 @@ mod tests {
             .send_key(KeyCode::Char('l')) // Select recipe list
             .open_actions()
             // Copy as cURL
-            .send_keys([KeyCode::Down, KeyCode::Down, KeyCode::Enter])
+            .send_keys([
+                KeyCode::Down,
+                KeyCode::Down,
+                KeyCode::Down,
+                KeyCode::Enter,
+            ])
             .assert_empty();
 
         assert_matches!(harness.pop_message_now(), Message::CopyRequestCurl);

--- a/crates/tui/src/view/component/root.rs
+++ b/crates/tui/src/view/component/root.rs
@@ -584,6 +584,7 @@ mod tests {
                 KeyCode::Down,
                 KeyCode::Down,
                 KeyCode::Down,
+                KeyCode::Down,
                 KeyCode::Enter,
                 // Decline
                 KeyCode::Left,
@@ -604,6 +605,7 @@ mod tests {
             .open_actions()
             .send_keys([
                 // "Delete Request" action
+                KeyCode::Down,
                 KeyCode::Down,
                 KeyCode::Down,
                 KeyCode::Down,

--- a/crates/tui/src/view/event.rs
+++ b/crates/tui/src/view/event.rs
@@ -262,6 +262,8 @@ pub enum Event {
 
     /// Tell the user something informational
     Notify(Notification),
+    /// Clear the current notification if it matches the given ID
+    NotifyClear(Uuid),
 
     /// A localized event emitted by a particular [Emitter] implementation.
     /// The event type here does not need to be unique because the emitter ID

--- a/crates/tui/src/view/state.rs
+++ b/crates/tui/src/view/state.rs
@@ -3,9 +3,11 @@
 pub mod fixed_select;
 pub mod select;
 
-use chrono::{DateTime, Utc};
 use derive_more::Deref;
-use std::cell::{Ref, RefCell};
+use std::{
+    cell::{Ref, RefCell},
+    time::Duration,
+};
 use uuid::Uuid;
 
 /// An internally mutable cell for UI state. Certain state needs to be updated
@@ -105,15 +107,20 @@ impl<T> From<T> for Identified<T> {
 /// It should be shown for a short period of time, then disappear on its own.
 #[derive(Debug)]
 pub struct Notification {
+    /// Unique ID for this notification. Used to ensure the clear timer is
+    /// clearing the correct notification
+    pub id: Uuid,
     pub message: String,
-    pub timestamp: DateTime<Utc>,
 }
 
 impl Notification {
+    /// Notifications should be cleared automatically after this amount of time
+    pub const DURATION: Duration = Duration::from_secs(5);
+
     pub fn new(message: String) -> Self {
         Self {
+            id: Uuid::new_v4(),
             message,
-            timestamp: Utc::now(),
         }
     }
 }

--- a/crates/tui/src/view/styles.rs
+++ b/crates/tui/src/view/styles.rs
@@ -106,6 +106,8 @@ pub struct TextStyle {
     pub edited: Style,
     /// Text that means BAD BUSINESS
     pub error: Style,
+    /// Informational notes
+    pub note: Style,
     /// Text at the top of something
     pub title: Style,
 }
@@ -189,6 +191,7 @@ impl Styles {
                 primary: Style::default().fg(theme.primary_color),
                 edited: Style::default().add_modifier(Modifier::ITALIC),
                 error: Style::default().bg(theme.error_color),
+                note: Style::default().add_modifier(Modifier::ITALIC),
                 title: Style::default().add_modifier(Modifier::BOLD),
             },
             text_box: TextBoxStyle {

--- a/docs/src/api/configuration/input_bindings.md
+++ b/docs/src/api/configuration/input_bindings.md
@@ -65,6 +65,7 @@ input_bindings:
 | `fullscreen`          | `f`                         | Fullscreen current pane                               |
 | `open_actions`        | `x`                         | Open actions menu                                     |
 | `open_help`           | `?`                         | Open help dialog                                      |
+| `select_collection`   | Unbound                     | Open collection select dialog                         |
 | `select_profile_list` | `p`                         | Open Profile List dialog                              |
 | `select_recipe_list`  | `l`                         | Select Recipe List pane                               |
 | `select_recipe`       | `c`                         | Select Recipe pane                                    |

--- a/docs/src/api/configuration/input_bindings.md
+++ b/docs/src/api/configuration/input_bindings.md
@@ -65,7 +65,7 @@ input_bindings:
 | `fullscreen`          | `f`                         | Fullscreen current pane                               |
 | `open_actions`        | `x`                         | Open actions menu                                     |
 | `open_help`           | `?`                         | Open help dialog                                      |
-| `select_collection`   | Unbound                     | Open collection select dialog                         |
+| `select_collection`   | `f3`                        | Open collection select dialog                         |
 | `select_profile_list` | `p`                         | Open Profile List dialog                              |
 | `select_recipe_list`  | `l`                         | Select Recipe List pane                               |
 | `select_recipe`       | `c`                         | Select Recipe pane                                    |


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Closes #536 

I originally had this accessible as a global action, but that menu is getting crowded so I decided to make it a keybind instead and put it in the footer. Makes it easy to see which collection you have selected too.

<img width="719" height="417" alt="image" src="https://github.com/user-attachments/assets/f0eb3532-9b6e-4f45-8738-510b5678d88d" />

<img width="717" height="412" alt="image" src="https://github.com/user-attachments/assets/ba0b9239-3ba7-43a8-afb9-356b885daef8" />

<img width="719" height="413" alt="image" src="https://github.com/user-attachments/assets/3a571a92-e553-4089-949a-741c8fd5b4bd" />


## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

- Additional clutter of UI and keybindings. The keyboard has a lot of keys though
- Collection swapping is a high-level state operation so it's potentially fragile. Mitigated with a test

## QA

_How did you test this?_

Manually, added a unit test

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
