### PR TITLE
Use TLS instead of set_boundary() for multipart assertions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,8 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 [[package]]
 name = "reqwest"
 version = "0.12.23"
-source = "git+https://github.com/LucasPickering/reqwest?branch=2374-custom-boundary#ab1b6a5223c4da5c8d0b63207d0255a6e97db9f5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,9 +41,7 @@ itertools = "0.13.0"
 mime = "0.3.17"
 pretty_assertions = "1.4.0"
 regex = {version = "1.10.5", default-features = false}
-# TODO use a stable version
-# reqwest = {version = "0.12.23", default-features = false}
-reqwest = {git = "https://github.com/LucasPickering/reqwest", branch = "2374-custom-boundary", default-features = false}
+reqwest = {version = "0.12.23", default-features = false}
 rstest = {version = "0.24.0", default-features = false}
 saphyr = "0.0.6"
 schemars = "1.0.2"

--- a/crates/core/src/http.rs
+++ b/crates/core/src/http.rs
@@ -746,13 +746,12 @@ impl RenderedBody {
             RenderedBody::FormMultipart(fields) => {
                 let mut form = Form::new();
 
-                // Use a static boundary in tests for assertions. Test-only
-                // code can be dangerous, but in non-test we're just using the
-                // default library behavior. There's also plenty of tests in
-                // other crates that hit this code path, and cfg(test) won't
-                // be enabled for those.
-                if cfg!(test) {
-                    form.set_boundary("BOUNDARY");
+                #[cfg(test)]
+                {
+                    // Hack alert!! Reqwest uses a random boundary between parts
+                    // in a multipart request. We share this with the tests via
+                    // TLS. See the TLS declaration for more info.
+                    tests::MULTIPART_BOUNDARY.set(form.boundary().to_owned());
                 }
 
                 for (field, stream) in fields {


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

This is a hack until reqwest merges https://github.com/seanmonstar/reqwest/pull/2814

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

There could potentially be concurrency bugs. Since it's using TLS, it would have to be bugs with multiple tests running concurrently on a single thread. As far as I know, tokio doesn't do that. I ran the tests a bunch too to test. It could also fuck up if multiple bodies are rendered concurrently in one test, but we don't do that either.

## QA

_How did you test this?_

Ran the tests 100 times.

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
