### PR TITLE
Add `slumber collections delete`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Add `slumber collections delete` subcommand to remove collections from history
+- Add `slumber history rm` as an alias for `slumber history delete`
+
 ### Changed
 
 - `slumber collections migrate` now accepts collection IDs in addition to paths

--- a/crates/cli/src/commands/history.rs
+++ b/crates/cli/src/commands/history.rs
@@ -77,6 +77,7 @@ enum HistorySubcommand {
     /// This operation is irreversible! Combine with `slumber history list
     /// --id-only` to delete requests in bulk. To delete all requests for a
     /// collection, you can also use `slumber collections delete`
+    #[command(visible_alias = "rm")]
     Delete {
         /// Request ID(s) to delete
         #[clap(num_args = 1..)]

--- a/docs/src/user_guide/database.md
+++ b/docs/src/user_guide/database.md
@@ -29,7 +29,8 @@ Unlike the TUI, requests made from the CLI are _not_ persisted by default. This 
 There are a few ways to delete requests from history:
 
 - In the TUI. Open the actions menu while a request/response is selected to delete that request. From the recipe list/recipe pane, you can delete all requests for that recipe.
-- The `slumber history delete` can delete one or more commands at a time. Combine with `slumber history list` for bulk deletes: `slumber history list login --id-only | xargs slumber history delete`
+- `slumber history delete` can delete one or more commands at a time. Combine with `slumber history list` for bulk deletes: `slumber history list login --id-only | xargs slumber history delete`
+- `slumber collections delete` can delete all history for a single collection. If you have an old collection that you no longer use, you can delete it from the list using this command. **Note:** If you moved a collection file and want to remove the old file's history, you can also [migrate the history to the new file location](#migrating-collections).
 - Manually modifying the database. You can access the DB with `slumber db`. While this is not an officially supported technique (as the DB schema may change without warning), it's simple enough to navigate if you want to performance bulk deletes with custom criteria.
 
 ### Migrating Collections


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Delete a collection. Begone!!

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

We have to manually delete the rows that belong to the collection before deleting the collection itself. This could be automatic with `ON DELETE CASCADE` but that requires recreating the `requests_v2` and `ui_state_v2` tables. So there's a risk we add a new table and forget to update the deletion.

## QA

_How did you test this?_

Added unit/integration tests, tested manually.

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
