### PR TITLE
Complete YAML files only for -f

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+- Shell completion for the global `--file`/`-f` flag only suggests `.yml`/`.yaml` files
+
 <!-- This anchor makes it easy for the site to include the content of the changelog -->
 <!-- ANCHOR: changelog -->
 

--- a/crates/cli/src/commands/history.rs
+++ b/crates/cli/src/commands/history.rs
@@ -10,7 +10,6 @@ use chrono::{
     format::{DelayedFormat, StrftimeItems},
 };
 use clap::Parser;
-use clap_complete::ArgValueCompleter;
 use itertools::Itertools;
 use slumber_core::{
     collection::{ProfileId, RecipeId},
@@ -36,17 +35,13 @@ enum HistorySubcommand {
     #[command(visible_alias = "ls")]
     List {
         /// Recipe to show requests for. Omit to show requests for all recipes
-        #[clap(add = ArgValueCompleter::new(complete_recipe))]
+        #[clap(add = complete_recipe())]
         recipe: Option<RecipeId>,
 
         /// Only show requests for a single profile. To show requests that were
         /// run under _no_ profile, pass `--profile` with no value. This must
         /// be used in conjunction with a recipe ID.
-        #[clap(
-            long = "profile",
-            short,
-            add = ArgValueCompleter::new(complete_profile),
-        )]
+        #[clap(long = "profile", short, add = complete_profile())]
         // None -> All profiles
         // Some(None) -> No profile
         // Some(Some("profile1")) -> profile1
@@ -69,7 +64,7 @@ enum HistorySubcommand {
         #[clap(
             // Autocomplete recipe IDs, because users won't ever be typing request
             // IDs by hand
-            add = ArgValueCompleter::new(complete_recipe),
+            add = complete_recipe(),
         )]
         request: RecipeOrRequest,
 
@@ -218,7 +213,7 @@ enum DeleteSelection {
     /// from the collection file.
     Recipe {
         /// Recipe to delete requests for
-        #[clap(add = ArgValueCompleter::new(complete_recipe))]
+        #[clap(add = complete_recipe())]
         recipe: RecipeId,
         /// Optional filter to delete requests for only a single profile. To
         /// delete requests that _no_ associated profile, pass `--profile`
@@ -226,7 +221,7 @@ enum DeleteSelection {
         #[clap(
             long = "profile",
             short,
-            add = ArgValueCompleter::new(complete_profile),
+            add = complete_profile(),
         )]
         // None -> All profiles
         // Some(None) -> No profile
@@ -238,7 +233,7 @@ enum DeleteSelection {
     },
     /// Delete a single request by ID
     Request {
-        #[clap(add = ArgValueCompleter::new(complete_request_id))]
+        #[clap(add = complete_request_id())]
         request: RequestId,
     },
 }

--- a/crates/cli/src/commands/request.rs
+++ b/crates/cli/src/commands/request.rs
@@ -5,7 +5,6 @@ use crate::{
 use anyhow::{Context, anyhow};
 use async_trait::async_trait;
 use clap::{Parser, ValueHint};
-use clap_complete::ArgValueCompleter;
 use dialoguer::{Input, Password, Select as DialoguerSelect};
 use indexmap::IndexMap;
 use itertools::Itertools;
@@ -75,7 +74,7 @@ pub struct RequestCommand {
 #[derive(Clone, Debug, Parser)]
 pub struct BuildRequestCommand {
     /// ID of the recipe to render into a request
-    #[clap(add = ArgValueCompleter::new(complete_recipe))]
+    #[clap(add = complete_recipe())]
     recipe_id: RecipeId,
 
     /// ID of the profile to pull template values from. If omitted and the
@@ -84,7 +83,7 @@ pub struct BuildRequestCommand {
     #[clap(
         long = "profile",
         short,
-        add = ArgValueCompleter::new(complete_profile),
+        add = complete_profile(),
     )]
     profile: Option<ProfileId>,
 

--- a/crates/cli/src/completions.rs
+++ b/crates/cli/src/completions.rs
@@ -6,55 +6,74 @@
 //!
 //! That will enable completions for the current shell
 
-use clap_complete::CompletionCandidate;
+use clap_complete::{ArgValueCompleter, CompletionCandidate, PathCompleter};
 use slumber_core::{
     collection::{Collection, CollectionFile, ProfileId},
     database::Database,
 };
 use std::{ffi::OsStr, ops::Deref};
 
-/// Provide completions for profile IDs
-pub fn complete_profile(current: &OsStr) -> Vec<CompletionCandidate> {
-    let Ok(collection) = load_collection() else {
-        return Vec::new();
-    };
+/// Build a completer for profile IDs
+pub fn complete_profile() -> ArgValueCompleter {
+    fn inner(current: &OsStr) -> Vec<CompletionCandidate> {
+        let Ok(collection) = load_collection() else {
+            return Vec::new();
+        };
 
-    get_candidates(
-        collection.profiles.keys().map(ProfileId::to_string),
-        current,
-    )
+        get_candidates(
+            collection.profiles.keys().map(ProfileId::to_string),
+            current,
+        )
+    }
+    ArgValueCompleter::new(inner)
 }
 
-/// Provide completions for recipe IDs
-pub fn complete_recipe(current: &OsStr) -> Vec<CompletionCandidate> {
-    let Ok(collection) = load_collection() else {
-        return Vec::new();
-    };
+/// Build a completer for recipe IDs
+pub fn complete_recipe() -> ArgValueCompleter {
+    fn inner(current: &OsStr) -> Vec<CompletionCandidate> {
+        let Ok(collection) = load_collection() else {
+            return Vec::new();
+        };
 
-    get_candidates(
-        collection
-            .recipes
-            .iter()
-            // Include recipe IDs only. Folder IDs are never passed to the CLI
-            .filter_map(|(_, node)| Some(node.recipe()?.id.to_string())),
-        current,
-    )
+        get_candidates(
+            collection
+                .recipes
+                .iter()
+                // Include recipe IDs only. Folder IDs are never passed to the
+                // CLI
+                .filter_map(|(_, node)| Some(node.recipe()?.id.to_string())),
+            current,
+        )
+    }
+    ArgValueCompleter::new(inner)
 }
 
-/// Provide completions for request IDs
-pub fn complete_request_id(current: &OsStr) -> Vec<CompletionCandidate> {
-    let Ok(database) = Database::load() else {
-        return Vec::new();
-    };
-    let Ok(exchanges) = database.get_all_requests() else {
-        return Vec::new();
-    };
-    get_candidates(
-        exchanges
-            .into_iter()
-            .map(|exchange| exchange.id.to_string()),
-        current,
-    )
+/// Build a completer for request IDs
+pub fn complete_request_id() -> ArgValueCompleter {
+    fn inner(current: &OsStr) -> Vec<CompletionCandidate> {
+        let Ok(database) = Database::load() else {
+            return Vec::new();
+        };
+        let Ok(exchanges) = database.get_all_requests() else {
+            return Vec::new();
+        };
+        get_candidates(
+            exchanges
+                .into_iter()
+                .map(|exchange| exchange.id.to_string()),
+            current,
+        )
+    }
+    ArgValueCompleter::new(inner)
+}
+
+/// Build a completer for `.yml` and `.yaml` files
+pub fn complete_collection_path() -> ArgValueCompleter {
+    ArgValueCompleter::new(PathCompleter::file().filter(|path| {
+        let extension = path.extension();
+        extension == Some(OsStr::new("yml"))
+            || extension == Some(OsStr::new("yaml"))
+    }))
 }
 
 fn load_collection() -> anyhow::Result<Collection> {

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -8,10 +8,14 @@ mod commands;
 mod completions;
 mod util;
 
-use crate::commands::{
-    collections::CollectionsCommand, db::DbCommand, generate::GenerateCommand,
-    history::HistoryCommand, import::ImportCommand, new::NewCommand,
-    request::RequestCommand, show::ShowCommand,
+use crate::{
+    commands::{
+        collections::CollectionsCommand, db::DbCommand,
+        generate::GenerateCommand, history::HistoryCommand,
+        import::ImportCommand, new::NewCommand, request::RequestCommand,
+        show::ShowCommand,
+    },
+    completions::complete_collection_path,
 };
 use clap::{CommandFactory, Parser};
 use clap_complete::CompleteEnv;
@@ -55,7 +59,7 @@ pub struct GlobalArgs {
     /// (in this order): slumber.yml, slumber.yaml, .slumber.yml,
     /// .slumber.yaml. If a directory is passed, apply the same search
     /// logic from the given directory rather than the current.
-    #[clap(long, short)]
+    #[clap(long, short, add = complete_collection_path())]
     pub file: Option<PathBuf>,
 }
 


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

The global --file/-f argument only suggests YAML files now

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

If someone has a collection file with a different extension, it won't be suggested anymore. I don't see that as a realistic possibility though, so the tradeoff is worth it.

## QA

_How did you test this?_

Manually with `COMPLETE=1 cargo run | source`. Completions only suggest directories and `.yml`/`.yaml` files now

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
