### PR TITLE
Allow migrating/deleting collection files that don't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - Shell completion for the global `--file`/`-f` flag only suggests `.yml`/`.yaml` files
+- `slumber collections migrate` now accepts paths for files that don't exist on disk (as long as they existed as collections at some point)
 
 <!-- This anchor makes it easy for the site to include the content of the changelog -->
 <!-- ANCHOR: changelog -->

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2007,6 +2007,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "path-clean"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3252,6 +3258,7 @@ version = "3.3.0"
 dependencies = [
  "anyhow",
  "dirs",
+ "path-clean",
  "rstest",
  "serde",
  "serde_path_to_error",

--- a/crates/cli/src/commands/collections.rs
+++ b/crates/cli/src/commands/collections.rs
@@ -51,7 +51,7 @@ impl Subcommand for CollectionsCommand {
         match self.subcommand {
             CollectionsSubcommand::List => {
                 let rows = database
-                    .collections()?
+                    .get_collections()?
                     .into_iter()
                     .map(|collection| {
                         [

--- a/crates/cli/src/completions.rs
+++ b/crates/cli/src/completions.rs
@@ -87,7 +87,7 @@ pub fn complete_collection_specifier() -> ArgValueCompleter {
         // Suggest all matching collection IDs
         completions.extend(
             Database::load()
-                .and_then(|db| db.collections())
+                .and_then(|db| db.get_collections())
                 .map(|collections| {
                     // Get all matching collection IDs
                     get_candidates(

--- a/crates/cli/tests/test_request.rs
+++ b/crates/cli/tests/test_request.rs
@@ -172,14 +172,14 @@ async fn test_set_collection_name() {
 
     // Sanity check: no collections in the DB
     let database = Database::from_directory(&data_dir).unwrap();
-    assert_eq!(database.collections().unwrap().as_slice(), &[]);
+    assert_eq!(database.get_collections().unwrap().as_slice(), &[]);
 
     command.args(["request", "jsonBody", "--dry-run"]);
     command.assert().success();
 
     // Collection name was updated in the DB
     assert_eq!(
-        database.collections().unwrap()[0].name.as_deref(),
+        database.get_collections().unwrap()[0].name.as_deref(),
         Some("CLI Tests")
     );
 }

--- a/crates/core/src/database.rs
+++ b/crates/core/src/database.rs
@@ -100,7 +100,7 @@ impl Database {
     }
 
     /// Get a list of all collections
-    pub fn collections(&self) -> anyhow::Result<Vec<CollectionMetadata>> {
+    pub fn get_collections(&self) -> anyhow::Result<Vec<CollectionMetadata>> {
         self.connection()
             .prepare("SELECT * FROM collections")?
             .query_map([], |row| row.try_into())
@@ -118,7 +118,7 @@ impl Database {
         path: &Path,
     ) -> anyhow::Result<CollectionId> {
         // Convert to canonicalize and make serializable
-        let path: CollectionPath = path.try_into()?;
+        let path = CollectionPath::try_from_path_maybe_missing(path)?;
 
         self.connection()
             .query_row(
@@ -273,7 +273,7 @@ impl Database {
         file: &CollectionFile,
     ) -> anyhow::Result<CollectionDatabase> {
         // Convert to canonicalize and make serializable
-        let path: CollectionPath = file.path().try_into()?;
+        let path = CollectionPath::try_from_path(file.path())?;
 
         // We have to set/get in two separate queries, because RETURNING doesn't
         // return anything if the insert didn't modify

--- a/crates/core/src/database/tests.rs
+++ b/crates/core/src/database/tests.rs
@@ -116,7 +116,7 @@ fn test_collection_delete(collection_file: CollectionFile) {
         .unwrap();
 
     // All gone!
-    assert_eq!(database.collections().unwrap(), []);
+    assert_eq!(database.get_collections().unwrap(), []);
     assert_eq!(database.get_all_requests().unwrap(), []);
     assert_eq!(
         collection.get_ui::<_, String>(key_type, ui_key).unwrap(),
@@ -198,7 +198,7 @@ fn test_collection_merge(
     // Make sure collection2 was deleted
     assert_eq!(
         database
-            .collections()
+            .get_collections()
             .unwrap()
             .into_iter()
             .map(|collection| collection.path)

--- a/crates/tui/src/view/component/collection_select.rs
+++ b/crates/tui/src/view/component/collection_select.rs
@@ -33,7 +33,7 @@ impl CollectionSelect {
         // Build the collection list from the DB's collections table. Preselect
         // the current collection
         let collections =
-            ViewContext::with_database(|db| db.root().collections())
+            ViewContext::with_database(|db| db.root().get_collections())
                 .reported(&ViewContext::messages_tx())
                 .unwrap_or_default();
         let current_collection =

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -16,6 +16,7 @@ tag = false
 [dependencies]
 anyhow = {workspace = true}
 dirs = {workspace = true}
+path-clean = "1.0.1"
 rstest = {workspace = true, optional = true}
 serde = {workspace = true}
 serde_path_to_error = "0.1.16"

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, anyhow};
+use path_clean::PathClean;
 use std::{
     borrow::Cow,
     fs,
@@ -119,6 +120,18 @@ pub fn expand_home<'a>(path: impl Into<Cow<'a, Path>>) -> Cow<'a, Path> {
         }
         Err(_) => path,
     }
+}
+
+/// Normalize a referenced file path, ensuring it is absolute and cannot have
+/// any equivalent aliases (barring the existence of symlinks). This will:
+/// - Make the path absolute by joining it with the given base path. If it's
+///   already absolute, this will have no effect
+/// - Expand a leading `~` to the home directory
+/// - "Clean" the path by resolving `.` and `..` segments
+///
+/// This will *not* touch the filesystem in any way and therefore is infallible.
+pub fn normalize_path(base_dir: &Path, file: &Path) -> PathBuf {
+    base_dir.join(expand_home(file)).clean()
 }
 
 #[cfg(test)]

--- a/docs/src/user_guide/database.md
+++ b/docs/src/user_guide/database.md
@@ -35,7 +35,7 @@ There are a few ways to delete requests from history:
 
 ### Migrating Collections
 
-As all Slumber collections' histories are stored in the same SQLite database, each collection gets a unique UUID generated when it is first accessed. This UUID is used to persist request history and other data related to the collection. This UUID is bound to the collection's path. If you move a collection file, a new UUID will be generated and it will be unlinked from its previous history. If you want to retain that history, you can migrate data from the old ID to the new one like so:
+As all Slumber collections' histories are stored in the same SQLite database, each collection gets a unique [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier) generated when it is first accessed. This UUID is used to persist request history and other data related to the collection. This UUID is bound to the collection's path. If you move a collection file, a new UUID will be generated and it will be unlinked from its previous history. If you want to retain that history, you can migrate data from the old ID to the new one like so:
 
 ```sh
 slumber collections migrate slumber-old.yml slumber-new.yml


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

For collection operations that don't involve creating a new collection (`delete` and `migrate`), we now support passing a path to a collection file that no longer exists. 

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Missing paths can't be canonicalized, meaning if the path is behind a symlink it won't match the path that was originally given. This is still better than the previous situation though.

## QA

_How did you test this?_

Unit test!

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
