### PR TITLE
Add URL tab and override URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   - This allows you to pass a list of values where the returned value is different from the string you see in the select list.
   - For example, to select a user from a list where you select users by name but the returned value is their ID: `select([{"label": "User 1", "value": 1}, {"label": "User 2", "value": 2}])`
   - [See docs for more](https://slumber.lucaspickering.me/api/template_functions.html#select)
+- Add URL tab to the recipe pane, allowing the URL to be temporarily overridden
 
 ### Changed
 

--- a/crates/core/src/http.rs
+++ b/crates/core/src/http.rs
@@ -151,7 +151,7 @@ impl HttpEngine {
 
             // Render everything up front so we can parallelize it
             let (url, query, headers, authentication, body) = try_join!(
-                recipe.render_url(context),
+                recipe.render_url(options, context),
                 recipe.render_query(options, context),
                 recipe.render_headers(options, context),
                 recipe.render_authentication(options, context),
@@ -221,7 +221,7 @@ impl HttpEngine {
 
             // Parallelization!
             let (url, query) = try_join!(
-                recipe.render_url(context),
+                recipe.render_url(options, context),
                 recipe.render_query(options, context),
             )?;
 
@@ -327,7 +327,7 @@ impl HttpEngine {
 
             // Render everything up front so we can parallelize it
             let (url, query, headers, authentication, body) = try_join!(
-                recipe.render_url(context),
+                recipe.render_url(options, context),
                 recipe.render_query(options, context),
                 recipe.render_headers(options, context),
                 recipe.render_authentication(options, context),
@@ -473,10 +473,11 @@ impl Recipe {
     /// Render base URL, *excluding* query params
     async fn render_url(
         &self,
+        options: &BuildOptions,
         context: &TemplateContext,
     ) -> Result<Url, RequestBuildErrorKind> {
-        let url = self
-            .url
+        let template = options.url.as_ref().unwrap_or(&self.url);
+        let url = template
             .render_string(&context.streaming(false))
             .await
             .map_err(RequestBuildErrorKind::UrlRender)?;

--- a/crates/core/src/http/models.rs
+++ b/crates/core/src/http/models.rs
@@ -283,6 +283,8 @@ impl RequestSeed {
 #[derive(Debug, Default)]
 #[cfg_attr(any(test, feature = "test"), derive(PartialEq))]
 pub struct BuildOptions {
+    /// URL can be overridden but not disabled
+    pub url: Option<Template>,
     /// Authentication can be overridden, but not disabled. For simplicity,
     /// the override is wholesale rather than by field.
     pub authentication: Option<Authentication>,
@@ -290,7 +292,7 @@ pub struct BuildOptions {
     pub query_parameters: BuildFieldOverrides,
     pub form_fields: BuildFieldOverrides,
     /// Override body. This should *not* be used for form bodies, since those
-    /// can be override on a field-by-field basis.
+    /// can be overridden on a field-by-field basis.
     pub body: Option<RecipeBody>,
 }
 

--- a/crates/core/src/http/tests.rs
+++ b/crates/core/src/http/tests.rs
@@ -525,6 +525,25 @@ async fn test_body_stream(
     assert_eq!(body, expected_body, "Incorrect body");
 }
 
+/// Test overriding URL in BuildOptions
+#[rstest]
+#[tokio::test]
+async fn test_override_url(http_engine: HttpEngine) {
+    let recipe = Recipe::factory(());
+    let context = template_context(recipe, None);
+
+    let seed = seed(
+        &context,
+        BuildOptions {
+            url: Some("http://custom-host/users/{{ username }}".into()),
+            ..Default::default()
+        },
+    );
+    let ticket = http_engine.build(seed, &context).await.unwrap();
+
+    assert_eq!(ticket.record.url.as_str(), "http://custom-host/users/user");
+}
+
 /// Test overriding authentication in BuildOptions
 #[rstest]
 #[tokio::test]

--- a/crates/tui/src/view/component/recipe_pane.rs
+++ b/crates/tui/src/view/component/recipe_pane.rs
@@ -3,6 +3,7 @@ mod body;
 mod persistence;
 mod recipe;
 mod table;
+mod url;
 
 pub use persistence::RecipeOverrideStore;
 


### PR DESCRIPTION

## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

- Add URL tab to the recipe pane
- Add the option to override the URL template

<img width="719" height="409" alt="image" src="https://github.com/user-attachments/assets/5d33a87e-5d7f-4b3e-a5ab-0797d3c1c957" />

<img width="720" height="416" alt="image" src="https://github.com/user-attachments/assets/9c5f0e68-d4dc-4368-b250-41625c241b96" />

<img width="725" height="411" alt="image" src="https://github.com/user-attachments/assets/2badc7c7-fdae-4a80-94b9-7d558d66785d" />

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Added clutter to the UI. The URL is already shown in the header so having it in two places is kind of clumsy. I couldn't come up with a good way to make the URL editable in the header though. There isn't a good interaction to select+edit it, as tab/shift+tab are already in use to navigate panes, and arrow keys are used to scroll on the tables/body. Fortunately this can always be changed again later without it being a breaking change.

## QA

_How did you test this?_

Wrote unit tests for both the HTTP engine and TUI components, and manually tested in the TUI.

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
