### PR TITLE
Fix empty actions modal queuing when opening actions while another modal is already open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Update to Rust 1.88
 
+### Fixed
+
+- Fix empty actions modal queuing when opening actions while another modal is already open
+
 ## [3.2.0] - 2025-06-20
 
 ### Added

--- a/crates/tui/src/view/component/root.rs
+++ b/crates/tui/src/view/component/root.rs
@@ -163,7 +163,10 @@ impl EventHandler for Root {
                     // Walk down the component tree and collect actions from
                     // all visible+focused components
                     let actions = self.primary_view.collect_actions();
-                    ActionsModal::new(actions).open();
+                    // Actions can be empty if a modal is already open
+                    if !actions.is_empty() {
+                        ActionsModal::new(actions).open();
+                    }
                 }
                 Action::History => {
                     self.open_history(context.request_store)


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

It's no longer possible to open an empty actions modal. The actions list will be empty if another modal is already open, because the primary view is not in focus so all its actions are filtered.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

No test means it could break again

## QA

_How did you test this?_

Tested manually. Didn't feel like writing a unit test

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
