### PR TITLE
`slumber collections` improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Changed
 
 - `slumber collections migrate` now accepts collection IDs in addition to paths
+- `slumber collections list` now includes an ID column in its output
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- `slumber collections migrate` now accepts collection IDs in addition to paths
+
 ### Fixed
 
 - Shell completion for the global `--file`/`-f` flag only suggests `.yml`/`.yaml` files

--- a/crates/cli/src/commands/collections.rs
+++ b/crates/cli/src/commands/collections.rs
@@ -47,12 +47,13 @@ impl Subcommand for CollectionsCommand {
                     .into_iter()
                     .map(|collection| {
                         [
+                            collection.id.to_string(),
                             collection.path.display().to_string(),
                             collection.name.unwrap_or_default(),
                         ]
                     })
                     .collect::<Vec<_>>();
-                print_table(["Path", "Name"], &rows);
+                print_table(["ID", "Path", "Name"], &rows);
             }
             CollectionsSubcommand::Migrate { from, to } => {
                 let from_id = from.to_id(&database)?;

--- a/crates/cli/src/commands/collections.rs
+++ b/crates/cli/src/commands/collections.rs
@@ -1,7 +1,15 @@
-use crate::{GlobalArgs, Subcommand, util::print_table};
+use crate::{
+    GlobalArgs, Subcommand, completions::complete_collection_specifier,
+    util::print_table,
+};
 use clap::Parser;
-use slumber_core::database::Database;
-use std::{path::PathBuf, process::ExitCode};
+use slumber_core::database::{CollectionId, Database};
+use std::{
+    fmt::{self, Display},
+    path::PathBuf,
+    process::ExitCode,
+    str::FromStr,
+};
 
 /// View and modify request collection metadata
 #[derive(Clone, Debug, Parser)]
@@ -20,10 +28,12 @@ enum CollectionsSubcommand {
     /// The data from the source collection will be merged into the target
     /// collection, then all traces of the source collection will be deleted!
     Migrate {
-        /// The path the collection to migrate *from*
-        from: PathBuf,
-        /// The path the collection to migrate *into*
-        to: PathBuf,
+        /// Path or ID the collection to migrate *from*
+        #[clap(add = complete_collection_specifier())]
+        from: CollectionSpecifier,
+        /// Path or ID the collection to migrate *into*
+        #[clap(add = complete_collection_specifier())]
+        to: CollectionSpecifier,
     },
 }
 
@@ -45,10 +55,47 @@ impl Subcommand for CollectionsCommand {
                 print_table(["Path", "Name"], &rows);
             }
             CollectionsSubcommand::Migrate { from, to } => {
-                database.merge_collections(&from, &to)?;
-                println!("Migrated {} into {}", from.display(), to.display());
+                let from_id = from.to_id(&database)?;
+                let to_id = to.to_id(&database)?;
+                database.merge_collections(from_id, to_id)?;
+                println!("Migrated {from} into {to}");
             }
         }
         Ok(ExitCode::SUCCESS)
+    }
+}
+
+/// Specify a collection by file path or ID
+#[derive(Clone, Debug)]
+enum CollectionSpecifier {
+    Id(CollectionId),
+    Path(PathBuf),
+}
+
+impl CollectionSpecifier {
+    fn to_id(&self, database: &Database) -> anyhow::Result<CollectionId> {
+        match self {
+            Self::Id(id) => Ok(*id),
+            Self::Path(path) => database.get_collection_id(path),
+        }
+    }
+}
+
+impl FromStr for CollectionSpecifier {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(s.parse::<CollectionId>()
+            .map(Self::Id)
+            .unwrap_or_else(|_| Self::Path(PathBuf::from(s))))
+    }
+}
+
+impl Display for CollectionSpecifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Id(id) => write!(f, "{id}"),
+            Self::Path(path) => write!(f, "{}", path.display()),
+        }
     }
 }

--- a/crates/cli/src/commands/history.rs
+++ b/crates/cli/src/commands/history.rs
@@ -75,7 +75,8 @@ enum HistorySubcommand {
     /// Delete requests from history
     ///
     /// This operation is irreversible! Combine with `slumber history list
-    /// --id-only` to delete requests in bulk
+    /// --id-only` to delete requests in bulk. To delete all requests for a
+    /// collection, you can also use `slumber collections delete`
     Delete {
         /// Request ID(s) to delete
         #[clap(num_args = 1..)]

--- a/crates/cli/tests/common.rs
+++ b/crates/cli/tests/common.rs
@@ -20,7 +20,7 @@ pub fn slumber() -> (Command, TempDir) {
     (command, data_dir)
 }
 
-fn tests_dir() -> PathBuf {
+pub fn tests_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("tests")
 }
 

--- a/crates/cli/tests/other.yml
+++ b/crates/cli/tests/other.yml
@@ -1,0 +1,12 @@
+# Collection for CLI integration tests
+
+profiles:
+  profile1:
+    data:
+      host: http://server
+      username: username1
+
+requests:
+  get: !request
+    method: GET
+    url: "{{host}}/users/{{username}}"

--- a/crates/cli/tests/test_collections.rs
+++ b/crates/cli/tests/test_collections.rs
@@ -1,0 +1,118 @@
+//! Test `slumber collections` command
+
+mod common;
+
+use crate::common::{collection_file, tests_dir};
+use predicates::prelude::PredicateBooleanExt;
+use rstest::rstest;
+use slumber_core::{
+    collection::{CollectionFile, RecipeId},
+    database::Database,
+    http::Exchange,
+};
+use slumber_util::Factory;
+use std::path::Path;
+
+/// `slumber collections list`
+#[rstest]
+fn test_collections_list() {
+    let (mut command, data_dir) = common::slumber();
+    init_db(&data_dir);
+
+    command
+        .args(["collections", "list"])
+        .assert()
+        .success()
+        .stdout(
+            predicates::str::contains("slumber.yml")
+                .and(predicates::str::contains("other.yml")),
+        );
+}
+
+/// `slumber collections migrate` with paths as  arguments
+///
+/// The actual merge logic is tested in the database so we're just trying to
+/// test the arg handling and basic functionality
+#[test]
+fn test_collections_migrate_paths() {
+    let (mut command, data_dir) = common::slumber();
+    let database = init_db(&data_dir);
+
+    // Verify we start with 2 collections
+    let collections = database.collections().unwrap();
+    assert_eq!(collections.len(), 2);
+    // Grab the first collection so we can ensure it's the only one left later.
+    // Do a sanity check to make sure this is the one we're migrating TO
+    let first_collection = &collections[0];
+    assert!(
+        first_collection.path.ends_with("slumber.yml"),
+        "Expected target collection to be first in list"
+    );
+
+    // Merge the collections
+    command
+        .args(["collections", "migrate", "other.yml", "slumber.yml"])
+        .assert()
+        .success()
+        .stdout("Migrated other.yml into slumber.yml\n");
+
+    // 1 collection now, all the requests are under that collection
+    let collections = database.collections().unwrap();
+    assert_eq!(collections.len(), 1);
+    assert_eq!(collections[0].id, first_collection.id);
+    assert_eq!(database.get_all_requests().unwrap().len(), 3);
+}
+
+/// `slumber collections migrate` with IDs as arguments
+#[test]
+fn test_collections_migrate_ids() {
+    let (mut command, data_dir) = common::slumber();
+    let database = init_db(&data_dir);
+
+    // Verify we start with 2 collections
+    let collections = database.collections().unwrap();
+    assert_eq!(collections.len(), 2);
+    let id1 = collections[0].id;
+    let id2 = collections[1].id;
+
+    // Merge the collections
+    command
+        .args(["collections", "migrate", &id2.to_string(), &id1.to_string()])
+        .assert()
+        .success()
+        .stdout(format!("Migrated {id2} into {id1}\n"));
+
+    // 1 collection now, all the requests are under that collection
+    let collections = database.collections().unwrap();
+    assert_eq!(collections.len(), 1);
+    assert_eq!(collections[0].id, id1);
+    assert_eq!(database.get_all_requests().unwrap().len(), 3);
+}
+
+/// Initialize database with multiple collections and some exchanges
+fn init_db(data_dir: &Path) -> Database {
+    let database = Database::from_directory(data_dir).unwrap();
+
+    let collection1_db = database
+        .clone()
+        .into_collection(&collection_file())
+        .unwrap();
+    collection1_db
+        .insert_exchange(&Exchange::factory(RecipeId::from("getUser")))
+        .unwrap();
+    collection1_db
+        .insert_exchange(&Exchange::factory(RecipeId::from("jsonBody")))
+        .unwrap();
+
+    let collection2_db = database
+        .clone()
+        .into_collection(
+            &CollectionFile::new(Some(tests_dir().join("other.yml"))).unwrap(),
+        )
+        .unwrap();
+    collection2_db
+        .insert_exchange(&Exchange::factory(RecipeId::from("getUser")))
+        .unwrap();
+
+    database
+}

--- a/crates/core/src/database/tests.rs
+++ b/crates/core/src/database/tests.rs
@@ -92,7 +92,7 @@ struct RequestDb {
 }
 
 #[rstest]
-fn test_merge(
+fn test_collection_merge(
     collection_file: CollectionFile,
     other_collection_file: CollectionFile,
 ) {
@@ -145,7 +145,7 @@ fn test_merge(
 
     // Do the merge
     database
-        .merge_collections(other_collection_file.path(), collection_file.path())
+        .merge_collections(collection2.collection_id, collection1.collection_id)
         .unwrap();
 
     // Collection 2 values should've overwritten

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,7 @@
 [tasks.cli]
 description = "Run a CLI command"
-run = "RUST_LOG=slumber=${LOG:-DEBUG} cargo run --no-default-features --features cli -- $@"
+quiet = true
+run = "RUST_LOG=slumber=${LOG:-DEBUG} cargo run --no-default-features --features cli --"
 
 [tasks.docs]
 description = "Build and serve docs"


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

The first set of improvements to `slumber collections`:

- `collections list` now includes an ID column
- `collections migrate` now accepts IDs *or* paths for both the `from` and `to` arguments
- `collections migrate` gets better arg completion now

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Exposing IDs adds a bit of complexity for the user. This subcommands is already advanced-ish so I don't think this is a major concern. We're not removing and existing information and I think the ID thing is fairly intuitive.

## QA

_How did you test this?_

Unit/integration tests, tested the new completion manually. Unit tests for completion to come in another PR

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
