### PR TITLE
Docs: Break long fn signatures over multiple lines

### DIFF
--- a/crates/doc_utils/src/template_functions.rs
+++ b/crates/doc_utils/src/template_functions.rs
@@ -144,6 +144,21 @@ impl TemplateFunctionMetadata {
 
 impl Display for TemplateFunctionMetadata {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn fmt_parameters(parameters: &[ParameterMetadata]) -> String {
+            // If the params get too long, overflow onto multiple lines
+            let one_line = parameters.iter().join(", ").to_string();
+            if one_line.len() <= 60 {
+                one_line
+            } else {
+                format!(
+                    "\n{}",
+                    parameters.iter().format_with("", |param, f| f(
+                        &format_args!("  {param},\n")
+                    ))
+                )
+            }
+        }
+
         write!(
             f,
             "### {name}
@@ -154,7 +169,7 @@ impl Display for TemplateFunctionMetadata {
 
 {doc}",
             name = self.name,
-            parameters = self.parameters.iter().join(", "),
+            parameters = fmt_parameters(&self.parameters),
             return_type = self.return_type,
             doc = self.doc_comment,
         )


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Before:

```
jsonpath(query: JsonPath, value: value, mode?: "auto" | "single" | "array"): value
```

After:

```
jsonpath(
  query: JsonPath,
  value: value,
  mode?: "auto" | "single" | "array",
): value
```

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

## QA

_How did you test this?_

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
