### PR TITLE
Fail command() for exit status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ The new collection _should_ be equivalent to the old one, but you should keep yo
 - YAML anchor/alias/merge syntax has been replaced with `$ref` references, similar to OpenAPI [#290](https://github.com/LucasPickering/slumber/issues/290)
   - These references are much more flexible, including the ability to import from other files
   - [See docs](https://slumber.lucaspickering.me/book/user_guide/composition.html) for examples
+- Commands in templates (previously `!command`, now `command()`) now fail if the command exits with a non-zero status code
 
 ## Added
 

--- a/crates/core/src/render/tests.rs
+++ b/crates/core/src/render/tests.rs
@@ -74,6 +74,11 @@ async fn test_override() {
 #[case::binary_output(vec!["cat", "-"], Some(invalid_utf8()), Ok(invalid_utf8()))]
 #[case::error_empty(vec![], None, Err("Command must have at least one element"))]
 #[case::error_bad_command(vec!["fake"], None, Err("Executing command `fake`"))]
+#[case::error_exit_code(
+    vec!["ls", "--fake"],
+    None,
+    Err(if cfg!(unix) { "unrecognized option" } else { "unknown option" }),
+)]
 #[tokio::test]
 async fn test_command(
     #[case] command: Vec<&str>,

--- a/docs/src/other/v4_migration.md
+++ b/docs/src/other/v4_migration.md
@@ -75,8 +75,10 @@ source: !command
   command: ["echo", "test"]
   stdin: "{{host}}"
 # becomes
-command(["echo", "test"], stdin=host)
+"{{ command(['echo', 'test'], stdin=host) }}"
 ```
+
+> Previously, an error was not triggered if the command failed with a non-zero status code. This will now trigger an error. If you want the template to render even if the command fails, you can use something like `['sh', '-c', ]
 
 **`!env` becomes [`env`](../api/template_functions.md#env)**
 
@@ -84,7 +86,7 @@ command(["echo", "test"], stdin=host)
 source: !env
   variable: MY_VAR
 # becomes
-env("MY_VAR")
+"{{ env('MY_VAR') }}"
 ```
 
 **`!file` becomes [`file`](../api/template_functions.md#file)**
@@ -93,7 +95,7 @@ env("MY_VAR")
 source: !file
   path: my/file
 # becomes
-file("my/file")
+"{{ file('my/file') }}"
 ```
 
 **`!prompt` becomes [`prompt`](../api/template_functions.md#prompt)**
@@ -104,7 +106,7 @@ source: !prompt
   default: "Default"
 sensitive: true
 # becomes
-prompt(message="Enter data", default="Default", sensitive=true)
+"{{ prompt(message='Enter data', default='Default', sensitive=true) }}"
 ```
 
 **`!request` split into [`response`](../api/template_functions.md#response) and [`response_header`](../api/template_functions.md#response_header)**
@@ -115,7 +117,7 @@ source: !request
   trigger: !expire 12h
   section: !body
 # becomes
-response("login", trigger="12h")
+"{{ response('login', trigger='12h') }}"
 ```
 
 ```yaml
@@ -124,7 +126,7 @@ source: !request
   trigger: !expire 12h
   section: !header Content-Type
 # becomes
-response_header("login", "Content-Type", trigger="12h")
+"{{ response_header('login', 'Content-Type', trigger='12h') }}"
 ```
 
 **`!select` becomes [`select`](../api/template_functions.md#select)**
@@ -136,7 +138,7 @@ source: !select
     - option2
   message: "Message"
 # becomes
-select(options=["option1", "option2"], message="Message")
+"{{ select(options=['option1', 'option2'], message='Message') }}"
 ```
 
 In addition, the following chain fields have been replaced by utility functions:
@@ -156,7 +158,7 @@ selector: "$.items"
 selector_mode: array
 sensitive: true
 # becomes
-file("file.json") | trim(mode="both") | jsonpath("$.items", mode="array") | sensitive()
+"{{ file('file.json') | trim(mode='both') | jsonpath('$.items', mode='array') | sensitive() }}"
 ```
 
 Finally, there is a function `concat()` that can be used to replicate the behavior of nested templates within chain config:


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._


Fail `command()` if the command exits with a non-zero status code. 

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

This is intuitive but it's a breaking change. If users don't want this behavior, it's a bit clunky to get around because you have to something like `sh -c cmd || true`.

## QA

_How did you test this?_

Added a unit test

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
