### PR TITLE
Remove node tags in recipe tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,12 +23,12 @@ The new collection _should_ be equivalent to the old one, but you should keep yo
 - Replace template chains with a more intuitive function syntax
   - Instead of defining chains separately then referencing them in templates, you can now call functions directly in templates: `{{ response('login') | jsonpath('$.token') }}`
   - [See docs for more](https://slumber.lucaspickering.me/book/user_guide/templates/functions.html)
-- Replace YAML `!tags` with an inner `type` field
+- Remove YAML `!tags` in favor of an inner `type` field
   - This change makes the format compatible with JSON Schema
   - Impacts these collection nodes:
-    - Folder/request nodes
     - Authentication
     - Body
+    - Folder/request nodes (`type` field not required at all; node type is inferred from the object structure)
 - Represent query parameters as a map of `{parameter: value}` instead of a list of strings like `parameter=value`
   - The map format has been supported as well, but did not allow for multiple values for the same value, hence the need for the string format
   - To define multiple values for the same value, you can now use a list associated to the parameter: `{parameter: [value1, value2]}`

--- a/crates/cli/src/commands/new.yml
+++ b/crates/cli/src/commands/new.yml
@@ -17,17 +17,14 @@ profiles:
 
 requests:
   example1:
-    type: request
     name: Example Request 1
     method: GET
     url: "{{ host }}/anything"
 
   example_folder:
-    type: folder
     name: Example Folder
     requests:
       example2:
-        type: request
         name: Example Request 2
         method: POST
         url: "{{ host }}/anything"

--- a/crates/cli/tests/slumber.yml
+++ b/crates/cli/tests/slumber.yml
@@ -15,12 +15,10 @@ profiles:
 
 requests:
   getUser:
-    type: request
     method: GET
     url: "{{ host }}/users/{{ username }}"
 
   jsonBody:
-    type: request
     method: POST
     url: "{{ host }}/json"
     body:
@@ -28,6 +26,5 @@ requests:
       data: { "username": "{{ username }}", "name": "Frederick Smidgen" }
 
   chained:
-    type: request
     method: GET
     url: "{{ host }}/chained/{{ response('getUser', trigger='always') | jsonpath('$.username') }}"

--- a/crates/core/src/collection.rs
+++ b/crates/core/src/collection.rs
@@ -229,36 +229,45 @@ mod tests {
     /// Test various error cases when deserializing a collection. Make sure
     /// we get a useful error message for each one
     #[rstest]
-    #[case::recipe_missing_type(
+    #[case::unknown_node(
+        // If we have no known fields to key on, we get a helpful error
+        r"
+        requests:
+          r1:
+            unknown: field
+        ",
+        "Error at :4:12: Requests must have a `method` and `url` field; \
+        folders must have a `requests` field"
+    )]
+    #[case::recipe_missing_url(
+        // If the method field is present, deserializer assumes it's a recipe
+        // so we get a recipe error
         r"
         requests:
           r1:
             method: GET
-            url: http://localhost
         ",
-        "Error at :4:12: Expected field `type` with one of \"request\", \"folder\""
+        "Error at :4:12: Expected field `url` with one of string, boolean, number"
     )]
     #[case::query(
         r"
         requests:
           r1:
-            type: request
             method: GET
             url: http://localhost
             query: 3
         ",
-        "Error at :7:19: Expected mapping, received `3`"
+        "Error at :6:19: Expected mapping, received `3`"
     )]
     #[case::headers(
         r"
         requests:
           r1:
-            type: request
             method: GET
             url: http://localhost
             headers: 3
         ",
-        "Error at :7:21: Expected mapping, received `3`"
+        "Error at :6:21: Expected mapping, received `3`"
     )]
     fn test_deserialize_collection_error(
         #[case] yaml: &str,

--- a/crates/core/src/collection/cereal.rs
+++ b/crates/core/src/collection/cereal.rs
@@ -277,14 +277,29 @@ impl DeserializeYaml for RecipeNode {
     }
 
     fn deserialize(yaml: MarkedYaml) -> Result<Self> {
-        deserialize_enum! {
-            yaml,
-            "request" => |yaml| {
-                Recipe::deserialize(yaml).map(RecipeNode::Recipe)
-            },
-            "folder" => |yaml| {
-                Folder::deserialize(yaml).map(RecipeNode::Folder)
-            },
+        // Recipe nodes are untagged enums. They're written very frequently,
+        // have distinct required fields that we can key on, and there's minimal
+        // risk that we'll need to add new variants. Forcing users to require a
+        // tag on every node is annoying so we can just omit it.
+
+        // Get a reference to the mapping without moving it
+        let YamlData::Mapping(mapping) = &yaml.data else {
+            return Err(LocatedError::unexpected(Expected::Mapping, yaml));
+        };
+
+        let has = |key| mapping.contains_key(&MarkedYaml::value_from_str(key));
+
+        // Do a little heuristicking to guess what the variant is. This gives
+        // slightly better error messages
+        if has("method") || has("url") {
+            Recipe::deserialize(yaml).map(RecipeNode::Recipe)
+        } else if has("requests") {
+            Folder::deserialize(yaml).map(RecipeNode::Folder)
+        } else {
+            Err(LocatedError {
+                error: Error::UnknownRecipeNodeVariant,
+                location: yaml.span.start,
+            })
         }
     }
 }
@@ -493,9 +508,9 @@ impl DeserializeYaml for Template {
     fn expected() -> Expected {
         Expected::OneOf(&[
             &Expected::String,
-            &Expected::Null,
             &Expected::Boolean,
             &Expected::Number,
+            // We accept `null` too, but it's not a helpful suggestion
         ])
     }
 
@@ -651,11 +666,11 @@ pub struct LocatedError<E> {
 impl LocatedError<Error> {
     /// Create a new [Other](Self::Other) from any error type
     fn other(
-        error: impl 'static + std::error::Error + Send + Sync,
+        error: impl Into<Box<dyn std::error::Error + Send + Sync>>,
         location: Marker,
     ) -> Self {
         Self {
-            error: Error::Other(Box::new(error)),
+            error: Error::Other(error.into()),
             location,
         }
     }
@@ -741,6 +756,13 @@ enum Error {
 
     #[error("Unexpected field `{0}`")]
     UnexpectedField(String),
+
+    /// We couldn't guess the variant of a recipe node based on its fields
+    #[error(
+        "Requests must have a `method` and `url` field; \
+        folders must have a `requests` field"
+    )]
+    UnknownRecipeNodeVariant,
 }
 
 /// When a value is expected but is either incorrect or missing, this type

--- a/crates/core/src/collection/recipe_tree.rs
+++ b/crates/core/src/collection/recipe_tree.rs
@@ -66,12 +66,12 @@ impl IntoIterator for RecipeLookupKey {
 #[derive(Debug, From, Serialize, EnumDiscriminants)]
 #[strum_discriminants(name(RecipeNodeType))]
 #[cfg_attr(any(test, feature = "test"), derive(PartialEq))]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[serde(untagged)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub enum RecipeNode {
     Folder(Folder),
-    /// Rename this variant to match the `requests` field in the root and
-    /// folders
+    // Rename this variant to match the `requests` field in the root and
+    // folders
     #[serde(rename = "request")]
     Recipe(Recipe),
 }
@@ -288,13 +288,12 @@ mod tests {
 
     /// Build a folder
     fn folder<const N: usize>(children: [(&str, Value); N]) -> Value {
-        mapping([("type", "folder".into()), ("requests", mapping(children))])
+        mapping([("requests", mapping(children))])
     }
 
     /// Build a recipe
     fn recipe() -> Value {
         mapping([
-            ("type", "request".into()),
             ("method", "GET".into()),
             ("url", "http://localhost/url".into()),
         ])

--- a/crates/tui/src/state.rs
+++ b/crates/tui/src/state.rs
@@ -761,7 +761,6 @@ mod tests {
             r#"
 requests:
     test:
-        type: "request"
         method: "GET"
         url: "test"
 "#,
@@ -878,7 +877,7 @@ requests:
         let other_collection = temp_dir.join("other_slumber.yml");
         fs::write(
             &other_collection,
-            r#"requests: {"r1": {"type": "request", "method": "GET", "url": "http://localhost"}}"#,
+            r#"requests: {"r1": {"method": "GET", "url": "http://localhost"}}"#,
         )
         .unwrap();
 

--- a/docs/src/api/request_collection/index.md
+++ b/docs/src/api/request_collection/index.md
@@ -61,7 +61,6 @@ profiles:
 
 requests:
   login:
-    type: request
     <<: *base_request
     method: POST
     url: "{{ host }}/anything/login"
@@ -71,10 +70,8 @@ requests:
 
   # Folders can be used to keep your recipes organized
   users:
-    type: folder
     requests:
       get_user:
-        type: request
         <<: *base_request
         name: Get User
         method: GET
@@ -82,7 +79,6 @@ requests:
         authentication: !bearer "{{ auth_token }}"
 
       update_user:
-        type: request
         <<: *base_request
         name: Update User
         method: PUT

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -38,20 +38,18 @@ profiles:
 
 requests:
   create_fish:
-    type: request
     method: POST
     url: "{{ host }}/fishes"
     body: !json { "kind": "barracuda", "name": "Jimmy" }
 
   list_fish:
-    type: request
     method: GET
     url: "{{ host }}/fishes"
     query:
       big: true
 ```
 
-> The `type: request` tag tells Slumber that this node is a request recipe, not a folder.
+` tag tells Slumber that this node is a request recipe, not a folder.
 
 This request collection uses [templates](./user_guide/templates/index.md) and [profiles](./user_guide/profiles.md), allowing you to dynamically change the target host.
 

--- a/docs/src/user_guide/profiles.md
+++ b/docs/src/user_guide/profiles.md
@@ -15,7 +15,6 @@ profiles:
 
 requests:
   list_fish:
-    type: request
     method: GET
     url: "{{ host }}/fishes"
 ```
@@ -33,7 +32,6 @@ profiles:
 
 requests:
   list_fish:
-    type: request
     method: GET
     url: "https://myfishes.fish/fishes"
     authentication:
@@ -60,7 +58,6 @@ profiles:
 
 requests:
   list_fish:
-    type: request
     method: GET
     url: "https://myfishes.fish/fishes"
     authentication:
@@ -91,7 +88,6 @@ profiles:
 
 requests:
   list_fish:
-    type: request
     method: GET
     url: "https://myfishes.fish/fishes"
     authentication:

--- a/docs/src/user_guide/templates/examples.md
+++ b/docs/src/user_guide/templates/examples.md
@@ -19,7 +19,6 @@ profiles:
 
 requests:
   list_fish:
-    type: request
     method: GET
     url: "{{ host }}/fishes"
     query:
@@ -53,11 +52,9 @@ If you want to send a request that includes data derived from a previous respons
 ```yaml
 requests:
   list_fish:
-    type: request
     method: GET
     url: "{{ host }}/fishes"
   post_fish_list:
-    type: request
     method: POST
     url: "{{ host }}/fishes"
     body: "{{ response('list_fish') }}"
@@ -74,11 +71,9 @@ In this example, we extract the first fish from `list_fish` to get additional de
 ```yaml
 requests:
   list_fish:
-    type: request
     method: GET
     url: "{{ host }}/fishes"
   get_fish:
-    type: request
     method: GET
     url: "{{ host }}/fishes/{{ response('fish_list') | jsonpath('$[0].id') }}"
 ```
@@ -92,11 +87,9 @@ Fetching the first fish is neat and all, but what if you want to select which fi
 ```yaml
 requests:
   list_fish:
-    type: request
     method: GET
     url: "{{ host }}/fishes"
   get_fish:
-    type: request
     method: GET
     url: "{{ host }}/fishes/{{ response('fish_list') | jsonpath('$[*].id', mode='array') | select() }}"
 ```
@@ -119,11 +112,9 @@ The first 3 options are pretty straight forward, so let's dig in the Duration op
 ```yaml
 requests:
   list_fish:
-    type: request
     method: GET
     url: "{{ host }}/fishes"
   get_fish:
-    type: request
     method: GET
     url: "{{ host }}/fishes/{{ response('fish_list', trigger='1d') | jsonpath('$[*].id', mode='array') | select() }}"
 ```
@@ -142,15 +133,12 @@ profiles:
 
 requests:
   list_fish:
-    type: request
     method: GET
     url: "{{ host }}/fishes"
   get_fish:
-    type: request
     method: GET
     url: "{{ host }}/fishes/{{ fish_id }}"
   delete_fish:
-    type: request
     method: DELETE
     url: "{{ host }}/fishes/{{ fish_id }}"
 ```
@@ -171,15 +159,12 @@ profiles:
 
 requests:
   list_fish:
-    type: request
     method: GET
     url: "{{ host }}/fishes"
   get_fish:
-    type: request
     method: GET
     url: "{{ host }}/fishes/{{ fish_id }}"
   delete_fish:
-    type: request
     method: DELETE
     url: "{{ host }}/fishes/{{ fish_id }}"
 ```

--- a/docs/src/user_guide/templates/index.md
+++ b/docs/src/user_guide/templates/index.md
@@ -38,7 +38,6 @@ Templates are defined as strings in your request collection YAML file. For examp
 ```yaml
 requests:
   list_fish:
-    type: request
     method: GET
     url: "{{ host }}/fish"
 ```
@@ -54,7 +53,6 @@ Not all template are dynamic. Static strings are also valid templates and just r
 ```yaml
 requests:
   list_fish:
-    type: request
     method: GET
     # This is a valid template
     url: "https://myfishes.fish/fish"

--- a/schemas/collection.json
+++ b/schemas/collection.json
@@ -40,7 +40,6 @@
       },
       "requests": {
         "my_recipe": {
-          "type": "request",
           "persist": true,
           "name": "My Recipe",
           "method": "POST",
@@ -69,17 +68,14 @@
           }
         },
         "my_folder": {
-          "type": "folder",
           "name": "My Folder",
           "requests": {
             "recipe1": {
-              "type": "request",
               "persist": true,
               "method": "GET",
               "url": "http://localhost/url"
             },
             "recipe2": {
-              "type": "request",
               "persist": true,
               "method": "GET",
               "url": "http://localhost/url"
@@ -146,33 +142,12 @@
     },
     "RecipeNode": {
       "description": "A node in the recipe tree, either a folder or recipe",
-      "oneOf": [
+      "anyOf": [
         {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "const": "folder"
-            }
-          },
-          "$ref": "#/$defs/Folder",
-          "required": [
-            "type"
-          ]
+          "$ref": "#/$defs/Folder"
         },
         {
-          "description": "Rename this variant to match the `requests` field in the root and\nfolders",
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "const": "request"
-            }
-          },
-          "$ref": "#/$defs/Recipe",
-          "required": [
-            "type"
-          ]
+          "$ref": "#/$defs/Recipe"
         }
       ]
     },
@@ -203,7 +178,6 @@
           "name": "My Folder",
           "requests": {
             "my_recipe": {
-              "type": "request",
               "persist": true,
               "name": "My Recipe",
               "method": "POST",
@@ -231,6 +205,102 @@
                 "Accept": "application/json"
               }
             }
+          }
+        }
+      ]
+    },
+    "Recipe": {
+      "description": "A definition of how to build an HTTP request. This is also commonly called\n\"request\" throughout Slumber documentation because that term is more common\nand intuitive.",
+      "type": "object",
+      "properties": {
+        "persist": {
+          "description": "Should requests and responses of this recipe be persisted in the local\nSlumber database?\n[See docs](https://slumber.lucaspickering.me/book/user_guide/database.html)\nfor more info",
+          "type": "boolean",
+          "default": true
+        },
+        "name": {
+          "description": "Display name",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "method": {
+          "description": "[HTTP request method](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Methods)",
+          "$ref": "#/$defs/HttpMethod"
+        },
+        "url": {
+          "description": "[HTTP request URL](https://developer.mozilla.org/en-US/docs/Learn_web_development/Howto/Web_mechanics/What_is_a_URL)\n\nQuery parameters *can* be included here, but typically it's easier to\nuse the `query` field instead.",
+          "$ref": "#/$defs/Template"
+        },
+        "body": {
+          "description": "HTTP request body\n\n- `type: json`: `application/json` body\n- `type: form_urlencoded`: `application/x-www-form-urlencoded` body\n- `type: form_multipart`: `multipart/form-data` body\n- Any template can be given to define the literal request body\n  text/bytes. In this case, consider including a\n  [`Content-Type` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Type)\n  to tell the server what type of content you're sending.\n\nSee individual variants for more details on usage.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RecipeBody"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "authentication": {
+          "description": "HTTP authentication scheme\n\n- `type: basic`: [Basic authentication](https://swagger.io/docs/specification/v3_0/authentication/basic-authentication/)\n- `type: bearer`: [Bearer authentication](https://swagger.io/docs/specification/v3_0/authentication/bearer-authentication/)\n\nSee individual variants for more details on usage.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Authentication"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "query": {
+          "description": "A map of [URL query parameters](https://developer.mozilla.org/en-US/docs/Learn_web_development/Howto/Web_mechanics/What_is_a_URL#parameters).\nEach value can either be a single value (`?foo=bar`) or multiple\n(`?foo=bar&foo=baz`)",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/QueryParameterValue"
+          }
+        },
+        "headers": {
+          "description": "A map of [HTTP request headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers)",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/Template"
+          }
+        }
+      },
+      "required": [
+        "method",
+        "url"
+      ],
+      "examples": [
+        {
+          "persist": true,
+          "name": "My Recipe",
+          "method": "POST",
+          "url": "http://localhost:8000/fish",
+          "body": {
+            "type": "json",
+            "data": {
+              "name": "Barry",
+              "species": "Barracuda"
+            }
+          },
+          "authentication": {
+            "type": "basic",
+            "username": "mememe",
+            "password": "{{ prompt(message='Password', sensitive=true) }}"
+          },
+          "query": {
+            "submit": "true",
+            "param_with_multiple_values": [
+              "value1",
+              "value2"
+            ]
+          },
+          "headers": {
+            "Accept": "application/json"
           }
         }
       ]
@@ -406,102 +476,6 @@
           "type": "array",
           "items": {
             "$ref": "#/$defs/Template"
-          }
-        }
-      ]
-    },
-    "Recipe": {
-      "description": "A definition of how to build an HTTP request. This is also commonly called\n\"request\" throughout Slumber documentation because that term is more common\nand intuitive.",
-      "type": "object",
-      "properties": {
-        "persist": {
-          "description": "Should requests and responses of this recipe be persisted in the local\nSlumber database?\n[See docs](https://slumber.lucaspickering.me/book/user_guide/database.html)\nfor more info",
-          "type": "boolean",
-          "default": true
-        },
-        "name": {
-          "description": "Display name",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "method": {
-          "description": "[HTTP request method](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Methods)",
-          "$ref": "#/$defs/HttpMethod"
-        },
-        "url": {
-          "description": "[HTTP request URL](https://developer.mozilla.org/en-US/docs/Learn_web_development/Howto/Web_mechanics/What_is_a_URL)\n\nQuery parameters *can* be included here, but typically it's easier to\nuse the `query` field instead.",
-          "$ref": "#/$defs/Template"
-        },
-        "body": {
-          "description": "HTTP request body\n\n- `type: json`: `application/json` body\n- `type: form_urlencoded`: `application/x-www-form-urlencoded` body\n- `type: form_multipart`: `multipart/form-data` body\n- Any template can be given to define the literal request body\n  text/bytes. In this case, consider including a\n  [`Content-Type` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Type)\n  to tell the server what type of content you're sending.\n\nSee individual variants for more details on usage.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RecipeBody"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "authentication": {
-          "description": "HTTP authentication scheme\n\n- `type: basic`: [Basic authentication](https://swagger.io/docs/specification/v3_0/authentication/basic-authentication/)\n- `type: bearer`: [Bearer authentication](https://swagger.io/docs/specification/v3_0/authentication/bearer-authentication/)\n\nSee individual variants for more details on usage.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Authentication"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "query": {
-          "description": "A map of [URL query parameters](https://developer.mozilla.org/en-US/docs/Learn_web_development/Howto/Web_mechanics/What_is_a_URL#parameters).\nEach value can either be a single value (`?foo=bar`) or multiple\n(`?foo=bar&foo=baz`)",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/QueryParameterValue"
-          }
-        },
-        "headers": {
-          "description": "A map of [HTTP request headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers)",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/Template"
-          }
-        }
-      },
-      "required": [
-        "method",
-        "url"
-      ],
-      "examples": [
-        {
-          "persist": true,
-          "name": "My Recipe",
-          "method": "POST",
-          "url": "http://localhost:8000/fish",
-          "body": {
-            "type": "json",
-            "data": {
-              "name": "Barry",
-              "species": "Barracuda"
-            }
-          },
-          "authentication": {
-            "type": "basic",
-            "username": "mememe",
-            "password": "{{ prompt(message='Password', sensitive=true) }}"
-          },
-          "query": {
-            "submit": "true",
-            "param_with_multiple_values": [
-              "value1",
-              "value2"
-            ]
-          },
-          "headers": {
-            "Accept": "application/json"
           }
         }
       ]

--- a/slumber.yml
+++ b/slumber.yml
@@ -7,7 +7,6 @@
   username: xX{{ command(['whoami']) | trim() | sensitive() }}Xx
   user_guid: abc123
 .base_request:
-  type: request
   headers:
     Accept: application/json
 
@@ -35,7 +34,6 @@ profiles:
 
 requests:
   authentication:
-    type: folder
     requests:
       login:
         $ref: "#/.base_request"
@@ -81,7 +79,6 @@ requests:
           Accept: application/json
 
   users:
-    type: folder
     name: Users
     requests:
       get_users:
@@ -120,7 +117,6 @@ requests:
             }
 
   get_image:
-    type: request
     headers:
       Accept: image/png
     name: Get Image

--- a/test_data/insomnia_imported.yml
+++ b/test_data/insomnia_imported.yml
@@ -15,15 +15,12 @@ profiles:
 
 requests:
   fld_9a7332db608943b093c929a82c81df50:
-    type: folder
     name: My Folder
     requests:
       fld_8077c48f5a89436bbe4b3a53c06471f5:
-        type: folder
         name: Inner Folder
         requests:
           req_2ec3dc9ff6774ac78248777e75984831:
-            type: request
             name: Bearer Auth
             method: GET
             url: https://httpbin.org/get
@@ -35,7 +32,6 @@ requests:
             headers: {}
 
           req_b08ee35904784b5f9af598f9b7fd7ca0:
-            type: request
             name: Digest Auth (Unsupported)
             method: GET
             url: https://httpbin.org/get
@@ -45,7 +41,6 @@ requests:
             headers: {}
 
           req_284e0d90f0d647b483f863af5ee79c23:
-            type: request
             name: Basic Auth
             method: GET
             url: https://httpbin.org/get
@@ -58,7 +53,6 @@ requests:
             headers: {}
 
           req_814a5e9b63a7482da1d8261311bc6c84:
-            type: request
             name: No Auth
             method: GET
             url: https://httpbin.org/get
@@ -68,7 +62,6 @@ requests:
             headers: {}
 
       req_583c296a600247d6b0c28a0afcefdb89:
-        type: request
         name: With Text Body
         method: POST
         url: https://httpbin.org/post
@@ -79,7 +72,6 @@ requests:
         body: "hello!"
 
       req_1419670d20eb4964956df954e1eb7c4b:
-        type: request
         name: With JSON Body
         method: POST
         url: https://httpbin.org/post
@@ -94,7 +86,6 @@ requests:
           data: { "message": "hello!" }
 
       req_a01b6de924274654bda0835e2a073bd0:
-        type: request
         name: With Multipart Body
         method: POST
         url: https://httpbin.org/post
@@ -111,7 +102,6 @@ requests:
             image: "{{ file('./public/slumber.png') }}"
 
   req_a345faa530a7453e83ee967d18555712:
-    type: request
     name: Login
     method: POST
     url: https://httpbin.org/anything/login

--- a/test_data/openapi_v3_0_petstore_imported.yml
+++ b/test_data/openapi_v3_0_petstore_imported.yml
@@ -6,11 +6,9 @@ profiles:
 
 requests:
   tag/pet:
-    type: folder
     name: pet
     requests:
       addPet:
-        type: request
         name: Add a new pet to the store
         method: POST
         url: "{{ host }}/pet"
@@ -26,7 +24,6 @@ requests:
               "status": "available",
             }
       updatePet:
-        type: request
         name: Update an existing pet
         method: PUT
         url: "{{ host }}/pet"
@@ -42,35 +39,30 @@ requests:
               "status": "available",
             }
       findPetsByStatus:
-        type: request
         name: Finds Pets by status
         method: GET
         url: "{{ host }}/pet/findByStatus"
         query:
           status: ""
       findPetsByTags:
-        type: request
         name: Finds Pets by tags
         method: GET
         url: "{{ host }}/pet/findByTags"
         query:
           tags: ""
       deletePet:
-        type: request
         name: Deletes a pet
         method: DELETE
         url: "{{ host }}/pet/{{petId}}"
         headers:
           api_key: ""
       getPetById:
-        type: request
         name: Find pet by ID
         method: GET
         url: "{{ host }}/pet/{{petId}}"
         headers:
           api_key: "{{api_key}}"
       updatePetWithForm:
-        type: request
         name: Updates a pet in the store with form data
         method: POST
         url: "{{ host }}/pet/{{petId}}"
@@ -78,7 +70,6 @@ requests:
           name: ""
           status: ""
       uploadFile:
-        type: request
         name: uploads an image
         method: POST
         url: "{{ host }}/pet/{{petId}}/uploadImage"
@@ -86,18 +77,15 @@ requests:
           additionalMetadata: ""
         body: '""'
   tag/store:
-    type: folder
     name: store
     requests:
       getInventory:
-        type: request
         name: Returns pet inventories by status
         method: GET
         url: "{{ host }}/store/inventory"
         headers:
           api_key: "{{api_key}}"
       placeOrder:
-        type: request
         name: Place an order for a pet
         method: POST
         url: "{{ host }}/store/order"
@@ -113,21 +101,17 @@ requests:
               complete: false,
             }
       deleteOrder:
-        type: request
         name: Delete purchase order by ID
         method: DELETE
         url: "{{ host }}/store/order/{{orderId}}"
       getOrderById:
-        type: request
         name: Find purchase order by ID
         method: GET
         url: "{{ host }}/store/order/{{orderId}}"
   tag/user:
-    type: folder
     name: user
     requests:
       createUser:
-        type: request
         name: Create user
         method: POST
         url: "{{ host }}/user"
@@ -146,7 +130,6 @@ requests:
               userStatus: 1,
             }
       createUsersWithListInput:
-        type: request
         name: Creates list of users with given input array
         method: POST
         url: "{{ host }}/user/createWithList"
@@ -166,7 +149,6 @@ requests:
               },
             ]
       loginUser:
-        type: request
         name: Logs user into the system
         method: GET
         url: "{{ host }}/user/login"
@@ -174,22 +156,18 @@ requests:
           username: ""
           password: ""
       logoutUser:
-        type: request
         name: Logs out current logged in user session
         method: GET
         url: "{{ host }}/user/logout"
       deleteUser:
-        type: request
         name: Delete user
         method: DELETE
         url: "{{ host }}/user/{{ username }}"
       getUserByName:
-        type: request
         name: Get user by user name
         method: GET
         url: "{{ host }}/user/{{ username }}"
       updateUser:
-        type: request
         name: Update user
         method: PUT
         url: "{{ host }}/user/{{ username }}"

--- a/test_data/openapi_v3_1_petstore_imported.yml
+++ b/test_data/openapi_v3_1_petstore_imported.yml
@@ -6,11 +6,9 @@ profiles:
 
 requests:
   tag/pet:
-    type: folder
     name: pet
     requests:
       addPet:
-        type: request
         name: Add a new pet to the store
         method: POST
         url: "{{host}}/pet"
@@ -26,7 +24,6 @@ requests:
               "tags": [{ "id": 0, "name": "" }],
             }
       updatePet:
-        type: request
         name: Update an existing pet
         method: PUT
         url: "{{host}}/pet"
@@ -42,35 +39,30 @@ requests:
               "tags": [{ "id": 0, "name": "" }],
             }
       findPetsByStatus:
-        type: request
         name: Finds Pets by status
         method: GET
         url: "{{host}}/pet/findByStatus"
         query:
           status: ""
       findPetsByTags:
-        type: request
         name: Finds Pets by tags
         method: GET
         url: "{{host}}/pet/findByTags"
         query:
           tags: ""
       deletePet:
-        type: request
         name: Deletes a pet
         method: DELETE
         url: "{{host}}/pet/{{petId}}"
         headers:
           api_key: ""
       getPetById:
-        type: request
         name: Find pet by ID
         method: GET
         url: "{{host}}/pet/{{petId}}"
         headers:
           api_key: "{{api_key}}"
       updatePetWithForm:
-        type: request
         name: Updates a pet in the store with form data
         method: POST
         url: "{{host}}/pet/{{petId}}"
@@ -80,24 +72,20 @@ requests:
             name: ""
             status: ""
       uploadFile:
-        type: request
         name: uploads an image
         method: POST
         url: "{{host}}/pet/{{petId}}/uploadImage"
         body: '""'
   tag/store:
-    type: folder
     name: store
     requests:
       getInventory:
-        type: request
         name: Returns pet inventories by status
         method: GET
         url: "{{host}}/store/inventory"
         headers:
           api_key: "{{api_key}}"
       placeOrder:
-        type: request
         name: Place an order for a pet
         method: POST
         url: "{{host}}/store/order"
@@ -113,21 +101,17 @@ requests:
               status: "placed",
             }
       deleteOrder:
-        type: request
         name: Delete purchase order by ID
         method: DELETE
         url: "{{host}}/store/order/{{orderId}}"
       getOrderById:
-        type: request
         name: Find purchase order by ID
         method: GET
         url: "{{host}}/store/order/{{orderId}}"
   tag/user:
-    type: folder
     name: user
     requests:
       createUser:
-        type: request
         name: Create user
         method: POST
         url: "{{host}}/user"
@@ -145,7 +129,6 @@ requests:
               username: "",
             }
       createUsersWithListInput:
-        type: request
         name: Creates list of users with given input array
         method: POST
         url: "{{host}}/user/createWithList"
@@ -165,7 +148,6 @@ requests:
               },
             ]
       loginUser:
-        type: request
         name: Logs user into the system
         method: GET
         url: "{{host}}/user/login"
@@ -173,22 +155,18 @@ requests:
           username: ""
           password: ""
       logoutUser:
-        type: request
         name: Logs out current logged in user session
         method: GET
         url: "{{host}}/user/logout"
       deleteUser:
-        type: request
         name: Delete user
         method: DELETE
         url: "{{host}}/user/{{username}}"
       getUserByName:
-        type: request
         name: Get user by user name
         method: GET
         url: "{{host}}/user/{{username}}"
       updateUser:
-        type: request
         name: Updated user
         method: PUT
         url: "{{host}}/user/{{username}}"

--- a/test_data/regression.yml
+++ b/test_data/regression.yml
@@ -24,7 +24,6 @@ profiles:
 
 requests:
   text_body:
-    type: request
     method: POST
     # Missing name
     url: "{{ host }}/anything/login"
@@ -38,11 +37,9 @@ requests:
       {"username":"{{ username }}","password":"{{ prompt('Password', sensitive=true) }}"}
 
   users:
-    type: folder
     name: Users
     requests:
       simple:
-        type: request
         name: Simple
         method: GET
         # No headers or authentication
@@ -52,7 +49,6 @@ requests:
           many: ["{{ field1 }}", "{{ field2 }}"]
 
       json_body:
-        type: request
         $ref: "#/.base_recipe"
         method: PUT
         url: "{{ host }}/anything/{{ user_guid }}"
@@ -64,7 +60,6 @@ requests:
           data: { "username": "new username" }
 
       json_body_but_not:
-        type: request
         $ref: "#/.base_recipe"
         method: PUT
         url: "{{ host }}/anything/{{ user_guid }}"
@@ -77,7 +72,6 @@ requests:
           data: '{"warning": "NOT an object"}'
 
       form_urlencoded_body:
-        type: request
         $ref: "#/.base_recipe"
         method: PUT
         url: "{{ host }}/anything/{{ user_guid }}"

--- a/test_data/rest_imported.yml
+++ b/test_data/rest_imported.yml
@@ -11,7 +11,6 @@ profiles:
 
 requests:
   SimpleGet_0:
-    type: request
     name: SimpleGet
     method: GET
     url: "{{ HOST }}/get"
@@ -20,7 +19,6 @@ requests:
     query: {}
     headers: {}
   JsonPost_1:
-    type: request
     name: JsonPost
     method: POST
     url: "{{ HOST }}/post"
@@ -39,7 +37,6 @@ requests:
       Content-Type: application/json
       X-Http-Method-Override: PUT
   Request_2:
-    type: request
     name: Request
     method: POST
     url: https://httpbin.org/{{ ENDPOINT }}
@@ -53,7 +50,6 @@ requests:
       My-Header: hello
       Other-Header: goodbye
   Pet_json_3:
-    type: request
     name: Pet.json
     method: POST
     url: "{{ HOST }}/post"


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Untagged nodes are pretty unambiguous because of the lack of overlapping fields between folders and recipes. Having to add `type: request` to every recipe is really annoying.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Untagged nodes have potential for ambiguity. This is mitigated by the fact that there's no dynamic fields in the data, the set of node types is only 2, it's unlikely for the set to expand, and there's no overlapping required fields.

## QA

_How did you test this?_

Unit tests, manual in tui

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
