### PR TITLE
Fix overflow crash for large select options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - Fix empty actions modal queuing when opening actions while another modal is already open
+- Fix crash when a select modal is opened with a very long option
 
 ## [3.2.0] - 2025-06-20
 

--- a/crates/tui/src/view/common/modal.rs
+++ b/crates/tui/src/view/common/modal.rs
@@ -216,6 +216,8 @@ impl Draw for ModalQueue {
             area.y = area.y.saturating_sub(y_buffer);
             area.width += x_buffer * 2;
             area.height += y_buffer * 2;
+            // Don't overflow the draw area
+            area = area.clamp(frame.area());
 
             let block = Block::default()
                 .title(modal.data().title())


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

The modal queue no longer allows modals to overflow the draw area, triggering a crash.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

More crashes probably exist!!

## QA

_How did you test this?_

Manually

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
