### PR TITLE
Display error after edit for --edit commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   - This will make it much easier to make tweaks to a recipe
 - The `Body` and `Authentication` tabs of the `Recipe` pane are now disabled if the recipe doesn't have a body/authentication (respectively)
 - Disabled actions can no longer be selected in the action menu
+- `slumber show config --edit` and `slumber show collection --edit` now display the error if the file is invalid after editing
 
 ## [4.1.0] - 2025-09-30
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -107,3 +107,12 @@ trait Subcommand {
     /// Execute the subcommand
     async fn execute(self, global: GlobalArgs) -> anyhow::Result<ExitCode>;
 }
+
+/// Print an error chain to stderr
+pub fn print_error(error: &anyhow::Error) {
+    eprintln!("{error}");
+    error
+        .chain()
+        .skip(1)
+        .for_each(|cause| eprintln!("  {cause}"));
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,11 +41,7 @@ async fn main() -> anyhow::Result<std::process::ExitCode> {
             // Do *not* return the error, because that prints a stack trace
             // which is way too verbose. Just print the error messages instead
             .unwrap_or_else(|error| {
-                eprintln!("{error}");
-                error
-                    .chain()
-                    .skip(1)
-                    .for_each(|cause| eprintln!("  {cause}"));
+                slumber_cli::print_error(&error);
                 ExitCode::FAILURE
             })),
     }


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

When using `slumber show config --edit` or `slumber show collection --edit`, if the file is invalid after editing it will now print the error before prompting to re-edit.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

## QA

_How did you test this?_

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
