### PR TITLE
Rename json() to json_parse()

### DIFF
--- a/crates/core/src/http/tests.rs
+++ b/crates/core/src/http/tests.rs
@@ -311,9 +311,9 @@ async fn test_authentication(
     &[],
 )]
 #[case::json_from_file_parsed(
-    // Pipe to json() to parse it
+    // Pipe to json_parse() to parse it
     RecipeBody::json(json!(
-        "{{ file(concat([test_data_dir, '/data.json'])) | json() }}"
+        "{{ file(concat([test_data_dir, '/data.json'])) | json_parse() }}"
     )).unwrap(),
     None,
     Some(r#"{"a":1,"b":2}"#),

--- a/crates/core/src/render.rs
+++ b/crates/core/src/render.rs
@@ -215,7 +215,7 @@ impl slumber_template::Context for TemplateContext {
             "file" => functions::file(arguments).await,
             "float" => functions::float(arguments),
             "integer" => functions::integer(arguments),
-            "json" => functions::json(arguments),
+            "json_parse" => functions::json_parse(arguments),
             "jsonpath" => functions::jsonpath(arguments),
             "prompt" => functions::prompt(arguments).await,
             "response" => functions::response(arguments).await,

--- a/crates/core/src/render/tests.rs
+++ b/crates/core/src/render/tests.rs
@@ -345,7 +345,7 @@ async fn test_integer(
     );
 }
 
-/// `json()`
+/// `json_parse()`
 #[rstest]
 #[case::object(br#"{"a": 1, "b": 2}"#, Ok(json!({"a": 1, "b": 2}).into()))]
 #[case::string(br#""json string""#, Ok(json!("json string").into()))]
@@ -353,11 +353,11 @@ async fn test_integer(
 // Binary content can't be parsed
 #[case::error_binary(invalid_utf8(), Err("invalid utf-8 sequence"))]
 #[tokio::test]
-async fn test_json(
+async fn test_json_parse(
     #[case] json: &'static [u8],
     #[case] expected: Result<slumber_template::Value, &str>,
 ) {
-    let template = Template::function_call("json", [json.into()], []);
+    let template = Template::function_call("json_parse", [json.into()], []);
     assert_result(
         template.render_value(&TemplateContext::factory(())).await,
         expected,

--- a/crates/doc_utils/src/template_functions.rs
+++ b/crates/doc_utils/src/template_functions.rs
@@ -299,6 +299,10 @@ fn type_map() -> HashMap<Type, TypeDef> {
         (parse_quote!(f64), TypeDef::Float),
         (parse_quote!(i64), TypeDef::Integer),
         (parse_quote!(Bytes), TypeDef::Bytes),
+        (
+            parse_quote!(CommandOutputMode),
+            union!("stdout" | "stderr" | "both"),
+        ),
         (parse_quote!(JsonPath), TypeDef::Custom("JsonPath")),
         (parse_quote!(JsonPathValue), TypeDef::Value),
         (

--- a/docs/src/user_guide/templates/examples.md
+++ b/docs/src/user_guide/templates/examples.md
@@ -189,7 +189,7 @@ requests:
       data:
         {
           "name": "Alfonso",
-          "friends": "{{ file('./friends.json') | json() }}",
+          "friends": "{{ file('./friends.json') | json_parse() }}",
         }
 ```
 
@@ -204,7 +204,7 @@ The request body will render as:
 
 A few things to notice here:
 
-- We had to explicitly parse the contents of the file with `json()`. By default the content loaded is just artbirary bytes; Slumber doesn't know it's supposed to be JSON.
+- We had to explicitly parse the contents of the file with `json_parse()`. By default the content loaded is just artbirary bytes; Slumber doesn't know it's supposed to be JSON.
 - The parsed JSON is included directly into the JSON body, _without_ the surrounding quotes from the template. In other words, the value was **unpacked**.
 
 In some cases this behavior may not be desired, e.g. when combined with `jsonpath()`. You can pipe to `string()` to **disable this behavior**:


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

It's less ambiguous, and we can add `json_stringify()` later to match. I don't see a use for stringify currently so I punted.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

## QA

_How did you test this?_

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
