### PR TITLE
Remove command() output kwarg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 <!-- ANCHOR: changelog -->
 
+### Fixed
+
+- Remove `output` argument for `command()`
+  - This wasn't intended to be released and didn't actually work
+
 ## [4.0.0] - 2025-09-12
 
 [Migration guide](https://slumber.lucaspickering.me/other/v4_migration.html)


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Whoopsie! This wasn't supposed to go out. A little git snafu.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

This is a partially breaking change, but the `output` kwarg didn't fully work and wasn't supposed to be part of the release at all, so I'm considering it a bug fix.

## QA

_How did you test this?_

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
