### PR TITLE
Add `name` field to collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Add collection switcher modal [#536](https://github.com/LucasPickering/slumber/issues/536)
   - You can now switch between any collection that you've opened in the past without having to close Slumber
+- Add optional root-level `name` field to collections
+  - This allows you to provide a descriptive name for the collection to show in the new switcher modal
+  - The name is purely descriptive and does not need to be unique
 
 ### Changed
 

--- a/crates/cli/src/commands/collections.rs
+++ b/crates/cli/src/commands/collections.rs
@@ -1,4 +1,4 @@
-use crate::{GlobalArgs, Subcommand};
+use crate::{GlobalArgs, Subcommand, util::print_table};
 use clap::Parser;
 use slumber_core::database::Database;
 use std::{path::PathBuf, process::ExitCode};
@@ -32,9 +32,17 @@ impl Subcommand for CollectionsCommand {
         let database = Database::load()?;
         match self.subcommand {
             CollectionsSubcommand::List => {
-                for path in database.collections()? {
-                    println!("{}", path.display());
-                }
+                let rows = database
+                    .collections()?
+                    .into_iter()
+                    .map(|collection| {
+                        [
+                            collection.path.display().to_string(),
+                            collection.name.unwrap_or_default(),
+                        ]
+                    })
+                    .collect::<Vec<_>>();
+                print_table(["Path", "Name"], &rows);
             }
             CollectionsSubcommand::Migrate { from, to } => {
                 database.merge_collections(&from, &to)?;

--- a/crates/cli/src/commands/history.rs
+++ b/crates/cli/src/commands/history.rs
@@ -2,6 +2,7 @@ use crate::{
     GlobalArgs, Subcommand,
     commands::request::DisplayExchangeCommand,
     completions::{complete_profile, complete_recipe, complete_request_id},
+    util::print_table,
 };
 use anyhow::{anyhow, bail};
 use chrono::{
@@ -16,7 +17,7 @@ use slumber_core::{
     database::{Database, ProfileFilter},
     http::RequestId,
 };
-use std::{iter, process::ExitCode, str::FromStr};
+use std::{process::ExitCode, str::FromStr};
 
 /// View and modify request history
 ///
@@ -245,28 +246,4 @@ enum DeleteSelection {
 /// Format a datetime in ISO 8601 format
 fn format_time_iso(time: &DateTime<Utc>) -> DelayedFormat<StrftimeItems> {
     time.with_timezone(&Local).format("%FT%TZ%Z")
-}
-
-/// Print request history as a table
-fn print_table<const N: usize>(header: [&str; N], rows: &[[String; N]]) {
-    // For each column, find the largest width of any cell
-    let mut widths = [0; N];
-    for column in 0..N {
-        widths[column] = iter::once(header[column].len())
-            .chain(rows.iter().map(|row| row[column].len()))
-            .max()
-            .unwrap_or_default()
-            + 1; // Min width, for spacing
-    }
-
-    for (header, width) in header.into_iter().zip(widths.iter()) {
-        print!("{header:<width$}");
-    }
-    println!();
-    for row in rows {
-        for (cell, width) in row.iter().zip(widths) {
-            print!("{cell:<width$}");
-        }
-        println!();
-    }
 }

--- a/crates/cli/src/commands/new.rs
+++ b/crates/cli/src/commands/new.rs
@@ -107,6 +107,7 @@ mod tests {
     fn test_deserialize() {
         let collection: Collection = serde_yaml::from_slice(SOURCE).unwrap();
         let expected = Collection {
+            name: Some("My Collection".into()),
             profiles: by_id([Profile {
                 id: "example".into(),
                 name: Some("Example Profile".into()),

--- a/crates/cli/src/commands/new.yml
+++ b/crates/cli/src/commands/new.yml
@@ -3,6 +3,8 @@
 # For all collection options, see:
 # https://slumber.lucaspickering.me/book/api/request_collection/index.html
 
+name: My Collection
+
 # Profiles are groups of data you can easily switch between. A common usage is
 # to define profiles for various environments of a REST service
 profiles:

--- a/crates/cli/src/commands/request.rs
+++ b/crates/cli/src/commands/request.rs
@@ -193,6 +193,7 @@ impl BuildRequestCommand {
         let config = Config::load()?;
         let collection = collection_file.load()?;
         let database = Database::load()?.into_collection(&collection_file)?;
+        database.set_name(collection.name.as_deref());
         let http_engine = HttpEngine::new(&config.http);
 
         // Validate profile ID, so we can provide a good error if it's invalid

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -6,6 +6,7 @@
 
 mod commands;
 mod completions;
+mod util;
 
 use crate::commands::{
     collections::CollectionsCommand, db::DbCommand, generate::GenerateCommand,

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -1,0 +1,25 @@
+use std::iter;
+
+/// Print rows in a table
+pub fn print_table<const N: usize>(header: [&str; N], rows: &[[String; N]]) {
+    // For each column, find the largest width of any cell
+    let mut widths = [0; N];
+    for column in 0..N {
+        widths[column] = iter::once(header[column].len())
+            .chain(rows.iter().map(|row| row[column].len()))
+            .max()
+            .unwrap_or_default()
+            + 1; // Min width, for spacing
+    }
+
+    for (header, width) in header.into_iter().zip(widths.iter()) {
+        print!("{header:<width$}");
+    }
+    println!();
+    for row in rows {
+        for (cell, width) in row.iter().zip(widths) {
+            print!("{cell:<width$}");
+        }
+        println!();
+    }
+}

--- a/crates/cli/tests/slumber.yml
+++ b/crates/cli/tests/slumber.yml
@@ -1,5 +1,7 @@
 # Collection for CLI integration tests
 
+name: CLI Tests
+
 profiles:
   profile1:
     name: Profile 1

--- a/crates/cli/tests/test_request.rs
+++ b/crates/cli/tests/test_request.rs
@@ -164,3 +164,22 @@ async fn test_request_persist() {
     assert_eq!(profile_id, &Some("profile1".into()));
     assert_eq!(*status, StatusCode::OK);
 }
+
+/// When loading a collection, the DB should be updated to reflect its name
+#[tokio::test]
+async fn test_set_collection_name() {
+    let (mut command, data_dir) = common::slumber();
+
+    // Sanity check: no collections in the DB
+    let database = Database::from_directory(&data_dir).unwrap();
+    assert_eq!(database.collections().unwrap().as_slice(), &[]);
+
+    command.args(["request", "jsonBody", "--dry-run"]);
+    command.assert().success();
+
+    // Collection name was updated in the DB
+    assert_eq!(
+        database.collections().unwrap()[0].name.as_deref(),
+        Some("CLI Tests")
+    );
+}

--- a/crates/core/src/collection.rs
+++ b/crates/core/src/collection.rs
@@ -231,6 +231,7 @@ mod tests {
         let loaded =
             Collection::load(&test_data_dir.join("regression.yml")).unwrap();
         let expected = Collection {
+            name: Some("Regression Test".to_owned()),
             profiles: by_id([
                 Profile {
                     id: "profile1".into(),

--- a/crates/core/src/collection/models.rs
+++ b/crates/core/src/collection/models.rs
@@ -28,6 +28,8 @@ use tracing::info;
 #[cfg_attr(any(test, feature = "test"), derive(PartialEq))]
 #[serde(deny_unknown_fields)]
 pub struct Collection {
+    /// Descriptive name for the collection
+    pub name: Option<String>,
     #[serde(default, deserialize_with = "cereal::deserialize_profiles")]
     pub profiles: IndexMap<ProfileId, Profile>,
     #[serde(default, deserialize_with = "cereal::deserialize_id_map")]

--- a/crates/core/src/database/migrations.rs
+++ b/crates/core/src/database/migrations.rs
@@ -98,6 +98,8 @@ pub fn migrations() -> Migrations<'static> {
             http_version TEXT NOT NULL DEFAULT 'HTTP/1.1'",
         )
         .down("ALTER TABLE requests_v2 DROP COLUMN http_version"),
+        M::up("ALTER TABLE collections ADD COLUMN name TEXT")
+            .down("ALTER TABLE collections DROP COLUMN name"),
     ])
 }
 

--- a/crates/core/src/database/tests.rs
+++ b/crates/core/src/database/tests.rs
@@ -164,7 +164,12 @@ fn test_merge(
 
     // Make sure collection2 was deleted
     assert_eq!(
-        database.collections().unwrap(),
+        database
+            .collections()
+            .unwrap()
+            .into_iter()
+            .map(|collection| collection.path)
+            .collect::<Vec<_>>(),
         vec![collection_file.path().canonicalize().unwrap()]
     );
 }

--- a/crates/core/src/http/tests.rs
+++ b/crates/core/src/http/tests.rs
@@ -52,6 +52,7 @@ fn template_context(recipe: Recipe) -> TemplateContext {
     ];
     TemplateContext {
         collection: Collection {
+            name: None,
             recipes: by_id([recipe]).into(),
             profiles: by_id([profile]),
             chains: by_id(chains),

--- a/crates/core/src/template/tests.rs
+++ b/crates/core/src/template/tests.rs
@@ -198,6 +198,7 @@ async fn test_chain_request(
     let context = TemplateContext {
         selected_profile: Some(profile.id.clone()),
         collection: Collection {
+            name: None,
             recipes: by_id([recipe]).into(),
             chains: by_id([chain]),
             profiles: by_id([profile]),
@@ -800,6 +801,7 @@ async fn test_chain_dynamic_select(
     let context = TemplateContext {
         selected_profile: Some(profile.id.clone()),
         collection: Collection {
+            name: None,
             recipes: by_id([recipe]).into(),
             chains: by_id([sut_chain, request_chain]),
             profiles: by_id([profile]),

--- a/crates/import/src/insomnia.rs
+++ b/crates/import/src/insomnia.rs
@@ -58,6 +58,7 @@ pub async fn from_insomnia(input: &ImportInput) -> anyhow::Result<Collection> {
     let recipes = build_recipe_tree(&workspace_id, request_groups, requests)?;
 
     Ok(Collection {
+        name: None,
         profiles,
         recipes,
         chains,

--- a/crates/import/src/openapi/v3_0.rs
+++ b/crates/import/src/openapi/v3_0.rs
@@ -28,6 +28,7 @@ pub fn from_openapi_v3_0(
     spec: serde_yaml::Value,
 ) -> anyhow::Result<Collection> {
     let OpenAPI {
+        info,
         components,
         paths,
         servers,
@@ -39,6 +40,7 @@ pub fn from_openapi_v3_0(
     let recipes = build_recipe_tree(paths, components)?;
 
     Ok(Collection {
+        name: Some(info.title),
         profiles,
         recipes,
         chains: IndexMap::new(),

--- a/crates/import/src/openapi/v3_1.rs
+++ b/crates/import/src/openapi/v3_1.rs
@@ -28,6 +28,7 @@ pub fn from_openapi_v3_1(
     let mut spec: Spec = serde_yaml::from_value(spec)
         .context("Error deserializing OpenAPI 3.1 collection")?;
 
+    let name = mem::take(&mut spec.info.title);
     let profiles = build_profiles(
         // We don't need the servers anywhere else so we can move them out to
         // avoid a clone
@@ -36,6 +37,7 @@ pub fn from_openapi_v3_1(
     let recipes = build_recipe_tree(spec)?;
 
     Ok(Collection {
+        name: Some(name),
         profiles,
         recipes,
         chains: IndexMap::new(),

--- a/crates/import/src/rest.rs
+++ b/crates/import/src/rest.rs
@@ -322,6 +322,7 @@ fn build_collection(rest_format: RestFormat) -> Collection {
     let profiles = build_profile_map(flavor, variables);
 
     Collection {
+        name: None,
         profiles,
         chains,
         recipes,

--- a/crates/tui/src/view/component/footer.rs
+++ b/crates/tui/src/view/component/footer.rs
@@ -15,7 +15,6 @@ use ratatui::{
     text::Span,
 };
 use slumber_config::Action;
-use slumber_core::database::CollectionDatabase;
 use slumber_util::ResultTraced;
 use tokio::time;
 
@@ -70,7 +69,7 @@ impl Draw for Footer {
         let styles = &TuiContext::get().styles;
 
         let collection_path =
-            ViewContext::with_database(CollectionDatabase::collection_path)
+            ViewContext::with_database(|db| Ok(db.metadata()?.path))
                 .traced()
                 .unwrap_or_default();
         let collection_path_text = Span::styled(

--- a/crates/tui/src/view/component/help.rs
+++ b/crates/tui/src/view/component/help.rs
@@ -14,6 +14,7 @@ use ratatui::{
     text::{Line, Span},
 };
 use slumber_config::{Action, Config, InputBinding};
+use slumber_core::database::CollectionDatabase;
 use slumber_util::{doc_link, paths};
 
 const CRATE_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -103,12 +104,10 @@ impl Draw for HelpModal {
                 ("Log", paths::log_file().display().to_string().into()),
                 (
                     "Collection",
-                    ViewContext::with_database(|database| {
-                        database.collection_path()
-                    })
-                    .map(|path| path.display().to_string())
-                    .unwrap_or_default()
-                    .into(),
+                    ViewContext::with_database(CollectionDatabase::metadata)
+                        .map(|metadata| metadata.path.display().to_string())
+                        .unwrap_or_default()
+                        .into(),
                 ),
             ]
             .into_iter()

--- a/test_data/openapi_v3_0_petstore_imported.yml
+++ b/test_data/openapi_v3_0_petstore_imported.yml
@@ -1,3 +1,4 @@
+name: Swagger Petstore - OpenAPI 3.0
 profiles:
   /v3:
     name: /v3

--- a/test_data/openapi_v3_1_petstore_imported.yml
+++ b/test_data/openapi_v3_1_petstore_imported.yml
@@ -1,3 +1,4 @@
+name: Swagger Petstore
 profiles:
   http://petstore.swagger.io/v2:
     name: http://petstore.swagger.io/v2

--- a/test_data/regression.yml
+++ b/test_data/regression.yml
@@ -2,6 +2,8 @@
 # deserialization, to make sure we don't accidentally introduce breaking changes
 # to the format
 
+name: Regression Test
+
 .base_profile_data: &base_profile_data
   host: https://httpbin.org
 .base_recipe: &base_recipe


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

The name allows user to provide a descriptive name in the switcher UI.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

- Adding top-level fields to the collection adds risk for clutter. This is a simple one though and very applicable
- Keeping the name in the DB up to date requires calling `set_name` wherever we load both the DB and the collection. This is clunky because the solution doesn't enforce that the call happens in any way.

## QA

_How did you test this?_

Manually tested in TUI, added unit tests.

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
