### PR TITLE
command() and file() improvements

### DIFF
--- a/crates/cli/src/commands/request.rs
+++ b/crates/cli/src/commands/request.rs
@@ -221,6 +221,7 @@ impl BuildRequestCommand {
             overrides,
             prompter: Box::new(CliPrompter),
             show_sensitive: true,
+            root_dir: collection_file.parent().to_owned(),
             state: Default::default(),
         };
         let seed = RequestSeed::new(self.recipe_id, BuildOptions::default());

--- a/crates/core/src/collection.rs
+++ b/crates/core/src/collection.rs
@@ -34,7 +34,11 @@ const CONFIG_FILES: &[&str] = &[
 ];
 
 /// A handle for a collection file. This makes it easy to load and reload
-/// the collection in the file. This is just a path that we've confirmed exists.
+/// the collection in the file.
+///
+/// Invariants:
+/// - The path exists
+/// - The path points to a file
 #[derive(Clone, Debug)]
 pub struct CollectionFile(PathBuf);
 
@@ -46,8 +50,8 @@ impl CollectionFile {
         Self::with_dir(env::current_dir()?, override_path)
     }
 
-    /// Get a handle to the collection file, seaching a specific directory. This
-    /// is only useful for testing. Typically you just want [Self::new].
+    /// Get a handle to the collection file, searching a specific directory.
+    /// This is only useful for testing. Typically you just want [Self::new].
     pub fn with_dir(
         mut dir: PathBuf,
         override_path: Option<PathBuf>,
@@ -87,6 +91,13 @@ impl CollectionFile {
     /// Get the path of the file that this collection was loaded from
     pub fn path(&self) -> &Path {
         &self.0
+    }
+
+    /// Get the directory that contains this file
+    pub fn parent(&self) -> &Path {
+        // This is safe because of the invariants: the path always points to a
+        // file
+        self.0.parent().expect("Collection file does not exist")
     }
 }
 

--- a/crates/core/src/render.rs
+++ b/crates/core/src/render.rs
@@ -50,6 +50,9 @@ pub struct TemplateContext {
     /// Should sensitive values be shown normally or masked? Enabled for
     /// request renders, disabled for previews
     pub show_sensitive: bool,
+    /// Directory in which to run file system operations. Should be the
+    /// directory containing the collection file.
+    pub root_dir: PathBuf,
     /// State that should be shared across all renders that use this context.
     /// This is meant to be opaque; just use [Default::default] to initialize.
     pub state: RenderGroupState,
@@ -253,6 +256,7 @@ impl
             database::CollectionDatabase,
             test_util::{TestHttpProvider, TestPrompter},
         };
+        use slumber_util::paths::get_repo_root;
 
         let selected_profile = profiles.first().map(|(id, _)| id.clone());
         Self {
@@ -269,6 +273,7 @@ impl
             )),
             overrides: IndexMap::new(),
             prompter: Box::<TestPrompter>::default(),
+            root_dir: get_repo_root().to_owned(),
             show_sensitive: true,
             state: Default::default(),
         }

--- a/crates/tui/src/state.rs
+++ b/crates/tui/src/state.rs
@@ -680,6 +680,7 @@ impl LoadedState {
             prompter,
             overrides: Default::default(),
             show_sensitive: !is_preview,
+            root_dir: self.collection_file.parent().to_owned(),
             state: Default::default(),
         }
     }


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

- command() and file() now operate relative to the root dir, which is the directory containing the collection file
- Add a cwd= kwarg to command() as well to make this customizable
- Resolve ~ to $HOME in file()

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Testing is a bit icky

## QA

_How did you test this?_

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
