### PR TITLE
Flip pipe operator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3563,6 +3563,7 @@ dependencies = [
  "serde_yaml",
  "slumber_util",
  "thiserror 2.0.12",
+ "tokio",
  "tracing",
  "winnow",
 ]

--- a/crates/config/src/cereal.rs
+++ b/crates/config/src/cereal.rs
@@ -28,7 +28,19 @@ impl DeserializeYaml for Config {
             commands: deserializer.get(Field::new("commands").opt())?,
             editor: deserializer.get(Field::new("editor").opt())?,
             pager: deserializer.get(Field::new("pager").opt())?,
-            http: deserializer.get(Field::new("http").opt())?,
+            // HTTP config is flattened into the top
+            http: HttpEngineConfig {
+                ignore_certificate_hosts: deserializer
+                    .get(Field::new("ignore_certificate_hosts").opt())?,
+                large_body_size: deserializer.get(
+                    Field::new("large_body_size")
+                        .or(HttpEngineConfig::default().large_body_size),
+                )?,
+                follow_redirects: deserializer.get(
+                    Field::new("follow_redirects")
+                        .or(HttpEngineConfig::default().follow_redirects),
+                )?,
+            },
             preview_templates: deserializer
                 .get(Field::new("preview_templates").or(true))?,
             input_bindings: deserializer

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -419,6 +419,10 @@ mod tests {
 
         // File should now exist
         assert!(config_path.path.exists());
+
+        // Should contain default values
+        let config = Config::load().unwrap();
+        assert_eq!(config, Config::default());
     }
 
     /// If the config file doesn't already exist, we'll attempt to create it.

--- a/crates/core/src/render/functions.rs
+++ b/crates/core/src/render/functions.rs
@@ -249,9 +249,8 @@ impl_try_from_value_str!(JsonPathMode);
 /// ```
 #[template(TemplateContext)]
 pub fn jsonpath(
-    // Value first so it can be piped in
-    value: serde_json::Value,
     query: JsonPath,
+    value: serde_json::Value, // Value last so it can be piped in
     #[kwarg] mode: JsonPathMode,
 ) -> Result<slumber_template::Value, FunctionError> {
     fn node_list_to_value(node_list: NodeList) -> slumber_template::Value {

--- a/crates/core/src/render/tests.rs
+++ b/crates/core/src/render/tests.rs
@@ -218,7 +218,7 @@ async fn test_jsonpath(
     });
     let template = Template::function_call(
         "jsonpath",
-        [json, query.into()],
+        [query.into(), json],
         [("mode", mode.map(Expression::from))],
     );
     assert_result(

--- a/crates/template/Cargo.toml
+++ b/crates/template/Cargo.toml
@@ -34,6 +34,7 @@ rstest = {workspace = true}
 serde_json = {workspace = true}
 serde_yaml = {workspace = true}
 slumber_util = {workspace = true, features = ["test"]}
+tokio = {workspace = true, features = ["macros", "rt"]}
 
 [features]
 schema = ["dep:schemars"]

--- a/crates/template/src/error.rs
+++ b/crates/template/src/error.rs
@@ -40,7 +40,7 @@ pub enum RenderError {
 
     /// A profile field key contained an unknown field
     #[error("Unknown field `{field}`")]
-    FieldUnknown { field: String },
+    FieldUnknown { field: Identifier },
 
     /// An bubbled-up error from rendering a profile field value
     #[error("Rendering nested template for field `{field}`")]

--- a/crates/template/src/expression.rs
+++ b/crates/template/src/expression.rs
@@ -24,8 +24,8 @@ pub enum Expression {
     /// Call to a plain function (**not** a filter)
     Call(FunctionCall),
     /// Data piped to another function: `name | trim()`. The expression on the
-    /// left will be passed as the first argument to the function call on the
-    /// right
+    /// left will be passed as the last positional argument to the function call
+    /// on the right
     Pipe {
         expression: Box<Self>,
         call: FunctionCall,
@@ -63,8 +63,8 @@ impl Expression {
                     // Box for recursion
                     let value = expression.render(context).boxed().await?;
                     let mut arguments = call.render_arguments(context).await?;
-                    // Pipe the filter value in as the first positional argument
-                    arguments.position.push_front(value);
+                    // Pipe the filter value in as the last positional argument
+                    arguments.position.push_back(value);
                     context.call(&call.function, arguments).await
                 }
             }

--- a/crates/util/src/lib.rs
+++ b/crates/util/src/lib.rs
@@ -56,19 +56,13 @@ impl<'a, T: Copy> Mapping<'a, T> {
     }
 
     /// Get the label mapped to a value. If it has multiple labels, use the
-    /// first. Panic if the value has no mapped labels
-    pub fn get_label(&self, value: T) -> &str
+    /// first. Return `None` if the value isn't in the map or has no labels
+    pub fn get_label(&self, value: T) -> Option<&str>
     where
         T: Debug + PartialEq,
     {
-        let (_, strings) = self
-            .0
-            .iter()
-            .find(|(v, _)| v == &value)
-            .unwrap_or_else(|| panic!("Unknown value {value:?}"));
-        strings
-            .first()
-            .unwrap_or_else(|| panic!("No mapped strings for value {value:?}"))
+        let (_, strings) = self.0.iter().find(|(v, _)| v == &value)?;
+        strings.first().copied()
     }
 
     /// Get all available mapped strings

--- a/docs/src/user_guide/templates/functions.md
+++ b/docs/src/user_guide/templates/functions.md
@@ -62,7 +62,7 @@ It's common to take the output of one function and pass it to another. This is e
 trim(command(["echo", "hello"]))
 ```
 
-This works, but it's a bit backward: we run the `command`, _then_ `trim` it. To make these types of composed operations easier to read and write, Slumber supports the pipe operator `|`. The left-hand side of the operator can be any expression, but is typically a function call. The right-hand side **must be a function call**. The left-hand side is evaluated, then the result is passed as the **first** argument to the right-hand side. We can rewrite the same expression from above with the pipe:
+This works, but it's a bit backward: we run the `command`, _then_ `trim` it. To make these types of composed operations easier to read and write, Slumber supports the pipe operator `|`. The left-hand side of the operator can be any expression, but is typically a function call. The right-hand side **must be a function call**. The left-hand side is evaluated, then the result is passed as the **last** argument to the right-hand side. We can rewrite the same expression from above with the pipe:
 
 ```python
 # Equivalent to the above expression
@@ -73,9 +73,10 @@ This is equivalent, but easier to read because the lexical ordering of calls mat
 
 > Unlike other template languages such as Jinja and Tera, the right-hand side of a pipe **must include parentheses**, even if they argument list is empty. Additionally, other languages have a distinction between "functions" and "filters", and only filters can be used on the right-hand side of a pipe operation. This distinction does **not** exist in Slumber; any function can be used on the right-hand side of a pipe, as long as it takes at least one positional argument.
 
-Remember: the piped value is passed as the **first** argument to the right-hand side. You can pass additional arguments as well. Here's another example, using [`response`](../../api/template_functions.md#response) and [`jsonpath`](../../api/template_functions.md#jsonpath).
+Remember: the piped value is passed as the **last** positional argument to the right-hand side. That means it will be inserted after other positional arguments but before any keyword arguments. Here's another example, using [`response`](../../api/template_functions.md#response) and [`jsonpath`](../../api/template_functions.md#jsonpath).
 
 ```python
-# Output of response is passed as the first arg
 response('login') | jsonpath("$.token", mode="single")
+# is equivalent to
+jsonpath("$.token", response('login'), mode="single")
 ```

--- a/docs/src/user_guide/templates/index.md
+++ b/docs/src/user_guide/templates/index.md
@@ -20,8 +20,8 @@ Slumber templates in 60 seconds or less:
 - Function calls: `g(f(), 1)`
   - [See all available functions](../../api/template_functions.md)
 - Pipes: `f() | g(1)`
-  - Result of `f()` is passed as the _first_ argument to `g`
-  - `f() | g(1)` is equivalent to `g(f(), 1)`
+  - Result of `f()` is passed as the _last_ argument to `g`
+  - `f() | g(1)` is equivalent to `g(1, f())`
 
 Put it all together and you can build collections like this:
 

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -124,7 +124,7 @@
           "enter"
         ],
         "toggle": [
-          " "
+          "space"
         ],
         "cancel": [
           "escape"
@@ -258,7 +258,7 @@
           "enter"
         ],
         "toggle": [
-          " "
+          "space"
         ],
         "cancel": [
           "escape"


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Flipped the pipe operator so it pipes in the last value instead of the first. The only function this really impacts is `jsonpath`, so I flipped the args on it too (so it's `jsonpath(query, value)` now, and the value can still be piped in). This sets us up better for partial function application in the future, since piping will just be calling the right side with the left side as the only arg. I.e. we match Haskell and ocaml pipes now.

Also fixed some bugs in config deserialization.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

## QA

_How did you test this?_

Added tests for everything that I changed.

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
