### PR TITLE
Show recipe ID in pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - `form_multipart` fields that consist of a single call to `file()` will now include the correct `Content-Type` header and `filename` field of the `Content-Disposition` header [#582](https://github.com/LucasPickering/slumber/issues/582)
   - [See docs](https://slumber.lucaspickering.me/user_guide/streaming.html)
+- Previews of `prompt()` will now show the default value if possible
+- Recipe ID is now shown in the top-right of the Recipe pane header
 
 ### Fixed
 

--- a/crates/tui/src/view/component/recipe_pane.rs
+++ b/crates/tui/src/view/component/recipe_pane.rs
@@ -26,6 +26,7 @@ use derive_more::Display;
 use itertools::{Itertools, Position};
 use ratatui::{
     Frame,
+    layout::Alignment,
     text::{Line, Text},
 };
 use slumber_config::Action;
@@ -103,8 +104,10 @@ impl<'a> Draw<RecipePaneProps<'a>> for RecipePane {
         props: RecipePaneProps<'a>,
         metadata: DrawMetadata,
     ) {
+        let context = TuiContext::get();
+
         // Render outermost block
-        let title = TuiContext::get().input_engine.add_hint(
+        let title = context.input_engine.add_hint(
             match props.selected_recipe_node {
                 Some(RecipeNode::Folder(_)) => "Folder",
                 Some(RecipeNode::Recipe(_)) | None => "Recipe",
@@ -115,8 +118,16 @@ impl<'a> Draw<RecipePaneProps<'a>> for RecipePane {
             title: &title,
             has_focus: metadata.has_focus(),
         };
-        let block = block.generate();
+        let mut block = block.generate();
         let inner_area = block.inner(metadata.area());
+        // Include the folder/recipe ID in the header
+        if let Some(node) = props.selected_recipe_node {
+            block = block.title(
+                Line::from(node.id().to_string())
+                    .alignment(Alignment::Right)
+                    .style(context.styles.text.title),
+            );
+        }
         frame.render_widget(block, metadata.area());
 
         // Whenever the recipe or profile changes, generate a preview for

--- a/crates/tui/src/view/util.rs
+++ b/crates/tui/src/view/util.rs
@@ -63,7 +63,8 @@ pub struct PreviewPrompter;
 
 impl Prompter for PreviewPrompter {
     fn prompt(&self, prompt: Prompt) {
-        prompt.channel.respond("<prompt>".into());
+        let value = prompt.default.unwrap_or_else(|| "<prompt>".into());
+        prompt.channel.respond(value);
     }
 
     fn select(&self, select: Select) {

--- a/slumber.yml
+++ b/slumber.yml
@@ -79,8 +79,8 @@ requests:
             {
               "name": "{{ prompt(message='Name', default='Fishy') }}",
               "species": "{{ prompt(message='Species', default='Fish') }}",
-              "age": "{{ prompt(message='Age', default=3, type='int') }}",
-              "weight_kg": "{{ prompt(message='Weight (kg)', default='1.5', type='float') }}",
+              "age": "{{ prompt(message='Age', default=3) | integer() }}",
+              "weight_kg": "{{ prompt(message='Weight (kg)', default='1.5') | float() }}",
             }
 
       modify_fish:
@@ -92,8 +92,8 @@ requests:
           type: json
           data:
             {
-              "age": "{{ prompt(message='Age', default=3, type='int') }}",
-              "weight_kg": "{{ prompt(message='Weight (kg)', default='1.5', type='float') }}",
+              "age": "{{ prompt(message='Age', default=3) | integer() }}",
+              "weight_kg": "{{ prompt(message='Weight (kg)', default='1.5') | float() }}",
             }
 
       delete_fish:


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

- Show folder/recipe ID in top-right of pane header
- Use default value for prompt previews if available

<img width="441" height="221" alt="image" src="https://github.com/user-attachments/assets/ab56fe56-f34b-421b-a689-98985edd4dc8" />


## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

## QA

_How did you test this?_

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
