### PR TITLE
Use terminput for common input events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,12 +262,27 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -288,6 +312,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +338,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
+name = "bytemuck"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,12 +357,6 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "cassowary"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "castaway"
@@ -453,9 +486,9 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "compact_str"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -519,6 +552,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,6 +575,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc32fast"
@@ -560,16 +611,19 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
  "bitflags 2.9.1",
  "crossterm_winapi",
+ "derive_more 2.0.1",
+ "document-features",
  "futures-core",
  "mio",
  "parking_lot",
- "rustix 0.38.44",
+ "rustix",
+ "serde",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -582,6 +636,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
 ]
 
 [[package]]
@@ -638,6 +712,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
+name = "deranged"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "derive-new"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,6 +773,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
+ "convert_case",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -713,6 +803,16 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "dirs"
@@ -751,6 +851,15 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "document-features"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
+dependencies = [
+ "litrs",
+]
 
 [[package]]
 name = "downcast-rs"
@@ -812,6 +921,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.22.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad9cdb4b747e485a12abb0e6566612956c7a1bafa3bdb8d682c5b6d403589e48"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,6 +940,16 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set 0.5.3",
+ "regex",
+]
 
 [[package]]
 name = "fastrand"
@@ -839,6 +967,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -849,6 +988,12 @@ dependencies = [
  "libredox",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "finl_unicode"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94c970b525906eb37d3940083aa65b95e481fc1857d467d13374e1d925cfc163"
 
 [[package]]
 name = "fixedbitset"
@@ -986,6 +1131,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "gethostname"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1103,6 +1258,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -1466,6 +1627,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1479,6 +1649,16 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kasuari"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d9e0d6a8bf886abccc1cbcac7d74f9000ae5882aedc4a9042188bbc9cd4487"
+dependencies = [
+ "hashbrown 0.15.3",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -1500,6 +1680,12 @@ dependencies = [
  "bitflags 1.3.2",
  "libc",
 ]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
 
 [[package]]
 name = "lazy_static"
@@ -1536,10 +1722,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
+name = "line-clipping"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "51a1679740111eb63b7b4cb3c97b1d5d9f82e142292a25edcfdb4120a48b3880"
+dependencies = [
+ "bitflags 2.9.1",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1552,6 +1741,12 @@ name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+
+[[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "lock_api"
@@ -1571,9 +1766,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "9f8cc7106155f10bdf99a6f379688f543ad6596a415375b36a59a054ceda1198"
 dependencies = [
  "hashbrown 0.15.3",
 ]
@@ -1583,6 +1778,16 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix 0.29.0",
+ "winapi",
+]
 
 [[package]]
 name = "malloc_buf"
@@ -1606,10 +1811,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
@@ -1666,7 +1886,20 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.6.5",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -1728,6 +1961,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1745,6 +1995,21 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "numtoa"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aa2c4e539b869820a2b82e1aef6ff40aa85e65decdd5185e83fb4b1249cd00f"
 
 [[package]]
 name = "oas3"
@@ -1837,6 +2102,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "os_pipe"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1876,12 +2150,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1907,6 +2175,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "pest"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
+dependencies = [
+ "memchr",
+ "thiserror 2.0.12",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1914,6 +2226,58 @@ checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
  "indexmap 2.9.0",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -1962,6 +2326,12 @@ checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2024,8 +2394,8 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
- "bit-set",
- "bit-vec",
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
  "bitflags 2.9.1",
  "lazy_static",
  "num-traits",
@@ -2066,7 +2436,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -2227,24 +2597,90 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.28.1"
+version = "0.30.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdef7f9be5c0122f890d58bdf4d964349ba6a6161f705907526d891efabba57d"
+checksum = "71365e96fb8f1350c02908e788815c5a57c0c1f557673b274a94edee7a4fe001"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-termion",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+ "serde",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0-alpha.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f836b2eac888da74162b680a8facdbe784ae73df3b0f711eef74bb90a7477f78"
 dependencies = [
  "bitflags 2.9.1",
- "cassowary",
  "compact_str",
- "crossterm",
- "instability",
- "itertools",
+ "hashbrown 0.15.3",
+ "indoc",
+ "itertools 0.14.0",
+ "kasuari",
  "lru",
- "paste",
  "serde",
- "strum",
- "strum_macros",
+ "strum 0.27.1",
+ "thiserror 2.0.12",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.0-alpha.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f4a90548bf8ed759d226d621d73561110db23aee7b7dc4e12c39ac7132062f"
+dependencies = [
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-termion"
+version = "0.1.0-alpha.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7185a3b43ee219d766d9e1c3420472d2b061adf86472c3d688697d07c3c6b93a"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "termion",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.0-alpha.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbb5d7645e56f06ead2a49a72b9cc05022f0b215ec7cdf39d37ed94e9a73d69"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0-alpha.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388428527811be6da3e23157d951308d9eae4ce1b4d1d545a55673bbcdfb7326"
+dependencies = [
+ "bitflags 2.9.1",
+ "hashbrown 0.15.3",
+ "indoc",
+ "instability",
+ "itertools 0.14.0",
+ "line-clipping",
+ "ratatui-core",
+ "serde",
+ "strum 0.27.1",
+ "time",
+ "unicode-segmentation",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -2255,6 +2691,12 @@ checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags 2.9.1",
 ]
+
+[[package]]
+name = "redox_termios"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20145670ba436b55d91fc92d25e71160fbfbdd57831631c8d7d36377a476f1cb"
 
 [[package]]
 name = "redox_users"
@@ -2451,19 +2893,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.9.1",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
@@ -2471,7 +2900,7 @@ dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
+ "linux-raw-sys",
  "windows-sys 0.59.0",
 ]
 
@@ -2736,6 +3165,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2787,6 +3227,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2822,7 +3268,7 @@ dependencies = [
  "dialoguer",
  "env-lock",
  "indexmap 2.9.0",
- "itertools",
+ "itertools 0.13.0",
  "predicates",
  "pretty_assertions",
  "reqwest",
@@ -2846,20 +3292,20 @@ name = "slumber_config"
 version = "3.2.0"
 dependencies = [
  "anyhow",
- "crossterm",
  "derive_more 1.0.0",
  "dirs",
  "editor-command",
  "env-lock",
  "glob",
  "indexmap 2.9.0",
- "itertools",
+ "itertools 0.13.0",
  "mime",
  "ratatui",
  "rstest",
  "serde",
  "serde_test",
  "slumber_util",
+ "terminput",
  "tracing",
 ]
 
@@ -2876,7 +3322,7 @@ dependencies = [
  "env-lock",
  "futures",
  "indexmap 2.9.0",
- "itertools",
+ "itertools 0.13.0",
  "mime",
  "pretty_assertions",
  "proptest",
@@ -2893,7 +3339,7 @@ dependencies = [
  "serde_yaml",
  "slumber_config",
  "slumber_util",
- "strum",
+ "strum 0.26.3",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -2911,7 +3357,7 @@ dependencies = [
  "derive_more 1.0.0",
  "futures",
  "indexmap 2.9.0",
- "itertools",
+ "itertools 0.13.0",
  "mime",
  "oas3",
  "openapiv3",
@@ -2925,7 +3371,7 @@ dependencies = [
  "serde_yaml",
  "slumber_core",
  "slumber_util",
- "strum",
+ "strum 0.26.3",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -2945,7 +3391,7 @@ dependencies = [
  "derive_more 1.0.0",
  "futures",
  "indexmap 2.9.0",
- "itertools",
+ "itertools 0.13.0",
  "mime",
  "notify",
  "notify-debouncer-full",
@@ -2961,7 +3407,9 @@ dependencies = [
  "slumber_config",
  "slumber_core",
  "slumber_util",
- "strum",
+ "strum 0.26.3",
+ "terminput",
+ "terminput-crossterm",
  "tokio",
  "tokio-util",
  "tracing",
@@ -3038,7 +3486,16 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+dependencies = [
+ "strum_macros 0.27.1",
 ]
 
 [[package]]
@@ -3046,6 +3503,19 @@ name = "strum_macros"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3111,8 +3581,61 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.7",
+ "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "terminput"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58cf4817f5ddfba01e35e0d4d310d6aeb345bad601e563ea7e5ee64ff0c7dd50"
+dependencies = [
+ "bitflags 2.9.1",
+]
+
+[[package]]
+name = "terminput-crossterm"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf84f76c20b685e026e8283023cb17a041b686f43666063e2727b3524d26f709"
+dependencies = [
+ "crossterm",
+ "terminput",
+]
+
+[[package]]
+name = "termion"
+version = "4.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3669a69de26799d6321a5aa713f55f7e2cd37bd47be044b50f2acafc42c122bb"
+dependencies = [
+ "libc",
+ "libredox",
+ "numtoa",
+ "redox_termios",
+ "serde",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3120,6 +3643,49 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bitflags 2.9.1",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix 0.29.0",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "serde",
+ "sha2",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
+]
 
 [[package]]
 name = "thiserror"
@@ -3170,6 +3736,27 @@ dependencies = [
  "cfg-if",
  "once_cell",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+dependencies = [
+ "deranged",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "tinystr"
@@ -3442,6 +4029,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3467,13 +4066,13 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-truncate"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+checksum = "8fbf03860ff438702f3910ca5f28f8dac63c1c11e7efb5012b8b175493606330"
 dependencies = [
- "itertools",
+ "itertools 0.13.0",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -3536,6 +4135,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
+ "atomic",
  "getrandom 0.3.3",
  "serde",
 ]
@@ -3551,6 +4151,21 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
 
 [[package]]
 name = "wait-timeout"
@@ -3675,7 +4290,7 @@ dependencies = [
  "bitflags 1.3.2",
  "downcast-rs",
  "libc",
- "nix",
+ "nix 0.24.3",
  "wayland-commons",
  "wayland-scanner",
  "wayland-sys",
@@ -3687,7 +4302,7 @@ version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8691f134d584a33a6606d9d717b95c4fa20065605f798a3f350d78dced02a902"
 dependencies = [
- "nix",
+ "nix 0.24.3",
  "once_cell",
  "smallvec",
  "wayland-sys",
@@ -3761,6 +4376,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.3",
+ "mac_address",
+ "serde",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
 ]
 
 [[package]]
@@ -4145,7 +4834,7 @@ dependencies = [
  "derive-new",
  "libc",
  "log",
- "nix",
+ "nix 0.24.3",
  "os_pipe",
  "tempfile",
  "thiserror 1.0.69",
@@ -4176,7 +4865,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "592b4883219f345e712b3209c62654ebda0bb50887f330cbd018d0f654bfd507"
 dependencies = [
  "gethostname",
- "nix",
+ "nix 0.24.3",
  "winapi",
  "winapi-wsapoll",
  "x11rb-protocol",
@@ -4188,7 +4877,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56b245751c0ac9db0e006dc812031482784e434630205a93c73cfefcaabeac67"
 dependencies = [
- "nix",
+ "nix 0.24.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ anyhow = "1.0.0"
 async-trait = "0.1.81"
 bytes = {version = "1.6.1", default-features = false}
 chrono = {version = "0.4.31", default-features = false}
-crossterm = {version = "0.28.0", default-features = false, features = ["events"]}
 derive_more = {version = "1.0.0", default-features = false}
 dialoguer = {version = "0.11.0", default-features = false}
 dirs = "5.0.1"
@@ -40,7 +39,7 @@ indexmap = {version = "2.0.0", default-features = false}
 itertools = "0.13.0"
 mime = "0.3.17"
 pretty_assertions = "1.4.0"
-ratatui = {version = "0.28.0", default-features = false}
+ratatui = {version = "0.30.0-alpha.5", default-features = false}
 reqwest = {version = "0.12.5", default-features = false}
 rstest = {version = "0.24.0", default-features = false}
 serde = {version = "1.0.204", default-features = false}
@@ -54,6 +53,7 @@ slumber_import = {path = "./crates/import", version = "3.2.0"}
 slumber_tui = {path = "./crates/tui", version = "3.2.0"}
 slumber_util = {path = "./crates/util", version = "3.2.0"}
 strum = {version = "0.26.3", default-features = false}
+terminput = "0.5.3"
 thiserror = "2.0.12"
 tokio = {version = "1.39.2", default-features = false}
 tracing = "0.1.40"

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -12,7 +12,6 @@ version = {workspace = true}
 
 [dependencies]
 anyhow = {workspace = true}
-crossterm = {workspace = true}
 derive_more = {workspace = true, features = ["deref", "display"]}
 editor-command = "1.0.0"
 glob = "0.3.2"
@@ -22,6 +21,7 @@ mime = {workspace = true}
 ratatui = {workspace = true, features = ["serde"]}
 serde = {workspace = true}
 slumber_util = {workspace = true}
+terminput = {workspace = true}
 tracing = {workspace = true}
 
 [dev-dependencies]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -17,14 +17,13 @@ mod input;
 mod mime;
 mod theme;
 
-pub use input::{Action, InputBinding, KeyCombination};
+pub use input::{Action, InputBinding, InputMap, KeyCombination};
 pub use theme::Theme;
 
 use crate::mime::MimeMap;
 use ::mime::Mime;
 use anyhow::Context;
 use editor_command::EditorBuilder;
-use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use slumber_util::{
     ResultTraced, doc_link, parse_yaml,
@@ -71,7 +70,7 @@ pub struct Config {
     /// raw text?
     pub preview_templates: bool,
     /// Overrides for default key bindings
-    pub input_bindings: IndexMap<Action, InputBinding>,
+    pub input_bindings: InputMap,
     /// Visual configuration for the TUI (e.g. colors)
     pub theme: Theme,
     /// Enable debug monitor in TUI

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -16,7 +16,7 @@ async-trait = {workspace = true}
 bytes = {workspace = true}
 chrono = {workspace = true}
 cli-clipboard = "0.4.0"
-crossterm = {workspace = true, features = ["bracketed-paste", "windows", "events", "event-stream"]}
+crossterm = {version = "0.29.0", default-features = false, features = ["bracketed-paste", "windows", "events", "event-stream"]}
 derive_more = {workspace = true, features = ["debug", "deref", "deref_mut", "display", "from"]}
 futures = {workspace = true}
 indexmap = {workspace = true}
@@ -35,6 +35,8 @@ slumber_config = {workspace = true}
 slumber_core = {workspace = true}
 slumber_util = {workspace = true}
 strum = {workspace = true}
+terminput = {workspace = true}
+terminput-crossterm = "0.3.3"
 tokio = {workspace = true, features = ["macros", "signal", "tracing"]}
 tokio-util = "0.7.13"
 tracing = {workspace = true}

--- a/crates/tui/src/message.rs
+++ b/crates/tui/src/message.rs
@@ -127,7 +127,7 @@ pub enum Message {
     /// User input from the terminal
     Input {
         /// Raw input event
-        event: crossterm::event::Event,
+        event: terminput::Event,
         /// Action mapped via input bindings. This is what most consumers use
         action: Option<Action>,
     },

--- a/crates/tui/src/view.rs
+++ b/crates/tui/src/view.rs
@@ -183,7 +183,7 @@ impl View {
     /// abstract action the input maps to.
     pub fn handle_input(
         &self,
-        event: crossterm::event::Event,
+        event: terminput::Event,
         action: Option<Action>,
     ) {
         ViewContext::push_event(Event::Input { event, action });

--- a/crates/tui/src/view/common/actions.rs
+++ b/crates/tui/src/view/common/actions.rs
@@ -207,9 +207,9 @@ mod tests {
         test_util::{TestHarness, TestTerminal, harness, terminal},
         view::test_util::TestComponent,
     };
-    use crossterm::event::KeyCode;
     use rstest::rstest;
     use strum::{EnumIter, IntoEnumIterator};
+    use terminput::KeyCode;
 
     /// A component that provides some actions
     #[derive(Default)]

--- a/crates/tui/src/view/common/modal.rs
+++ b/crates/tui/src/view/common/modal.rs
@@ -176,7 +176,7 @@ impl EventHandler for ModalQueue {
                 // background components
                 Event::Input {
                     action: _,
-                    event: crossterm::event::Event::Mouse(_),
+                    event: terminput::Event::Mouse(_),
                 } if self.is_open() => None,
 
                 // Open a new modal

--- a/crates/tui/src/view/common/table.rs
+++ b/crates/tui/src/view/common/table.rs
@@ -89,7 +89,7 @@ impl<'a, const COLS: usize> Generate for Table<'a, COLS, Row<'a>> {
             row.set_style(base_style.patch(row_style))
         });
         let mut table = ratatui::widgets::Table::new(rows, self.column_widths)
-            .highlight_style(styles.table.highlight);
+            .row_highlight_style(styles.table.highlight);
 
         // Add title
         if let Some(title) = self.title {

--- a/crates/tui/src/view/common/text_box.rs
+++ b/crates/tui/src/view/common/text_box.rs
@@ -9,7 +9,6 @@ use crate::{
         event::{Emitter, Event, EventHandler, OptionEvent, ToEmitter},
     },
 };
-use crossterm::event::{KeyCode, KeyModifiers};
 use persisted::PersistedContainer;
 use ratatui::{
     Frame,
@@ -19,6 +18,7 @@ use ratatui::{
 };
 use slumber_config::Action;
 use std::{cell::Cell, mem};
+use terminput::{KeyCode, KeyModifiers};
 
 /// Single line text submission component
 #[derive(derive_more::Debug, Default)]
@@ -132,7 +132,7 @@ impl TextBox {
             KeyCode::Backspace => self.state.delete_left(),
             KeyCode::Delete => self.state.delete_right(),
             KeyCode::Left => {
-                if modifiers == KeyModifiers::CONTROL {
+                if modifiers == KeyModifiers::CTRL {
                     self.state.home();
                 } else {
                     self.state.left();
@@ -140,7 +140,7 @@ impl TextBox {
                 false
             }
             KeyCode::Right => {
-                if modifiers == KeyModifiers::CONTROL {
+                if modifiers == KeyModifiers::CTRL {
                     self.state.end();
                 } else {
                     self.state.right();
@@ -192,7 +192,7 @@ impl EventHandler for TextBox {
             .any(|event| match event {
                 // Handle any other input as text
                 Event::Input {
-                    event: crossterm::event::Event::Key(key_event),
+                    event: terminput::Event::Key(key_event),
                     ..
                 } if self.handle_key(key_event.code, key_event.modifiers) => {
                     None
@@ -533,7 +533,7 @@ mod tests {
                 .send_key_modifiers(
                     // This is what crossterm actually sends
                     KeyCode::Char('W'),
-                    KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+                    KeyModifiers::CTRL | KeyModifiers::SHIFT,
                 )
                 .events(),
             &[Event::Input { .. }]

--- a/crates/tui/src/view/common/text_window.rs
+++ b/crates/tui/src/view/common/text_window.rs
@@ -285,9 +285,9 @@ mod tests {
         test_util::{TestHarness, TestTerminal, harness, terminal},
         view::test_util::TestComponent,
     };
-    use crossterm::event::{KeyCode, KeyModifiers};
     use ratatui::text::Span;
     use rstest::rstest;
+    use terminput::{KeyCode, KeyModifiers};
 
     #[rstest]
     fn test_scroll(

--- a/crates/tui/src/view/component/exchange_pane.rs
+++ b/crates/tui/src/view/component/exchange_pane.rs
@@ -27,7 +27,7 @@ use ratatui::{
     layout::{Alignment, Constraint, Layout},
     style::Style,
     text::{Line, Span},
-    widgets::{Paragraph, block::Title},
+    widgets::Paragraph,
 };
 use serde::{Deserialize, Serialize};
 use slumber_config::Action;
@@ -91,7 +91,7 @@ impl Draw for ExchangePane {
         // If a recipe is selected, history is available so show the hint
         if matches!(self.state, State::Content { .. }) {
             let text = input_engine.add_hint("History", Action::History);
-            block = block.title(Title::from(text).alignment(Alignment::Right));
+            block = block.title(Line::from(text).alignment(Alignment::Right));
         }
         frame.render_widget(&block, metadata.area());
         let area = block.inner(metadata.area());

--- a/crates/tui/src/view/component/footer.rs
+++ b/crates/tui/src/view/component/footer.rs
@@ -61,7 +61,7 @@ impl Draw for Footer {
         // Notifications are auto-cleared so it's ok to hide other stuff
         // temporarily
         if let Some(notification) = &self.notification {
-            frame.render_widget(&notification.message, metadata.area());
+            frame.render_widget(notification.message.as_str(), metadata.area());
             return;
         }
 

--- a/crates/tui/src/view/component/history.rs
+++ b/crates/tui/src/view/component/history.rs
@@ -213,11 +213,11 @@ mod tests {
         test_util::{TestHarness, TestTerminal, harness, terminal},
         view::test_util::TestComponent,
     };
-    use crossterm::event::KeyCode;
     use itertools::Itertools;
     use rstest::rstest;
     use slumber_core::http::Exchange;
     use slumber_util::{Factory, assert_matches};
+    use terminput::KeyCode;
 
     /// Test that we can browse requests, and selecting one updates root state
     #[rstest]

--- a/crates/tui/src/view/component/internal.rs
+++ b/crates/tui/src/view/component/internal.rs
@@ -8,16 +8,16 @@ use crate::view::{
     draw::{Draw, DrawMetadata},
     event::{Child, Emitter, Event, LocalEvent, ToChild, ToEmitter},
 };
-use crossterm::event::{
-    Event::{Key, Mouse, Paste},
-    MouseEvent,
-};
 use derive_more::Display;
 use ratatui::{Frame, layout::Rect};
 use std::{
     any,
     cell::{Cell, RefCell},
     collections::HashSet,
+};
+use terminput::{
+    Event::{Key, Mouse, Paste},
+    MouseEvent,
 };
 use tracing::{instrument, trace, trace_span, warn};
 use uuid::Uuid;
@@ -392,14 +392,14 @@ mod tests {
         test_util::{TestHarness, TestTerminal, harness, terminal},
         view::event::EventHandler,
     };
-    use crossterm::event::{
-        KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers,
-        MouseButton, MouseEventKind,
-    };
     use ratatui::layout::Layout;
     use rstest::{fixture, rstest};
     use slumber_config::Action;
     use slumber_util::assert_matches;
+    use terminput::{
+        KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers,
+        MouseButton, MouseEventKind,
+    };
 
     #[derive(Debug, Default)]
     struct Branch {
@@ -500,7 +500,7 @@ mod tests {
 
     fn keyboard_event() -> Event {
         Event::Input {
-            event: crossterm::event::Event::Key(KeyEvent {
+            event: terminput::Event::Key(KeyEvent {
                 code: KeyCode::Enter,
                 modifiers: KeyModifiers::NONE,
                 kind: KeyEventKind::Press,
@@ -512,7 +512,7 @@ mod tests {
 
     fn mouse_event((x, y): (u16, u16)) -> Event {
         Event::Input {
-            event: crossterm::event::Event::Mouse(MouseEvent {
+            event: terminput::Event::Mouse(MouseEvent {
                 kind: MouseEventKind::Down(MouseButton::Left),
                 column: x,
                 row: y,

--- a/crates/tui/src/view/component/primary.rs
+++ b/crates/tui/src/view/component/primary.rs
@@ -495,11 +495,11 @@ mod tests {
             test_util::TestComponent, util::persistence::DatabasePersistedStore,
         },
     };
-    use crossterm::event::KeyCode;
     use persisted::PersistedStore;
     use rstest::rstest;
     use slumber_core::http::BuildOptions;
     use slumber_util::assert_matches;
+    use terminput::KeyCode;
 
     /// Create component to be tested
     fn create_component<'term>(

--- a/crates/tui/src/view/component/queryable_body.rs
+++ b/crates/tui/src/view/component/queryable_body.rs
@@ -481,13 +481,13 @@ mod tests {
             util::persistence::{DatabasePersistedStore, PersistedLazy},
         },
     };
-    use crossterm::event::KeyCode;
     use persisted::{PersistedKey, PersistedStore};
     use ratatui::{layout::Margin, text::Span};
     use rstest::{fixture, rstest};
     use serde::Serialize;
     use slumber_core::http::{ResponseBody, ResponseRecord};
     use slumber_util::{Factory, TempDir, assert_matches, temp_dir};
+    use terminput::KeyCode;
     use tokio::fs;
 
     const TEXT: &str = "{\"greeting\":\"hello\"}";

--- a/crates/tui/src/view/component/recipe_list.rs
+++ b/crates/tui/src/view/component/recipe_list.rs
@@ -451,7 +451,6 @@ mod tests {
         test_util::{TestHarness, TestTerminal, terminal},
         view::test_util::TestComponent,
     };
-    use crossterm::event::KeyCode;
     use itertools::Itertools;
     use rstest::{fixture, rstest};
     use slumber_core::{
@@ -459,6 +458,7 @@ mod tests {
         test_util::by_id,
     };
     use slumber_util::{Factory, assert_matches};
+    use terminput::KeyCode;
 
     /// Test the filter box
     #[rstest]

--- a/crates/tui/src/view/component/recipe_pane/authentication.rs
+++ b/crates/tui/src/view/component/recipe_pane/authentication.rs
@@ -355,10 +355,10 @@ mod tests {
             test_util::TestComponent,
         },
     };
-    use crossterm::event::KeyCode;
     use persisted::PersistedStore;
     use rstest::rstest;
     use slumber_util::Factory;
+    use terminput::KeyCode;
 
     #[rstest]
     fn test_edit_basic(harness: TestHarness, terminal: TestTerminal) {

--- a/crates/tui/src/view/component/recipe_pane/body.rs
+++ b/crates/tui/src/view/component/recipe_pane/body.rs
@@ -359,7 +359,6 @@ mod tests {
             test_util::TestComponent,
         },
     };
-    use crossterm::event::KeyCode;
     use persisted::PersistedStore;
     use ratatui::{
         style::{Color, Styled},
@@ -368,6 +367,7 @@ mod tests {
     use rstest::rstest;
     use serde_json::json;
     use slumber_util::{Factory, assert_matches};
+    use terminput::KeyCode;
 
     /// Test editing a raw body, which should open a file for the user to edit,
     /// then load the response

--- a/crates/tui/src/view/component/recipe_pane/table.rs
+++ b/crates/tui/src/view/component/recipe_pane/table.rs
@@ -396,12 +396,12 @@ mod tests {
             test_util::TestComponent,
         },
     };
-    use crossterm::event::KeyCode;
     use persisted::PersistedStore;
     use rstest::rstest;
     use serde::Serialize;
     use slumber_core::collection::RecipeId;
     use slumber_util::Factory;
+    use terminput::KeyCode;
 
     #[derive(Debug, Serialize, persisted::PersistedKey)]
     #[persisted(Option<String>)]

--- a/crates/tui/src/view/component/response_view.rs
+++ b/crates/tui/src/view/component/response_view.rs
@@ -145,11 +145,11 @@ mod tests {
         test_util::{TestHarness, TestTerminal, harness, terminal},
         view::test_util::TestComponent,
     };
-    use crossterm::event::KeyCode;
     use indexmap::indexmap;
     use rstest::rstest;
     use slumber_core::{http::Exchange, test_util::header_map};
     use slumber_util::{Factory, assert_matches};
+    use terminput::KeyCode;
 
     /// Test "Copy Body" menu action
     #[rstest]

--- a/crates/tui/src/view/component/root.rs
+++ b/crates/tui/src/view/component/root.rs
@@ -293,7 +293,6 @@ mod tests {
             test_util::TestComponent, util::persistence::DatabasePersistedStore,
         },
     };
-    use crossterm::event::KeyCode;
     use persisted::PersistedStore;
     use rstest::rstest;
     use slumber_core::{
@@ -302,6 +301,7 @@ mod tests {
         test_util::by_id,
     };
     use slumber_util::Factory;
+    use terminput::KeyCode;
 
     /// Test that, on first render, the view loads the most recent historical
     /// request for the first recipe+profile

--- a/crates/tui/src/view/event.rs
+++ b/crates/tui/src/view/event.rs
@@ -238,7 +238,7 @@ pub enum Event {
     /// Input from the user, which may or may not correspond to a bound action.
     /// Most components just care about the action, but some require raw input
     Input {
-        event: crossterm::event::Event,
+        event: terminput::Event,
         action: Option<Action>,
     },
 

--- a/crates/tui/src/view/state/select.rs
+++ b/crates/tui/src/view/state/select.rs
@@ -487,13 +487,13 @@ mod tests {
             util::persistence::{DatabasePersistedStore, PersistedLazy},
         },
     };
-    use crossterm::event::KeyCode;
     use persisted::{PersistedKey, PersistedStore};
     use ratatui::widgets::List;
     use rstest::{fixture, rstest};
     use serde::Serialize;
     use slumber_core::collection::ProfileId;
     use slumber_util::assert_matches;
+    use terminput::KeyCode;
 
     /// Test going up and down in the list
     #[rstest]

--- a/crates/tui/src/view/test_util.rs
+++ b/crates/tui/src/view/test_util.rs
@@ -19,14 +19,14 @@ use crate::{
         },
     },
 };
-use crossterm::event::{
-    KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseButton,
-    MouseEvent, MouseEventKind,
-};
 use itertools::Itertools;
 use ratatui::{Frame, layout::Rect};
 use slumber_config::Action;
 use std::{cell::RefCell, iter, rc::Rc};
+use terminput::{
+    KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseButton,
+    MouseEvent, MouseEventKind,
+};
 
 /// A wrapper around a component that makes it easy to test. This provides lots
 /// of methods for sending events to the component. The goal is to make
@@ -297,10 +297,10 @@ where
     /// Push a terminal input event onto the event queue, then drain events and
     /// draw. This will include the bound action for the event, based on the key
     /// code or mouse button. See [Self::update_draw] about return value.
-    pub fn send_input(self, crossterm_event: crossterm::event::Event) -> Self {
-        let action = TuiContext::get().input_engine.action(&crossterm_event);
+    pub fn send_input(self, terminal_event: terminput::Event) -> Self {
+        let action = TuiContext::get().input_engine.action(&terminal_event);
         let event = Event::Input {
-            event: crossterm_event,
+            event: terminal_event,
             action,
         };
         self.update_draw(event)
@@ -309,7 +309,7 @@ where
     /// Simulate a left click at the given location, then drain events and draw.
     /// See [Self::update_draw] about return value.
     pub fn click(self, x: u16, y: u16) -> Self {
-        let crossterm_event = crossterm::event::Event::Mouse(MouseEvent {
+        let crossterm_event = terminput::Event::Mouse(MouseEvent {
             kind: MouseEventKind::Up(MouseButton::Left),
             column: x,
             row: y,
@@ -332,7 +332,7 @@ where
         code: KeyCode,
         modifiers: KeyModifiers,
     ) -> Self {
-        let crossterm_event = crossterm::event::Event::Key(KeyEvent {
+        let crossterm_event = terminput::Event::Key(KeyEvent {
             code,
             modifiers,
             kind: KeyEventKind::Press,

--- a/docs/src/api/configuration/input_bindings.md
+++ b/docs/src/api/configuration/input_bindings.md
@@ -31,46 +31,46 @@ input_bindings:
 
 ## Actions
 
-| Action                | Default Binding             | Description                                           |
-| --------------------- | --------------------------- | ----------------------------------------------------- |
-| `left_click`          | None                        |                                                       |
-| `right_click`         | None                        |                                                       |
-| `scroll_up`           | None                        |                                                       |
-| `scroll_down`         | None                        |                                                       |
-| `scroll_left`         | `shift left`                |                                                       |
-| `scroll_right`        | `shift right`               |                                                       |
-| `quit`                | `q`                         | Exit current dialog, or the entire app                |
-| `force_quit`          | `ctrl c`                    | Exit the app, regardless                              |
-| `previous_pane`       | `backtab` (AKA `shift tab`) | Select previous pane in the cycle                     |
-| `next_pane`           | `tab`                       |                                                       |
-| `up`                  | `up`                        |                                                       |
-| `down`                | `down`                      |                                                       |
-| `left`                | `left`                      |                                                       |
-| `right`               | `right`                     |                                                       |
-| `page_up`             | `pgup`                      |                                                       |
-| `page_down`           | `pgdn`                      |                                                       |
-| `home`                | `home`                      |                                                       |
-| `end`                 | `end`                       |                                                       |
-| `submit`              | `enter`                     | Send a request, submit a text box, etc.               |
-| `toggle`              | `space`                     | Toggle a checkbox on/off                              |
-| `cancel`              | `esc`                       | Cancel current dialog or request                      |
-| `delete`              | `delete`                    | Delete the selected object (e.g. a request)           |
-| `edit`                | `e`                         | Apply a temporary override to a recipe value          |
-| `reset`               | `r`                         | Reset temporary recipe override to its default        |
-| `view`                | `v`                         | Open the selected content (e.g. body) in your pager   |
-| `history`             | `h`                         | Open request history for a recipe                     |
-| `search`              | `/`                         | Open/select search for current pane                   |
-| `export`              | `:`                         | Enter command for exporting response data             |
-| `reload_collection`   | `f5`                        | Force reload collection file                          |
-| `fullscreen`          | `f`                         | Fullscreen current pane                               |
-| `open_actions`        | `x`                         | Open actions menu                                     |
-| `open_help`           | `?`                         | Open help dialog                                      |
-| `select_collection`   | `f3`                        | Open collection select dialog                         |
-| `select_profile_list` | `p`                         | Open Profile List dialog                              |
-| `select_recipe_list`  | `l`                         | Select Recipe List pane                               |
-| `select_recipe`       | `c`                         | Select Recipe pane                                    |
-| `select_response`     | `s`                         | Select Request/Response pane                          |
-| `select_request`      | `r`                         | Select Request/Response pane (backward compatibility) |
+| Action                | Default Binding | Description                                           |
+| --------------------- | --------------- | ----------------------------------------------------- |
+| `left_click`          | None            |                                                       |
+| `right_click`         | None            |                                                       |
+| `scroll_up`           | None            |                                                       |
+| `scroll_down`         | None            |                                                       |
+| `scroll_left`         | `shift left`    |                                                       |
+| `scroll_right`        | `shift right`   |                                                       |
+| `quit`                | `q`             | Exit current dialog, or the entire app                |
+| `force_quit`          | `ctrl c`        | Exit the app, regardless                              |
+| `previous_pane`       | `shift tab`     | Select previous pane in the cycle                     |
+| `next_pane`           | `tab`           |                                                       |
+| `up`                  | `up`            |                                                       |
+| `down`                | `down`          |                                                       |
+| `left`                | `left`          |                                                       |
+| `right`               | `right`         |                                                       |
+| `page_up`             | `pgup`          |                                                       |
+| `page_down`           | `pgdn`          |                                                       |
+| `home`                | `home`          |                                                       |
+| `end`                 | `end`           |                                                       |
+| `submit`              | `enter`         | Send a request, submit a text box, etc.               |
+| `toggle`              | `space`         | Toggle a checkbox on/off                              |
+| `cancel`              | `esc`           | Cancel current dialog or request                      |
+| `delete`              | `delete`        | Delete the selected object (e.g. a request)           |
+| `edit`                | `e`             | Apply a temporary override to a recipe value          |
+| `reset`               | `r`             | Reset temporary recipe override to its default        |
+| `view`                | `v`             | Open the selected content (e.g. body) in your pager   |
+| `history`             | `h`             | Open request history for a recipe                     |
+| `search`              | `/`             | Open/select search for current pane                   |
+| `export`              | `:`             | Enter command for exporting response data             |
+| `reload_collection`   | `f5`            | Force reload collection file                          |
+| `fullscreen`          | `f`             | Fullscreen current pane                               |
+| `open_actions`        | `x`             | Open actions menu                                     |
+| `open_help`           | `?`             | Open help dialog                                      |
+| `select_collection`   | `f3`            | Open collection select dialog                         |
+| `select_profile_list` | `p`             | Open Profile List dialog                              |
+| `select_recipe_list`  | `l`             | Select Recipe List pane                               |
+| `select_recipe`       | `c`             | Select Recipe pane                                    |
+| `select_response`     | `s`             | Select Request/Response pane                          |
+| `select_request`      | `r`             | Select Request/Response pane (backward compatibility) |
 
 > Note: mouse bindings are not configurable; mouse actions such as `left_click` _can_ be bound to a key combination, which cannot be unbound from the default mouse action.
 
@@ -98,7 +98,7 @@ All single-character keys (e.g. `w`, `/`, `=`, etc.) are not listed; the code is
 - `pageup`/`pgup`
 - `pagedown`/`pgdn`
 - `tab`
-- `backtab`
+- `backtab` (equivalent to `shift tab`, supported for backward compatibility)
 - `backspace`
 - `delete`/`del`
 - `insert`/`ins`


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

- Use `terminput` in `slumber_config` to eliminate the direct dependency on `crossterm` there
  - `crossterm` is still pulled in by `ratatui`, there's more work to be done
- Move input defaults into the config crate so the big lists are all in one place

This brings us a step closer to making stuff backend-agnostic, which is necessary to run in the web

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Another dependency may increase compile time

## QA

_How did you test this?_

Unit tests, manually ran tui locally

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
