### PR TITLE
Accept labelled object in select()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Add [Python bindings](https://slumber.lucaspickering.me/integration/python.html), allowing you to use your Slumber collection from Python scripts without having to invoke the CLI
 - Add [`jq`](https://slumber.lucaspickering.me/api/template_functions.html#jq) function to the template language, to query and transform JSON with [jq](https://jqlang.org/manual/)
+- `select()` now accepts a list of objects `{"label": "Label", "value": "Value"}` in addition to a list of strings [#609](https://github.com/LucasPickering/slumber/issues/609)
+  - This allows you to pass a list of values where the returned value is different from the string you see in the select list.
+  - For example, to select a user from a list where you select users by name but the returned value is their ID: `select([{"label": "User 1", "value": 1}, {"label": "User 2", "value": 2}])`
+  - [See docs for more](https://slumber.lucaspickering.me/api/template_functions.html#select)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,6 +856,7 @@ dependencies = [
  "clap",
  "itertools 0.13.0",
  "mdbook",
+ "quote",
  "serde_json",
  "syn 2.0.101",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ mime = "0.3.17"
 pretty_assertions = "1.4.0"
 proptest = "1.5.0"
 proptest-derive = "0.5.0"
+quote = "1.0.40"
 regex = {version = "1.10.5", default-features = false}
 reqwest = {version = "0.12.23", default-features = false}
 rstest = {version = "0.24.0", default-features = false}

--- a/crates/cli/src/commands/request.rs
+++ b/crates/cli/src/commands/request.rs
@@ -386,10 +386,12 @@ impl Prompter for CliPrompter {
             .interact();
 
         // If we failed to read the value, print an error and report nothing
-        if let Ok(value) =
+        if let Ok(index) =
             result.context("Error reading value from select").traced()
         {
-            select.channel.respond(select.options.swap_remove(value));
+            select
+                .channel
+                .respond(select.options.swap_remove(index).value);
         }
     }
 }

--- a/crates/core/src/render.rs
+++ b/crates/core/src/render.rs
@@ -22,10 +22,11 @@ use crate::{
 };
 use async_trait::async_trait;
 use chrono::Utc;
-use derive_more::{Deref, From};
+use derive_more::{Deref, From, derive::Display};
 use indexmap::IndexMap;
 use itertools::Itertools;
-use slumber_template::{Arguments, Identifier, LazyValue, RenderError};
+use serde::Deserialize;
+use slumber_template::{Arguments, Identifier, LazyValue, RenderError, Value};
 use std::{
     fmt::Debug, io, iter, path::PathBuf, process::ExitStatus, sync::Arc,
 };
@@ -414,9 +415,21 @@ pub struct Select {
     /// Tell the user what we're asking for
     pub message: String,
     /// List of choices the user can pick from
-    pub options: Vec<String>,
-    /// How the prompter will pass the answer back
-    pub channel: ResponseChannel<String>,
+    pub options: Vec<SelectOption>,
+    /// How the prompter will pass the answer back. The returned value is the
+    /// `value` field from the selected [SelectOption]
+    pub channel: ResponseChannel<Value>,
+}
+
+/// An entry in a `select()` list
+#[derive(Debug, Display, Deserialize)]
+#[display("{label}")]
+pub struct SelectOption {
+    /// Label to display to the user for this option
+    pub label: String,
+    /// Underlying value to return if this option is selected. This will be the
+    /// same as the label if the input was a single string.
+    pub value: Value,
 }
 
 /// Channel used to return a response to a one-time request. This is its own

--- a/crates/core/src/test_util.rs
+++ b/crates/core/src/test_util.rs
@@ -145,8 +145,10 @@ impl Prompter for TestSelectPrompter {
 
     fn select(&self, mut select: Select) {
         let index = self.index.fetch_add(1, Ordering::Relaxed);
-        if let Some(value) = self.responses.get(index) {
-            select.channel.respond(select.options.swap_remove(*value));
+        if let Some(value_index) = self.responses.get(index) {
+            select
+                .channel
+                .respond(select.options.swap_remove(*value_index).value);
         }
     }
 }

--- a/crates/doc_utils/Cargo.toml
+++ b/crates/doc_utils/Cargo.toml
@@ -21,7 +21,8 @@ clap = {workspace = true, features = ["derive"]}
 itertools = {workspace = true}
 mdbook = {version = "0.4", default-features = false}
 serde_json = {workspace = true}
-syn = {workspace = true, features = ["extra-traits", "full"]}
+syn = {workspace = true, features = ["extra-traits", "full", "printing"]}
+quote = {workspace = true}
 
 [lints]
 workspace = true

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 
 [dependencies]
 proc-macro2 = "1.0.95"
-quote = "1.0.40"
+quote = {workspace = true}
 syn = {workspace = true, features = ["full"]}
 
 [lints]

--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -315,8 +315,10 @@ impl Prompter for PythonPrompter {
             .default(0)
             .interact();
 
-        if let Ok(value) = result {
-            select.channel.respond(select.options.swap_remove(value));
+        if let Ok(index) = result {
+            select
+                .channel
+                .respond(select.options.swap_remove(index).value);
         }
     }
 }

--- a/crates/template/src/error.rs
+++ b/crates/template/src/error.rs
@@ -99,15 +99,6 @@ impl RenderError {
     }
 }
 
-impl de::Error for RenderError {
-    fn custom<T>(msg: T) -> Self
-    where
-        T: Display,
-    {
-        RenderError::Other(msg.to_string().into())
-    }
-}
-
 /// Information about where an error occurred
 #[derive(Debug, Display)]
 pub enum RenderErrorContext {
@@ -218,6 +209,15 @@ impl ValueError {
         error: impl 'static + Into<Box<dyn std::error::Error + Send + Sync>>,
     ) -> Self {
         Self::Other(error.into())
+    }
+}
+
+impl de::Error for ValueError {
+    fn custom<T>(msg: T) -> Self
+    where
+        T: Display,
+    {
+        Self::Other(msg.to_string().into())
     }
 }
 

--- a/crates/template/src/expression.rs
+++ b/crates/template/src/expression.rs
@@ -175,6 +175,7 @@ impl From<&'static [u8]> for Expression {
     }
 }
 
+// Bytes from byte literal. b"" literals are type &[u8; N], not &[u8]
 impl<const N: usize> From<&'static [u8; N]> for Expression {
     fn from(value: &'static [u8; N]) -> Self {
         value.as_slice().into()
@@ -184,6 +185,13 @@ impl<const N: usize> From<&'static [u8; N]> for Expression {
 impl From<Vec<Expression>> for Expression {
     fn from(values: Vec<Expression>) -> Self {
         Self::Array(values)
+    }
+}
+
+/// Object from (key, value) pairs
+impl<const N: usize> From<[(&str, Expression); N]> for Expression {
+    fn from(value: [(&str, Expression); N]) -> Self {
+        Self::Object(value.into_iter().map(|(k, v)| (k.into(), v)).collect())
     }
 }
 

--- a/crates/template/src/value.rs
+++ b/crates/template/src/value.rs
@@ -15,9 +15,10 @@ use std::{collections::VecDeque, fmt::Debug, path::PathBuf};
 /// A runtime template value. This very similar to a JSON value, except:
 /// - Numbers do not support arbitrary size
 /// - Bytes are supported
-#[derive(Clone, Debug, From, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, From, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Value {
+    #[default]
     Null,
     Boolean(bool),
     Integer(i64),

--- a/slumber.yml
+++ b/slumber.yml
@@ -6,7 +6,7 @@
 .base_profile_data:
   username: xX{{ command(['whoami']) | trim() | sensitive() }}Xx
   fish_id: "{{ response('list_fish', trigger='no_history')
-    | jq('.[].id')
+    | jq('[.[] | { label: .name, value: .id }]')
     | select(message='Fish ID') }}"
   stream_compound: "command: {{ command(['echo', 'test']) }}\nfile: {{ file('Cargo.toml') }}"
 


### PR DESCRIPTION



## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

select() now accepts an array of objects like {label: "Label", value: 1} (in addition to the existing support for an array of strings). This allows you to specify one value for display but return a different value (e.g. select a user by name, then forward on the ID). It also allows select to output arbitrary values instead of just strings.

Right now the easiest way to use this is to pipe to command() and call jq. I plan to add a jq() function to support jq natively, which will make it even easier.

Closes #609

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

There are a lot of ways to solve this. I picked one that I think is flexible and intuitive but easy to implement. The other ones iI considered:

- Pass a `label=` function to `select()` instead. Requires higher-order functions in the template lang, which is a ton of complexity. In particular, user-defined scopes is a nightmare.
- Pass a separate list of aliases like `select([1,2,3], aliases=['a', 'b', 'c'])`. When building a select dynamically from JSON, this is a pain because you have to split the input expression into two args. Without variable assignment that's not possible
- Pass a `label=` *template* to `select()`. Right now there's no way to create templates at runtime and I think it would be a strange usage. The input values would have to be objects, and the template namespace would be constructed dynamically.
- Pass a `label_jsonpath=` argument that uses JSONPath to extract the desired value. This is simpler but locks you into JSONPath. If your input values aren't JSON objects, it doesn't work.

## QA

_How did you test this?_

Unit tests!! Also manually tested in the TUI and CLI

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
