### PR TITLE
Replace ratatui with ratatui_core in config crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,7 +623,6 @@ dependencies = [
  "mio",
  "parking_lot",
  "rustix",
- "serde",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -2006,12 +2005,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "numtoa"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aa2c4e539b869820a2b82e1aef6ff40aa85e65decdd5185e83fb4b1249cd00f"
-
-[[package]]
 name = "oas3"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2604,10 +2597,8 @@ dependencies = [
  "instability",
  "ratatui-core",
  "ratatui-crossterm",
- "ratatui-termion",
  "ratatui-termwiz",
  "ratatui-widgets",
- "serde",
 ]
 
 [[package]]
@@ -2643,17 +2634,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ratatui-termion"
-version = "0.1.0-alpha.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7185a3b43ee219d766d9e1c3420472d2b061adf86472c3d688697d07c3c6b93a"
-dependencies = [
- "instability",
- "ratatui-core",
- "termion",
-]
-
-[[package]]
 name = "ratatui-termwiz"
 version = "0.1.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2676,7 +2656,6 @@ dependencies = [
  "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
- "serde",
  "strum 0.27.1",
  "time",
  "unicode-segmentation",
@@ -2691,12 +2670,6 @@ checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags 2.9.1",
 ]
-
-[[package]]
-name = "redox_termios"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20145670ba436b55d91fc92d25e71160fbfbdd57831631c8d7d36377a476f1cb"
 
 [[package]]
 name = "redox_users"
@@ -3300,7 +3273,7 @@ dependencies = [
  "indexmap 2.9.0",
  "itertools 0.13.0",
  "mime",
- "ratatui",
+ "ratatui-core",
  "rstest",
  "serde",
  "serde_test",
@@ -3617,19 +3590,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termion"
-version = "4.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3669a69de26799d6321a5aa713f55f7e2cd37bd47be044b50f2acafc42c122bb"
-dependencies = [
- "libc",
- "libredox",
- "numtoa",
- "redox_termios",
- "serde",
-]
-
-[[package]]
 name = "termios"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3669,7 +3629,6 @@ dependencies = [
  "pest",
  "pest_derive",
  "phf",
- "serde",
  "sha2",
  "signal-hook",
  "siphasher",
@@ -4396,7 +4355,6 @@ checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
 dependencies = [
  "getrandom 0.3.3",
  "mac_address",
- "serde",
  "sha2",
  "thiserror 1.0.69",
  "uuid",
@@ -4411,7 +4369,6 @@ dependencies = [
  "csscolorparser",
  "deltae",
  "lazy_static",
- "serde",
  "wezterm-dynamic",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ indexmap = {version = "2.0.0", default-features = false}
 itertools = "0.13.0"
 mime = "0.3.17"
 pretty_assertions = "1.4.0"
-ratatui = {version = "0.30.0-alpha.5", default-features = false}
 reqwest = {version = "0.12.5", default-features = false}
 rstest = {version = "0.24.0", default-features = false}
 serde = {version = "1.0.204", default-features = false}

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -18,7 +18,7 @@ glob = "0.3.2"
 indexmap = {workspace = true, features = ["serde"]}
 itertools = {workspace = true}
 mime = {workspace = true}
-ratatui = {workspace = true, features = ["serde"]}
+ratatui-core = {version = "0.1.0-alpha.6", default-features = false, features = ["serde"]}
 serde = {workspace = true}
 slumber_util = {workspace = true}
 terminput = {workspace = true}

--- a/crates/config/src/theme.rs
+++ b/crates/config/src/theme.rs
@@ -1,4 +1,4 @@
-use ratatui::style::Color;
+use ratatui_core::style::Color;
 use serde::{Deserialize, Serialize};
 
 /// User-configurable visual settings. These are used to generate the full style

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -25,7 +25,7 @@ mime = {workspace = true}
 notify = {version = "8.0.0", default-features = false, features = ["macos_fsevent"]}
 notify-debouncer-full = {version = "0.5.0", default-features = false}
 persisted = "1.0.0"
-ratatui = {workspace = true, features = ["crossterm", "underline-color", "unstable-widget-ref"]}
+ratatui = {version = "0.30.0-alpha.5", default-features = false, features = ["crossterm", "underline-color", "unstable-widget-ref"]}
 reqwest = {workspace = true}
 serde = {workspace = true}
 serde_json = {workspace = true}


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

This eliminates the slumber_config -> crossterm dependency, which will make multi-backend support easier.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

There's still a lot of code in ratatui-core that we're not using in the config crate, but it's much less now. I tried inlining `Color` directly (#547) but it's a lot of code.

## QA

_How did you test this?_

Unit tests are unchanged

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
