### PR TITLE
Dynamic action labels

### DIFF
--- a/crates/tui/src/view/component/recipe_list.rs
+++ b/crates/tui/src/view/component/recipe_list.rs
@@ -4,7 +4,7 @@ use crate::{
         Component, ViewContext,
         common::{
             Pane,
-            actions::{IntoMenuAction, MenuAction},
+            actions::MenuAction,
             list::List,
             text_box::{TextBox, TextBoxEvent, TextBoxProps},
         },
@@ -29,7 +29,6 @@ use slumber_core::collection::{
     HasId, RecipeId, RecipeLookupKey, RecipeNode, RecipeNodeType, RecipeTree,
 };
 use std::collections::HashSet;
-use strum::IntoEnumIterator;
 
 /// List/tree of recipes and folders. This is mostly just a list, but with some
 /// extra logic to allow expanding/collapsing nodes. This could be made into a
@@ -207,9 +206,10 @@ impl EventHandler for RecipeListPane {
     }
 
     fn menu_actions(&self) -> Vec<MenuAction> {
-        RecipeMenuAction::iter()
-            .map(MenuAction::with_data(self, self.actions_emitter))
-            .collect()
+        RecipeMenuAction::menu_actions(
+            self.actions_emitter,
+            self.selected_recipe_id().is_some(),
+        )
     }
 
     fn children(&mut self) -> Vec<Component<Child<'_>>> {
@@ -273,20 +273,6 @@ pub enum RecipeListPaneEvent {
     Click,
     /// Forward menu actions to the parent because it has the needed context
     Action(RecipeMenuAction),
-}
-
-impl IntoMenuAction<RecipeListPane> for RecipeMenuAction {
-    fn label(&self, _: &RecipeListPane) -> String {
-        self.to_string()
-    }
-
-    fn enabled(&self, data: &RecipeListPane) -> bool {
-        let has_recipe = data.selected_recipe_id().is_some();
-        // Use a match so we have to think about this for any new variants
-        match self {
-            Self::CopyUrl | Self::CopyCurl | Self::DeleteRecipe => has_recipe,
-        }
-    }
 }
 
 /// Simplified version of [RecipeNode], to be used in the display tree. This

--- a/crates/tui/src/view/event.rs
+++ b/crates/tui/src/view/event.rs
@@ -438,6 +438,12 @@ impl<T: Sized + LocalEvent> Emitter<T> {
             phantom: PhantomData,
         }
     }
+
+    /// Generate a menu action bound to this emitter. When fired, the action
+    /// will emit an event through this emitter.
+    pub fn menu(self, action: T, name: impl Into<String>) -> MenuAction {
+        MenuAction::new(self, action, name)
+    }
 }
 
 impl Emitter<dyn LocalEvent> {


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Set the label for the `Edit Recipe` action dynamically.

Also refactor action menus to consolidate the logic. Sets us up better for nested action menus

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

## QA

_How did you test this?_

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
