### PR TITLE
Inline Ratatui::Color into config crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,9 +301,6 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "block"
@@ -495,7 +492,6 @@ dependencies = [
  "itoa",
  "rustversion",
  "ryu",
- "serde",
  "static_assertions",
 ]
 
@@ -623,7 +619,6 @@ dependencies = [
  "mio",
  "parking_lot",
  "rustix",
- "serde",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -2006,12 +2001,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "numtoa"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aa2c4e539b869820a2b82e1aef6ff40aa85e65decdd5185e83fb4b1249cd00f"
-
-[[package]]
 name = "oas3"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2604,10 +2593,8 @@ dependencies = [
  "instability",
  "ratatui-core",
  "ratatui-crossterm",
- "ratatui-termion",
  "ratatui-termwiz",
  "ratatui-widgets",
- "serde",
 ]
 
 [[package]]
@@ -2623,7 +2610,6 @@ dependencies = [
  "itertools 0.14.0",
  "kasuari",
  "lru",
- "serde",
  "strum 0.27.1",
  "thiserror 2.0.12",
  "unicode-segmentation",
@@ -2640,17 +2626,6 @@ dependencies = [
  "crossterm",
  "instability",
  "ratatui-core",
-]
-
-[[package]]
-name = "ratatui-termion"
-version = "0.1.0-alpha.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7185a3b43ee219d766d9e1c3420472d2b061adf86472c3d688697d07c3c6b93a"
-dependencies = [
- "instability",
- "ratatui-core",
- "termion",
 ]
 
 [[package]]
@@ -2676,7 +2651,6 @@ dependencies = [
  "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
- "serde",
  "strum 0.27.1",
  "time",
  "unicode-segmentation",
@@ -2691,12 +2665,6 @@ checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags 2.9.1",
 ]
-
-[[package]]
-name = "redox_termios"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20145670ba436b55d91fc92d25e71160fbfbdd57831631c8d7d36377a476f1cb"
 
 [[package]]
 name = "redox_users"
@@ -3300,7 +3268,6 @@ dependencies = [
  "indexmap 2.9.0",
  "itertools 0.13.0",
  "mime",
- "ratatui",
  "rstest",
  "serde",
  "serde_test",
@@ -3617,19 +3584,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termion"
-version = "4.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3669a69de26799d6321a5aa713f55f7e2cd37bd47be044b50f2acafc42c122bb"
-dependencies = [
- "libc",
- "libredox",
- "numtoa",
- "redox_termios",
- "serde",
-]
-
-[[package]]
 name = "termios"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3669,7 +3623,6 @@ dependencies = [
  "pest",
  "pest_derive",
  "phf",
- "serde",
  "sha2",
  "signal-hook",
  "siphasher",
@@ -4396,7 +4349,6 @@ checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
 dependencies = [
  "getrandom 0.3.3",
  "mac_address",
- "serde",
  "sha2",
  "thiserror 1.0.69",
  "uuid",
@@ -4411,7 +4363,6 @@ dependencies = [
  "csscolorparser",
  "deltae",
  "lazy_static",
- "serde",
  "wezterm-dynamic",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ indexmap = {version = "2.0.0", default-features = false}
 itertools = "0.13.0"
 mime = "0.3.17"
 pretty_assertions = "1.4.0"
-ratatui = {version = "0.30.0-alpha.5", default-features = false}
 reqwest = {version = "0.12.5", default-features = false}
 rstest = {version = "0.24.0", default-features = false}
 serde = {version = "1.0.204", default-features = false}

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -18,8 +18,7 @@ glob = "0.3.2"
 indexmap = {workspace = true, features = ["serde"]}
 itertools = {workspace = true}
 mime = {workspace = true}
-ratatui = {workspace = true, features = ["serde"]}
-serde = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
 slumber_util = {workspace = true}
 terminput = {workspace = true}
 tracing = {workspace = true}

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -18,7 +18,7 @@ mod mime;
 mod theme;
 
 pub use input::{Action, InputBinding, InputMap, KeyCombination};
-pub use theme::Theme;
+pub use theme::{Color, Theme};
 
 use crate::mime::MimeMap;
 use ::mime::Mime;

--- a/crates/config/src/theme.rs
+++ b/crates/config/src/theme.rs
@@ -1,5 +1,5 @@
-use ratatui::style::Color;
 use serde::{Deserialize, Serialize};
+use std::{fmt, str::FromStr};
 
 /// User-configurable visual settings. These are used to generate the full style
 /// set.
@@ -27,5 +27,441 @@ impl Default for Theme {
             success_color: Color::Green,
             error_color: Color::Red,
         }
+    }
+}
+
+/// ANSI Color
+///
+/// # Source
+///
+/// This struct was copied from [Ratatui](https://github.com/ratatui/ratatui/blob/v0.28.1/src/style/color.rs).
+/// Inlining it allows us to eliminate Ratatui as dependency for the config
+/// (and subsequently the CLI) crate.
+///
+/// All colors from the [ANSI color table] are supported (though some names are
+/// not exactly the same).
+///
+/// | Color Name     | Color                   | Foreground | Background |
+/// |----------------|-------------------------|------------|------------|
+/// | `black`        | [`Color::Black`]        | 30         | 40         |
+/// | `red`          | [`Color::Red`]          | 31         | 41         |
+/// | `green`        | [`Color::Green`]        | 32         | 42         |
+/// | `yellow`       | [`Color::Yellow`]       | 33         | 43         |
+/// | `blue`         | [`Color::Blue`]         | 34         | 44         |
+/// | `magenta`      | [`Color::Magenta`]      | 35         | 45         |
+/// | `cyan`         | [`Color::Cyan`]         | 36         | 46         |
+/// | `gray`*        | [`Color::Gray`]         | 37         | 47         |
+/// | `darkgray`*    | [`Color::DarkGray`]     | 90         | 100        |
+/// | `lightred`     | [`Color::LightRed`]     | 91         | 101        |
+/// | `lightgreen`   | [`Color::LightGreen`]   | 92         | 102        |
+/// | `lightyellow`  | [`Color::LightYellow`]  | 93         | 103        |
+/// | `lightblue`    | [`Color::LightBlue`]    | 94         | 104        |
+/// | `lightmagenta` | [`Color::LightMagenta`] | 95         | 105        |
+/// | `lightcyan`    | [`Color::LightCyan`]    | 96         | 106        |
+/// | `white`*       | [`Color::White`]        | 97         | 107        |
+///
+/// - `gray` is sometimes called `white` - this is not supported as we use
+///   `white` for bright white
+/// - `gray` is sometimes called `silver` - this is supported
+/// - `darkgray` is sometimes called `light black` or `bright black` (both are
+///   supported)
+/// - `white` is sometimes called `light white` or `bright white` (both are
+///   supported)
+/// - we support `bright` and `light` prefixes for all colors
+/// - we support `-` and `_` and ` ` as separators for all colors
+/// - we support both `gray` and `grey` spellings
+///
+/// `From<Color> for Style` is implemented by creating a style with the
+/// foreground color set to the given color. This allows you to use colors
+/// anywhere that accepts `Into<Style>`.
+///
+/// # Example
+///
+/// ```
+/// use slumber_config::Color;
+/// use std::str::FromStr;
+///
+/// assert_eq!(Color::from_str("red"), Ok(Color::Red));
+/// assert_eq!("red".parse(), Ok(Color::Red));
+/// assert_eq!("lightred".parse(), Ok(Color::LightRed));
+/// assert_eq!("light red".parse(), Ok(Color::LightRed));
+/// assert_eq!("light-red".parse(), Ok(Color::LightRed));
+/// assert_eq!("light_red".parse(), Ok(Color::LightRed));
+/// assert_eq!("lightRed".parse(), Ok(Color::LightRed));
+/// assert_eq!("bright red".parse(), Ok(Color::LightRed));
+/// assert_eq!("bright-red".parse(), Ok(Color::LightRed));
+/// assert_eq!("silver".parse(), Ok(Color::Gray));
+/// assert_eq!("dark-grey".parse(), Ok(Color::DarkGray));
+/// assert_eq!("dark gray".parse(), Ok(Color::DarkGray));
+/// assert_eq!("light-black".parse(), Ok(Color::DarkGray));
+/// assert_eq!("white".parse(), Ok(Color::White));
+/// assert_eq!("bright white".parse(), Ok(Color::White));
+/// ```
+///
+/// [ANSI color table]: https://en.wikipedia.org/wiki/ANSI_escape_code#Colors
+#[derive(
+    Debug, Default, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize,
+)]
+#[serde(into = "String", try_from = "String")]
+pub enum Color {
+    /// Resets the foreground or background color
+    #[default]
+    Reset,
+    /// ANSI Color: Black. Foreground: 30, Background: 40
+    Black,
+    /// ANSI Color: Red. Foreground: 31, Background: 41
+    Red,
+    /// ANSI Color: Green. Foreground: 32, Background: 42
+    Green,
+    /// ANSI Color: Yellow. Foreground: 33, Background: 43
+    Yellow,
+    /// ANSI Color: Blue. Foreground: 34, Background: 44
+    Blue,
+    /// ANSI Color: Magenta. Foreground: 35, Background: 45
+    Magenta,
+    /// ANSI Color: Cyan. Foreground: 36, Background: 46
+    Cyan,
+    /// ANSI Color: White. Foreground: 37, Background: 47
+    ///
+    /// Note that this is sometimes called `silver` or `white` but we use
+    /// `white` for bright white
+    Gray,
+    /// ANSI Color: Bright Black. Foreground: 90, Background: 100
+    ///
+    /// Note that this is sometimes called `light black` or `bright black` but
+    /// we use `dark gray`
+    DarkGray,
+    /// ANSI Color: Bright Red. Foreground: 91, Background: 101
+    LightRed,
+    /// ANSI Color: Bright Green. Foreground: 92, Background: 102
+    LightGreen,
+    /// ANSI Color: Bright Yellow. Foreground: 93, Background: 103
+    LightYellow,
+    /// ANSI Color: Bright Blue. Foreground: 94, Background: 104
+    LightBlue,
+    /// ANSI Color: Bright Magenta. Foreground: 95, Background: 105
+    LightMagenta,
+    /// ANSI Color: Bright Cyan. Foreground: 96, Background: 106
+    LightCyan,
+    /// ANSI Color: Bright White. Foreground: 97, Background: 107
+    /// Sometimes called `bright white` or `light white` in some terminals
+    White,
+    /// An RGB color.
+    ///
+    /// Note that only terminals that support 24-bit true color will display
+    /// this correctly. Notably versions of Windows Terminal prior to
+    /// Windows 10 and macOS Terminal.app do not support this.
+    ///
+    /// If the terminal does not support true color, code using the
+    /// [`TermwizBackend`] will fallback to the default text color.
+    /// Crossterm and Termion do not have this capability and the display
+    /// will be unpredictable (e.g. Terminal.app may display glitched blinking
+    /// text). See <https://github.com/ratatui/ratatui/issues/475> for an example of this problem.
+    ///
+    /// See also: <https://en.wikipedia.org/wiki/ANSI_escape_code#24-bit>
+    ///
+    /// [`TermwizBackend`]: crate::backend::TermwizBackend
+    Rgb(u8, u8, u8),
+    /// An 8-bit 256 color.
+    ///
+    /// See also <https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit>
+    Indexed(u8),
+}
+
+/// Error type indicating a failure to parse a color string.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub struct ParseColorError;
+
+impl fmt::Display for ParseColorError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Failed to parse color")
+    }
+}
+
+impl std::error::Error for ParseColorError {}
+
+/// Converts a string representation to a `Color` instance.
+///
+/// The `from_str` function attempts to parse the given string and convert it to
+/// the corresponding `Color` variant. It supports named colors, RGB values, and
+/// indexed colors. If the string cannot be parsed, a `ParseColorError` is
+/// returned.
+///
+/// See the [`Color`] documentation for more information on the supported color
+/// names.
+///
+/// # Examples
+///
+/// ```
+/// use slumber_config::Color;
+/// use std::str::FromStr;
+///
+/// let color: Color = Color::from_str("blue").unwrap();
+/// assert_eq!(color, Color::Blue);
+///
+/// let color: Color = Color::from_str("#FF0000").unwrap();
+/// assert_eq!(color, Color::Rgb(255, 0, 0));
+///
+/// let color: Color = Color::from_str("10").unwrap();
+/// assert_eq!(color, Color::Indexed(10));
+///
+/// let color: Result<Color, _> = Color::from_str("invalid_color");
+/// assert!(color.is_err());
+/// ```
+impl FromStr for Color {
+    type Err = ParseColorError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(
+            // There is a mix of different color names and formats in the wild.
+            // This is an attempt to support as many as possible.
+            match s
+                .to_lowercase()
+                .replace([' ', '-', '_'], "")
+                .replace("bright", "light")
+                .replace("grey", "gray")
+                .replace("silver", "gray")
+                .replace("lightblack", "darkgray")
+                .replace("lightwhite", "white")
+                .replace("lightgray", "white")
+                .as_ref()
+            {
+                "reset" => Self::Reset,
+                "black" => Self::Black,
+                "red" => Self::Red,
+                "green" => Self::Green,
+                "yellow" => Self::Yellow,
+                "blue" => Self::Blue,
+                "magenta" => Self::Magenta,
+                "cyan" => Self::Cyan,
+                "gray" => Self::Gray,
+                "darkgray" => Self::DarkGray,
+                "lightred" => Self::LightRed,
+                "lightgreen" => Self::LightGreen,
+                "lightyellow" => Self::LightYellow,
+                "lightblue" => Self::LightBlue,
+                "lightmagenta" => Self::LightMagenta,
+                "lightcyan" => Self::LightCyan,
+                "white" => Self::White,
+                _ => {
+                    if let Ok(index) = s.parse::<u8>() {
+                        Self::Indexed(index)
+                    } else if let Some((r, g, b)) = parse_hex_color(s) {
+                        Self::Rgb(r, g, b)
+                    } else {
+                        return Err(ParseColorError);
+                    }
+                }
+            },
+        )
+    }
+}
+
+fn parse_hex_color(input: &str) -> Option<(u8, u8, u8)> {
+    if !input.starts_with('#') || input.len() != 7 {
+        return None;
+    }
+    let r = u8::from_str_radix(input.get(1..3)?, 16).ok()?;
+    let g = u8::from_str_radix(input.get(3..5)?, 16).ok()?;
+    let b = u8::from_str_radix(input.get(5..7)?, 16).ok()?;
+    Some((r, g, b))
+}
+
+impl fmt::Display for Color {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Reset => write!(f, "Reset"),
+            Self::Black => write!(f, "Black"),
+            Self::Red => write!(f, "Red"),
+            Self::Green => write!(f, "Green"),
+            Self::Yellow => write!(f, "Yellow"),
+            Self::Blue => write!(f, "Blue"),
+            Self::Magenta => write!(f, "Magenta"),
+            Self::Cyan => write!(f, "Cyan"),
+            Self::Gray => write!(f, "Gray"),
+            Self::DarkGray => write!(f, "DarkGray"),
+            Self::LightRed => write!(f, "LightRed"),
+            Self::LightGreen => write!(f, "LightGreen"),
+            Self::LightYellow => write!(f, "LightYellow"),
+            Self::LightBlue => write!(f, "LightBlue"),
+            Self::LightMagenta => write!(f, "LightMagenta"),
+            Self::LightCyan => write!(f, "LightCyan"),
+            Self::White => write!(f, "White"),
+            Self::Rgb(r, g, b) => write!(f, "#{r:02X}{g:02X}{b:02X}"),
+            Self::Indexed(i) => write!(f, "{i}"),
+        }
+    }
+}
+
+// For serialization
+impl From<Color> for String {
+    fn from(color: Color) -> Self {
+        color.to_string()
+    }
+}
+
+// For deserialization
+impl TryFrom<String> for Color {
+    type Error = <Self as FromStr>::Err;
+
+    fn try_from(color: String) -> Result<Self, Self::Error> {
+        color.parse()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::de::{Deserialize, IntoDeserializer};
+    use std::error::Error;
+
+    #[test]
+    fn from_rgb_color() {
+        let color: Color = Color::from_str("#FF0000").unwrap();
+        assert_eq!(color, Color::Rgb(255, 0, 0));
+    }
+
+    #[test]
+    fn from_indexed_color() {
+        let color: Color = Color::from_str("10").unwrap();
+        assert_eq!(color, Color::Indexed(10));
+    }
+
+    #[test]
+    fn from_ansi_color() -> Result<(), Box<dyn Error>> {
+        assert_eq!(Color::from_str("reset")?, Color::Reset);
+        assert_eq!(Color::from_str("black")?, Color::Black);
+        assert_eq!(Color::from_str("red")?, Color::Red);
+        assert_eq!(Color::from_str("green")?, Color::Green);
+        assert_eq!(Color::from_str("yellow")?, Color::Yellow);
+        assert_eq!(Color::from_str("blue")?, Color::Blue);
+        assert_eq!(Color::from_str("magenta")?, Color::Magenta);
+        assert_eq!(Color::from_str("cyan")?, Color::Cyan);
+        assert_eq!(Color::from_str("gray")?, Color::Gray);
+        assert_eq!(Color::from_str("darkgray")?, Color::DarkGray);
+        assert_eq!(Color::from_str("lightred")?, Color::LightRed);
+        assert_eq!(Color::from_str("lightgreen")?, Color::LightGreen);
+        assert_eq!(Color::from_str("lightyellow")?, Color::LightYellow);
+        assert_eq!(Color::from_str("lightblue")?, Color::LightBlue);
+        assert_eq!(Color::from_str("lightmagenta")?, Color::LightMagenta);
+        assert_eq!(Color::from_str("lightcyan")?, Color::LightCyan);
+        assert_eq!(Color::from_str("white")?, Color::White);
+
+        // aliases
+        assert_eq!(Color::from_str("lightblack")?, Color::DarkGray);
+        assert_eq!(Color::from_str("lightwhite")?, Color::White);
+        assert_eq!(Color::from_str("lightgray")?, Color::White);
+
+        // silver = grey = gray
+        assert_eq!(Color::from_str("grey")?, Color::Gray);
+        assert_eq!(Color::from_str("silver")?, Color::Gray);
+
+        // spaces are ignored
+        assert_eq!(Color::from_str("light black")?, Color::DarkGray);
+        assert_eq!(Color::from_str("light white")?, Color::White);
+        assert_eq!(Color::from_str("light gray")?, Color::White);
+
+        // dashes are ignored
+        assert_eq!(Color::from_str("light-black")?, Color::DarkGray);
+        assert_eq!(Color::from_str("light-white")?, Color::White);
+        assert_eq!(Color::from_str("light-gray")?, Color::White);
+
+        // underscores are ignored
+        assert_eq!(Color::from_str("light_black")?, Color::DarkGray);
+        assert_eq!(Color::from_str("light_white")?, Color::White);
+        assert_eq!(Color::from_str("light_gray")?, Color::White);
+
+        // bright = light
+        assert_eq!(Color::from_str("bright-black")?, Color::DarkGray);
+        assert_eq!(Color::from_str("bright-white")?, Color::White);
+
+        // bright = light
+        assert_eq!(Color::from_str("brightblack")?, Color::DarkGray);
+        assert_eq!(Color::from_str("brightwhite")?, Color::White);
+
+        Ok(())
+    }
+
+    #[test]
+    fn from_invalid_colors() {
+        let bad_colors = [
+            "invalid_color", // not a color string
+            "abcdef0",       // 7 chars is not a color
+            " bcdefa",       // doesn't start with a '#'
+            "#abcdef00",     // too many chars
+            "#1🦀2",         // len 7 but on char boundaries shouldnt panic
+            "resett",        // typo
+            "lightblackk",   // typo
+        ];
+
+        for bad_color in bad_colors {
+            assert!(
+                Color::from_str(bad_color).is_err(),
+                "bad color: '{bad_color}'"
+            );
+        }
+    }
+
+    #[test]
+    fn display() {
+        assert_eq!(format!("{}", Color::Black), "Black");
+        assert_eq!(format!("{}", Color::Red), "Red");
+        assert_eq!(format!("{}", Color::Green), "Green");
+        assert_eq!(format!("{}", Color::Yellow), "Yellow");
+        assert_eq!(format!("{}", Color::Blue), "Blue");
+        assert_eq!(format!("{}", Color::Magenta), "Magenta");
+        assert_eq!(format!("{}", Color::Cyan), "Cyan");
+        assert_eq!(format!("{}", Color::Gray), "Gray");
+        assert_eq!(format!("{}", Color::DarkGray), "DarkGray");
+        assert_eq!(format!("{}", Color::LightRed), "LightRed");
+        assert_eq!(format!("{}", Color::LightGreen), "LightGreen");
+        assert_eq!(format!("{}", Color::LightYellow), "LightYellow");
+        assert_eq!(format!("{}", Color::LightBlue), "LightBlue");
+        assert_eq!(format!("{}", Color::LightMagenta), "LightMagenta");
+        assert_eq!(format!("{}", Color::LightCyan), "LightCyan");
+        assert_eq!(format!("{}", Color::White), "White");
+        assert_eq!(format!("{}", Color::Indexed(10)), "10");
+        assert_eq!(format!("{}", Color::Rgb(255, 0, 0)), "#FF0000");
+        assert_eq!(format!("{}", Color::Reset), "Reset");
+    }
+
+    #[test]
+    fn deserialize() -> Result<(), serde::de::value::Error> {
+        assert_eq!(
+            Color::Black,
+            Color::deserialize("Black".into_deserializer())?
+        );
+        assert_eq!(
+            Color::Magenta,
+            Color::deserialize("magenta".into_deserializer())?
+        );
+        assert_eq!(
+            Color::LightGreen,
+            Color::deserialize("LightGreen".into_deserializer())?
+        );
+        assert_eq!(
+            Color::White,
+            Color::deserialize("bright-white".into_deserializer())?
+        );
+        assert_eq!(
+            Color::Indexed(42),
+            Color::deserialize("42".into_deserializer())?
+        );
+        assert_eq!(
+            Color::Rgb(0, 255, 0),
+            Color::deserialize("#00ff00".into_deserializer())?
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn deserialize_error() {
+        let color: Result<_, serde::de::value::Error> =
+            Color::deserialize("invalid".into_deserializer());
+        assert!(color.is_err());
+
+        let color: Result<_, serde::de::value::Error> =
+            Color::deserialize("#00000000".into_deserializer());
+        assert!(color.is_err());
     }
 }

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -25,7 +25,7 @@ mime = {workspace = true}
 notify = {version = "8.0.0", default-features = false, features = ["macos_fsevent"]}
 notify-debouncer-full = {version = "0.5.0", default-features = false}
 persisted = "1.0.0"
-ratatui = {workspace = true, features = ["crossterm", "underline-color", "unstable-widget-ref"]}
+ratatui = {version = "0.30.0-alpha.5", default-features = false, features = ["crossterm", "underline-color", "unstable-widget-ref"]}
 reqwest = {workspace = true}
 serde = {workspace = true}
 serde_json = {workspace = true}

--- a/crates/tui/src/view/styles.rs
+++ b/crates/tui/src/view/styles.rs
@@ -1,3 +1,4 @@
+use crate::view::util::IntoRatatui;
 use ratatui::{
     style::{Color, Modifier, Style},
     widgets::BorderType,
@@ -133,8 +134,8 @@ impl Styles {
         Self {
             list: ListStyles {
                 highlight: Style::default()
-                    .bg(theme.primary_color)
-                    .fg(theme.primary_text_color)
+                    .bg(theme.primary_color.rat())
+                    .fg(theme.primary_text_color.rat())
                     .add_modifier(Modifier::BOLD),
                 disabled: Style::default().fg(Color::DarkGray),
             },
@@ -145,7 +146,7 @@ impl Styles {
             pane: PaneStyles {
                 border: Style::default(),
                 border_selected: Style::default()
-                    .fg(theme.primary_color)
+                    .fg(theme.primary_color.rat())
                     .add_modifier(Modifier::BOLD),
                 border_type: BorderType::Plain,
                 border_type_selected: BorderType::Double,
@@ -153,12 +154,12 @@ impl Styles {
             status_code: StatusCodeStyles {
                 success: Style::default()
                     .fg(Color::Black)
-                    .bg(theme.success_color),
-                error: Style::default().bg(theme.error_color),
+                    .bg(theme.success_color.rat()),
+                error: Style::default().bg(theme.error_color.rat()),
             },
             tab: TabStyles {
                 highlight: Style::default()
-                    .fg(theme.primary_color)
+                    .fg(theme.primary_color.rat())
                     .add_modifier(Modifier::BOLD)
                     .add_modifier(Modifier::UNDERLINED),
             },
@@ -170,27 +171,27 @@ impl Styles {
                 alt: Style::default().bg(Color::DarkGray),
                 disabled: Style::default().add_modifier(Modifier::DIM),
                 highlight: Style::default()
-                    .bg(theme.primary_color)
-                    .fg(theme.primary_text_color)
+                    .bg(theme.primary_color.rat())
+                    .fg(theme.primary_text_color.rat())
                     .add_modifier(Modifier::BOLD)
                     .add_modifier(Modifier::UNDERLINED),
                 title: Style::default().add_modifier(Modifier::BOLD),
             },
             template_preview: TemplatePreviewStyles {
                 text: Style::default()
-                    .fg(theme.secondary_color)
+                    .fg(theme.secondary_color.rat())
                     .add_modifier(Modifier::UNDERLINED),
                 error: Style::default()
                     .fg(Color::default()) // Override syntax highlighting
-                    .bg(theme.error_color),
+                    .bg(theme.error_color.rat()),
             },
             text: TextStyle {
                 highlight: Style::default()
-                    .fg(theme.primary_text_color)
-                    .bg(theme.primary_color),
-                primary: Style::default().fg(theme.primary_color),
+                    .fg(theme.primary_text_color.rat())
+                    .bg(theme.primary_color.rat()),
+                primary: Style::default().fg(theme.primary_color.rat()),
                 edited: Style::default().add_modifier(Modifier::ITALIC),
-                error: Style::default().bg(theme.error_color),
+                error: Style::default().bg(theme.error_color.rat()),
                 note: Style::default().add_modifier(Modifier::ITALIC),
                 title: Style::default().add_modifier(Modifier::BOLD),
             },

--- a/crates/tui/src/view/util.rs
+++ b/crates/tui/src/view/util.rs
@@ -16,11 +16,51 @@ use itertools::Itertools;
 use mime::Mime;
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
+    style::Color as RatColor,
     text::{Line, Text},
 };
 use slumber_core::template::{Prompt, Prompter, ResponseChannel, Select};
 use std::io::Write;
 use tracing::trace;
+
+/// Convert a [slumber_config::Color] to a [ratatui::style::Color]. This is
+/// needed to get around the orphan rule. Ideally we could have a `From`
+/// implementation defined in [slumber_config], but that would add [ratatui] as
+/// a dependency which clutters up the core config repo. Also `rat()` is a funny
+/// method.
+pub trait IntoRatatui {
+    type Output;
+
+    fn rat(self) -> Self::Output;
+}
+
+impl IntoRatatui for slumber_config::Color {
+    type Output = RatColor;
+
+    fn rat(self) -> Self::Output {
+        match self {
+            Self::Reset => RatColor::Reset,
+            Self::Black => RatColor::Black,
+            Self::Red => RatColor::Red,
+            Self::Green => RatColor::Green,
+            Self::Yellow => RatColor::Yellow,
+            Self::Blue => RatColor::Blue,
+            Self::Magenta => RatColor::Magenta,
+            Self::Cyan => RatColor::Cyan,
+            Self::Gray => RatColor::Gray,
+            Self::DarkGray => RatColor::DarkGray,
+            Self::LightRed => RatColor::LightRed,
+            Self::LightGreen => RatColor::LightGreen,
+            Self::LightYellow => RatColor::LightYellow,
+            Self::LightBlue => RatColor::LightBlue,
+            Self::LightMagenta => RatColor::LightMagenta,
+            Self::LightCyan => RatColor::LightCyan,
+            Self::White => RatColor::White,
+            Self::Rgb(r, g, b) => RatColor::Rgb(r, g, b),
+            Self::Indexed(index) => RatColor::Indexed(index),
+        }
+    }
+}
 
 /// A data structure for representation a yes/no confirmation. This is similar
 /// to [Prompt], but it only asks a yes/no question.


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

This prevents slumber_config->ratatui dependency and slumber_config->crossterm, which will improve compile times for the CLI and tests. It will enable a JsonSchema implementation on Color in the future, as well as backend-agnostic theming.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

## QA

_How did you test this?_

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
