### PR TITLE
Add nested action menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 <!-- ANCHOR: changelog -->
 
+### Changed
+
+- Some menu actions have been moved into nested sections for better organization
+
 ## [4.2.0] - 2025-10-14
 
 <!-- ANCHOR: changelog -->

--- a/crates/tui/src/view/common/actions.rs
+++ b/crates/tui/src/view/common/actions.rs
@@ -1,142 +1,472 @@
 use crate::{
     context::TuiContext,
     view::{
-        Generate,
-        common::{
-            list::List,
-            modal::{Modal, ModalEvent},
-        },
         component::{
-            Canvas, Child, Component, ComponentId, Draw, DrawMetadata, ToChild,
+            Canvas, Child, Component, ComponentId, Draw, DrawMetadata, Portal,
+            ToChild,
         },
         context::UpdateContext,
-        event::{Emitter, Event, LocalEvent, OptionEvent},
-        state::select::SelectState,
+        event::{Emitter, Event, LocalEvent, OptionEvent, ToEmitter},
+        state::select::{
+            SelectItem, SelectState, SelectStateEvent, SelectStateEventType,
+        },
     },
 };
 use itertools::Itertools;
 use ratatui::{
+    buffer::Buffer,
     layout::Constraint,
-    text::{Line, Span},
+    prelude::Rect,
+    style::Style,
+    text::Span,
+    widgets::{List, ListItem, ListState, StatefulWidget},
 };
 use slumber_config::Action;
 
-/// Modal to list and trigger arbitrary actions. The user opens the action menu
-/// with a keybinding, at which point the list of available actions is built
-/// dynamically via [Component::menu_actions]. When an action is selected,
-/// the modal is closed and that action will be emitted as a dynamic event, to
-/// be handled by the component that originally supplied it. Each component that
-/// provides actions should store an [Emitter] specifically for its actions,
-/// which will be provided to each supplied action and can be used to check and
-/// consume the action events.
-#[derive(Debug)]
-pub struct ActionsModal {
+/// Popup menu to list and trigger arbitrary actions.
+///
+/// The user opens the action menu with a keybinding, at which point the list of
+/// available actions is built dynamically via [Component::menu]. When an action
+/// is selected, the modal is closed and that action will be emitted as a
+/// dynamic event, to be handled by the component that originally supplied it.
+/// Each component that provides actions should store an [Emitter] specifically
+/// for its actions, which will be provided to each supplied action and can be
+/// used to check and consume the action events.
+///
+/// This is implemented as its own [Portal] type instead of using
+/// [ModalQueue](super::modal::ModalQueue) because the behavior is sufficiently
+/// different:
+/// - It doesn't use the modal's standard border styling
+/// - The location isn't necessarily centered
+/// - The event handling is more complex (indirect submission)
+#[derive(Debug, Default)]
+pub struct ActionsMenu {
     id: ComponentId,
-    /// Join the list of global actions into the given one
-    actions: SelectState<MenuAction>,
-    /// Emit modal close events back to the parent
-    modal_emitter: Emitter<ModalEvent>,
+    /// Menu content, which is `Some` when the menu is open
+    content: Option<ActionMenuContent>,
 }
 
-impl ActionsModal {
-    /// Create a new actions modal, optional disabling certain actions based on
-    /// some external condition(s).
-    pub fn new(actions: Vec<MenuAction>) -> Self {
-        let disabled_indexes = actions
+impl ActionsMenu {
+    /// Open the actions menu with the given actions/groups
+    pub fn open(&mut self, items: Vec<MenuItem>) {
+        self.content = Some(ActionMenuContent::new(items));
+    }
+
+    fn close(&mut self) {
+        self.content = None;
+    }
+}
+
+impl Portal for ActionsMenu {
+    fn area(&self, canvas_area: Rect) -> Rect {
+        let Some(content) = &self.content else {
+            return Rect::default();
+        };
+
+        // Center just based on the first layer, so it doesn't shift when
+        // opening other layers
+        let first = content.stack.first().expect("Menu stack cannot be empty");
+        let Rect { x, y, .. } = canvas_area.centered(
+            Constraint::Length(ActionMenuContent::WIDTH),
+            Constraint::Length(first.len() as u16),
+        );
+
+        let width = ActionMenuContent::WIDTH * content.stack.len() as u16;
+        // Calculate how far down the menus expand. Each menu is offset so that
+        // the first item lines up with the selected item in the parent
+        let height = content
+            .stack
             .iter()
             .enumerate()
-            .filter(|(_, action)| !action.enabled)
-            .map(|(i, _)| i)
-            .collect_vec();
-        Self {
-            id: ComponentId::default(),
-            actions: SelectState::builder(actions)
-                .disabled_indexes(disabled_indexes)
-                .build(),
-            modal_emitter: Emitter::default(),
+            .map(|(i, layer)| {
+                let offset = if i == 0 {
+                    None
+                } else {
+                    content.stack[i - 1].selected_index()
+                }
+                .unwrap_or(0);
+                (offset + layer.len()) as u16
+            })
+            .max()
+            .unwrap_or(0);
+
+        Rect {
+            x,
+            y,
+            width,
+            height,
         }
     }
 }
 
-impl Modal for ActionsModal {
-    fn title(&self) -> Line<'_> {
-        "Actions".into()
-    }
-
-    fn dimensions(&self) -> (Constraint, Constraint) {
-        (
-            Constraint::Length(30),
-            Constraint::Length(self.actions.len() as u16),
-        )
-    }
-
-    fn emitter(&self) -> Option<Emitter<ModalEvent>> {
-        Some(self.modal_emitter)
-    }
-
-    fn on_submit(self, _: &mut UpdateContext) {
-        let Some(action) = self.actions.into_selected() else {
-            // Possible if the action list is empty
-            return;
-        };
-        // Emit an event on behalf of the component that supplied this
-        // action. The component will use its own supplied emitter ID to
-        // consume the event
-        action.emitter.emit(action.value);
-    }
-}
-
-impl Component for ActionsModal {
+impl Component for ActionsMenu {
     fn id(&self) -> ComponentId {
         self.id
     }
 
     fn update(&mut self, _: &mut UpdateContext, event: Event) -> Option<Event> {
-        // Enter submission is handled by the modal parent. Hotkey submission
-        // requires extra logic
-        event.opt().action(|action, propagate| {
-            // For any input action, check if any menu items are bound to it
-            // as a shortcut. If there are multiple menu actions bound to
-            // the same shortcut, we'll just take the first.
-            let bound_index = self
-                .actions
-                .items()
-                .position(|menu_action| menu_action.shortcut == Some(action));
-            if let Some(index) = bound_index {
-                // We need ownership of the menu action to emit it, so defer
-                // into the on_submit handler. Selecting the item is how we
-                // know which one to submit
-                self.actions.select_index(index);
-                // Normally the modal queue parent listens for the Enter key
-                // to know when a submission occurs. Since this is a hotkey
-                // submission, we have to explicitly tell it
-                self.modal_emitter.emit(ModalEvent::Submit);
-            } else {
-                propagate.set();
-            }
-        })
+        // Don't eat events until we're open
+        let Some(content) = &self.content else {
+            return Some(event);
+        };
+        let emitter = content.emitter;
+
+        event
+            .opt()
+            .action(|action, propagate| match action {
+                Action::Cancel | Action::Quit => self.close(),
+                _ => propagate.set(),
+            })
+            .emitted(
+                emitter,
+                // Unwraps are safe because we can only get an event if the
+                // content exists
+                |_: ActionSubmit| self.content.take().unwrap().submit(),
+            )
+            .any(|event| match event {
+                // Eat any input events, since we're the sole focus holder
+                Event::Input { .. } => None,
+                _ => Some(event),
+            })
     }
 
     fn children(&mut self) -> Vec<Child<'_>> {
-        vec![self.actions.to_child_mut()]
+        self.content
+            .as_mut()
+            .into_iter()
+            .map(ToChild::to_child_mut)
+            .collect()
     }
 }
 
-impl Draw for ActionsModal {
+impl Draw for ActionsMenu {
     fn draw(&self, canvas: &mut Canvas, (): (), metadata: DrawMetadata) {
-        canvas.draw(
-            &self.actions,
-            List::from(&self.actions),
-            metadata.area(),
-            true,
+        if let Some(state) = &self.content {
+            canvas.draw(state, (), metadata.area(), true);
+        }
+    }
+}
+
+/// Data for a particular action menu. This is created when the menu is opened
+/// based on what actions are available
+#[derive(Debug)]
+struct ActionMenuContent {
+    id: ComponentId,
+    /// Original action tree that this modal is derived from. This is stored in
+    /// its original state
+    items: Vec<MenuItem>,
+    /// Stack of menu levels. Push when a group becomes visible, pop when it's
+    /// hidden. The visual data is cloned from `self.items` so we can organize
+    /// this in a stack. The original item tree doesn't allow that, and we
+    /// can't use references to the tree because it would be self-referential.
+    /// INVARIANT: len >= 1
+    stack: Vec<SelectState<MenuItemDisplay>>,
+    /// The index of the layer in the stack that the user is controlling. This
+    /// index is always valid because the stack is never empty
+    /// INVARIANT: selected_layer < self.stack.len()
+    active_layer: usize,
+    /// Emitter to tell the parent when we're executing an action. Submission
+    /// requires an owned `self`, so it has to be done as the parent closes us
+    emitter: Emitter<ActionSubmit>,
+}
+
+impl ActionMenuContent {
+    const WIDTH: u16 = 30;
+
+    fn new(items: Vec<MenuItem>) -> Self {
+        let root_select = build_select(map_items(&items));
+        Self {
+            id: ComponentId::default(),
+            items,
+            stack: vec![root_select],
+            active_layer: 0,
+            emitter: Emitter::default(),
+        }
+    }
+
+    /// Clear all layers right of the given layer
+    fn clear_children(&mut self, layer: usize) {
+        self.stack.drain((layer + 1)..);
+        // Defensive programming!!
+        assert!(
+            !self.stack.is_empty(),
+            "Action menu stack must have at least one element"
         );
+    }
+
+    /// Open the children of a group in the active layer. This assumes the
+    /// active layer is the top layer, so call [Self::clear_children] first.
+    fn open_group(&mut self, items: Vec<MenuItemDisplay>) {
+        self.stack.push(build_select(items));
+    }
+
+    /// Check if the given input action is bound to a menu action **in any
+    /// layer**. This will start with the left-most layer and check each layer
+    /// for an item bound to that action. If it's found, select that layer+item
+    /// and return `true`. If not, return `false`.
+    fn select_by_action(&mut self, action: Action) -> bool {
+        for (layer, select) in self.stack.iter_mut().enumerate() {
+            // Check if this input is bound to any item in this select
+            let bound_index = select.items().position(|item| match item {
+                MenuItemDisplay::Action { shortcut, .. } => {
+                    shortcut == &Some(action)
+                }
+                MenuItemDisplay::Group { .. } => false,
+            });
+
+            // This action is bound to something!
+            if let Some(bound_index) = bound_index {
+                self.active_layer = layer;
+                select.select_index(bound_index);
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Select the previous layer to the left in the stack
+    fn previous_layer(&mut self) {
+        self.active_layer = self.active_layer.saturating_sub(1);
+    }
+
+    /// Select the next layer to the right in the stack
+    fn next_layer(&mut self) {
+        self.active_layer = (self.active_layer + 1).min(self.stack.len() - 1);
+    }
+
+    /// Perform the selected action
+    fn submit(self) {
+        // To find the submitted action, we need to walk down the original
+        // action tree in parallel with the stack. In each stack layer we have
+        // a selected index, which we'll use to grab the next tree layer.
+        let mut items = self.items;
+        for i in 0..=self.active_layer {
+            // Indexing is safe because active_layer < stack.len()
+            let select = &self.stack[i];
+
+            let Some(selected_index) = select.selected_index() else {
+                return; // Possible if the final action menu is empty
+            };
+            let item = items.swap_remove(selected_index);
+            if i < self.active_layer {
+                // We have more layers to go - we're looking for a group
+                let MenuItem::Group { children, .. } = item else {
+                    panic!("Expected group at layer {i}, found {item:?}");
+                };
+                items = children;
+            } else {
+                // This is the last layer - we're looking for an action
+                let MenuItem::Action(action) = item else {
+                    panic!("Expected action at layer {i}, found {item:?}");
+                };
+
+                // Emit an event on behalf of the component that supplied this
+                // action. The component will use its own supplied emitter ID to
+                // consume the event
+                action.emitter.emit(action.value);
+            }
+        }
+    }
+}
+
+impl Component for ActionMenuContent {
+    fn id(&self) -> ComponentId {
+        self.id
+    }
+
+    fn update(&mut self, _: &mut UpdateContext, event: Event) -> Option<Event> {
+        let mut propagated =
+            event.opt().action(|action, propagate| match action {
+                // Navigate between layers with left/right
+                Action::Left => self.previous_layer(),
+                Action::Right => self.next_layer(),
+                // Check if the input is bound to any action in *any* list in
+                // the stack
+                _ if self.select_by_action(action) => {
+                    // Submission is deferred because it requires an
+                    // owned value
+                    self.emitter.emit(ActionSubmit);
+                }
+                _ => propagate.set(),
+            });
+
+        // Check for events from all layers of the stack. It's possible for
+        // inactive layers to emit events because of mouse input (e.g.
+        // scrolling).
+        //
+        // Iterate with indexes + while loop because we may modify the stack
+        // while iterating. We need to recheck the bound after each iteration
+        // to prevent iterating past the end when children are cleared
+        let mut layer = 0;
+        while layer < self.stack.len() {
+            let emitter = self.stack[layer].to_emitter();
+            propagated = propagated.emitted(emitter, |event| match event {
+                SelectStateEvent::Select(index) => {
+                    // When changing selection, any existing child menus are no
+                    // longer relevant so close them
+                    self.clear_children(layer);
+                    // If the selected item is a group, open a new child menu
+                    let selected = &self.stack[layer][index];
+                    if let MenuItemDisplay::Group { children, .. } = selected {
+                        self.open_group(children.clone());
+                    }
+                }
+                SelectStateEvent::Submit(index) => {
+                    // Submitting on an action closes the menu and emits the
+                    // action. Submitting on a group moves to the children
+                    //
+                    // We have to handle the submission event here instead of
+                    // letting the modal queue handle it because **not all
+                    // submissions close the modal**; submission on a group
+                    // just enters the next layer
+                    let selected = &self.stack[layer][index];
+                    match selected {
+                        MenuItemDisplay::Action { .. } => {
+                            // Submission is deferred because it requires an
+                            // owned value
+                            self.emitter.emit(ActionSubmit);
+                        }
+                        // The group should already be open because it had to be
+                        // selected before it was submitted
+                        MenuItemDisplay::Group { .. } => self.next_layer(),
+                    }
+                }
+                SelectStateEvent::Toggle(_) => {}
+            });
+            layer += 1;
+        }
+
+        propagated
+    }
+
+    fn children(&mut self) -> Vec<Child<'_>> {
+        // Reverse the list so lowest children get priority. It shouldn't
+        // actually matter though because only the active menu is focused so
+        // only that one gets key events, and there's no visual overlap so they
+        // shouldn't be competing for mouse events
+
+        self.stack
+            .iter_mut()
+            .rev()
+            .map(ToChild::to_child_mut)
+            .collect()
+    }
+}
+
+impl Draw for ActionMenuContent {
+    fn draw(&self, canvas: &mut Canvas, (): (), metadata: DrawMetadata) {
+        for (i, select) in self.stack.iter().enumerate() {
+            // Each menu steps out to the right
+            let x = Self::WIDTH * (i as u16);
+            // Offset in y so our first item aligns with the parent, which is
+            // the selected item from the previous layer
+            let y = if i == 0 {
+                0
+            } else {
+                self.stack[i - 1].selected_index().unwrap_or(0) as u16
+            };
+            let area = Rect {
+                width: Self::WIDTH,
+                height: select.len() as u16,
+                x: metadata.area().x + x,
+                y: metadata.area().y + y,
+            };
+
+            let active = i == self.active_layer;
+            let widget = MenuLayer { select, active };
+            canvas.draw(select, widget, area, active);
+        }
+    }
+}
+
+struct MenuLayer<'a> {
+    select: &'a SelectState<MenuItemDisplay>,
+    /// Should we use active or inactive styling?
+    active: bool,
+}
+
+impl StatefulWidget for MenuLayer<'_> {
+    type State = ListState;
+
+    fn render(self, area: Rect, buf: &mut Buffer, state: &mut ListState) {
+        fn render_item(item: &SelectItem<MenuItemDisplay>) -> ListItem {
+            let styles = &TuiContext::get().styles.menu;
+
+            let span: Span = match &item.value {
+                MenuItemDisplay::Action { name, shortcut, .. } => {
+                    // If a shortcut is given, include the binding in the text
+                    shortcut
+                        .map(|shortcut| {
+                            TuiContext::get()
+                                .input_engine
+                                .add_hint(name, shortcut)
+                                .into()
+                        })
+                        .unwrap_or_else(|| name.as_str().into())
+                }
+                MenuItemDisplay::Group { name, .. } => {
+                    format!("{name} ▶").into()
+                }
+            };
+
+            let style = if item.enabled() {
+                Style::default()
+            } else {
+                styles.disabled
+            };
+
+            ListItem::new(span).style(style)
+        }
+
+        let styles = &TuiContext::get().styles.menu;
+
+        // Build the list
+        let items = self.select.items_with_metadata().map(render_item);
+        let highlight_style = if self.active {
+            styles.highlight
+        } else {
+            styles.highlight_inactive
+        };
+        let list = List::new(items).highlight_style(highlight_style);
+        StatefulWidget::render(list, area, buf, state);
+    }
+}
+
+/// Emitted event to tell the parent when the user has submitted an action
+#[derive(Debug)]
+struct ActionSubmit;
+
+/// An entry in an action menu
+#[derive(Debug, derive_more::Display)]
+pub enum MenuItem {
+    /// A executable action
+    #[display("{}", _0.name)]
+    Action(MenuAction),
+    /// A grouping of related actions, which can be opened in a nested menu
+    #[display("{name}")]
+    Group { name: String, children: Vec<Self> },
+}
+
+impl MenuItem {
+    /// Is this menu item enabled?
+    #[cfg(test)]
+    pub fn enabled(&self) -> bool {
+        match self {
+            MenuItem::Action(action) => action.enabled,
+            MenuItem::Group { .. } => true,
+        }
+    }
+}
+
+impl From<MenuAction> for MenuItem {
+    fn from(value: MenuAction) -> Self {
+        Self::Action(value)
     }
 }
 
 /// One item in an action menu modal. The action menu is built dynamically, and
 /// each action is tied back to the component that supplied it via an [Emitter].
-#[derive(Debug, derive_more::Display)]
-#[display("{name}")]
+#[derive(Debug)]
 pub struct MenuAction {
     name: String,
     value: Box<dyn LocalEvent>,
@@ -178,34 +508,57 @@ impl MenuAction {
         self.shortcut = shortcut;
         self
     }
-
-    /// Is this action enabled?
-    #[cfg(test)]
-    pub fn enabled(&self) -> bool {
-        self.enabled
-    }
 }
 
-impl Generate for &MenuAction {
-    type Output<'this>
-        = Span<'this>
-    where
-        Self: 'this;
+/// Minimal version of [MenuItem] that can be cloned repeatedly to build
+/// [SelectState]s
+#[derive(Clone, Debug)]
+enum MenuItemDisplay {
+    Action {
+        name: String,
+        enabled: bool,
+        shortcut: Option<Action>,
+    },
+    Group {
+        name: String,
+        children: Vec<Self>,
+    },
+}
 
-    fn generate<'this>(self) -> Self::Output<'this>
-    where
-        Self: 'this,
-    {
-        // If a shortcut is given, include the binding in the text
-        self.shortcut
-            .map(|shortcut| {
-                TuiContext::get()
-                    .input_engine
-                    .add_hint(&self.name, shortcut)
-                    .into()
-            })
-            .unwrap_or_else(|| self.name.as_str().into())
-    }
+/// Map data tree to a tree that can be freely cloned and displayed
+fn map_items(items: &[MenuItem]) -> Vec<MenuItemDisplay> {
+    items
+        .iter()
+        .map(|item| match item {
+            MenuItem::Action(action) => MenuItemDisplay::Action {
+                name: action.name.clone(),
+                enabled: action.enabled,
+                shortcut: action.shortcut,
+            },
+            MenuItem::Group { name, children } => MenuItemDisplay::Group {
+                name: name.clone(),
+                // Recursion!
+                children: map_items(children),
+            },
+        })
+        .collect()
+}
+
+/// Build a select state from a list of menu items
+fn build_select(items: Vec<MenuItemDisplay>) -> SelectState<MenuItemDisplay> {
+    let disabled_indexes = items
+        .iter()
+        .enumerate()
+        .filter(|(_, item)| {
+            matches!(item, MenuItemDisplay::Action { enabled, .. } if !enabled)
+        })
+        .map(|(i, _)| i)
+        .collect_vec();
+
+    SelectState::builder(items)
+        .disabled_indexes(disabled_indexes)
+        .subscribe([SelectStateEventType::Select, SelectStateEventType::Submit])
+        .build()
 }
 
 #[cfg(test)]
@@ -219,10 +572,70 @@ mod tests {
     use terminput::KeyCode;
 
     /// A component that provides some actions
-    #[derive(Debug, Default)]
+    #[derive(derive_more::Debug)]
     struct Actionable {
         id: ComponentId,
-        emitter: Emitter<TestMenuAction>,
+        emitter: Emitter<TestAction>,
+        /// List of returned actions is customizable for different test cases
+        #[debug(skip)]
+        get_actions: Box<dyn Fn(Emitter<TestAction>) -> Vec<MenuItem>>,
+    }
+
+    impl Actionable {
+        fn new(
+            get_actions: impl 'static + Fn(Emitter<TestAction>) -> Vec<MenuItem>,
+        ) -> Self {
+            Self {
+                id: ComponentId::default(),
+                emitter: Default::default(),
+                get_actions: Box::new(get_actions),
+            }
+        }
+    }
+
+    impl Default for Actionable {
+        fn default() -> Self {
+            // By default, return all actions
+            let get_actions = |emitter: Emitter<TestAction>| {
+                vec![
+                    // Disablify is first to test that disabled actions are
+                    // skipped
+                    emitter
+                        .menu(TestAction::Disabled, "Disabled")
+                        .enable(false)
+                        .into(),
+                    emitter.menu(TestAction::Action1, "Action 1").into(),
+                    emitter.menu(TestAction::Action2, "Action 2").into(),
+                    emitter
+                        .menu(TestAction::Shortcutted, "Shortcutted")
+                        .shortcut(Some(Action::Edit))
+                        .into(),
+                    MenuItem::Group {
+                        name: "Nested".into(),
+                        children: vec![
+                            emitter
+                                .menu(TestAction::Nested1, "Nested 1")
+                                .into(),
+                            emitter
+                                .menu(TestAction::Nested2, "Nested 2")
+                                .into(),
+                            MenuItem::Group {
+                                name: "Nested Group".into(),
+                                children: vec![
+                                    emitter
+                                        .menu(
+                                            TestAction::NestedNested1,
+                                            "Nested Nested 1",
+                                        )
+                                        .into(),
+                                ],
+                            },
+                        ],
+                    },
+                ]
+            };
+            Self::new(get_actions)
+        }
     }
 
     impl Component for Actionable {
@@ -230,18 +643,8 @@ mod tests {
             self.id
         }
 
-        fn menu_actions(&self) -> Vec<MenuAction> {
-            let emitter = self.emitter;
-            vec![
-                emitter.menu(TestMenuAction::Flobrigate, "Flobrigate"),
-                emitter.menu(TestMenuAction::Profilate, "Profilate"),
-                emitter
-                    .menu(TestMenuAction::Disablify, "Disablify")
-                    .enable(false),
-                emitter
-                    .menu(TestMenuAction::Shortcutticated, "Shortcutticated")
-                    .shortcut(Some(Action::Edit)),
-            ]
+        fn menu(&self) -> Vec<MenuItem> {
+            (self.get_actions)(self.to_emitter())
         }
     }
 
@@ -249,19 +652,23 @@ mod tests {
         fn draw(&self, _: &mut Canvas, (): (), _: DrawMetadata) {}
     }
 
-    impl ToEmitter<TestMenuAction> for Actionable {
-        fn to_emitter(&self) -> Emitter<TestMenuAction> {
+    impl ToEmitter<TestAction> for Actionable {
+        fn to_emitter(&self) -> Emitter<TestAction> {
             self.emitter
         }
     }
 
     #[derive(Debug, PartialEq)]
-    enum TestMenuAction {
-        // Disablify is first to test that disabled actions are skipped
-        Disablify,
-        Flobrigate,
-        Profilate,
-        Shortcutticated,
+    enum TestAction {
+        Disabled,
+        Action1,
+        Action2,
+        Shortcutted,
+        // Second level!!
+        Nested1,
+        Nested2,
+        // Third level!!
+        NestedNested1,
     }
 
     /// Test basic action menu interactions
@@ -273,13 +680,83 @@ mod tests {
         // Select a basic action
         component
             .int()
-            .action("Profilate")
-            .assert_emitted([TestMenuAction::Profilate]);
+            .action("Action 2")
+            .assert_emitted([TestAction::Action2]);
 
         // Actions can be selected by shortcut
         component
             .int()
             .send_keys([KeyCode::Char('x'), KeyCode::Char('e')])
-            .assert_emitted([TestMenuAction::Shortcutticated]);
+            .assert_emitted([TestAction::Shortcutted]);
+    }
+
+    /// Various input sequences on multiple levels of nested actions
+    #[rstest]
+    // Navigate to the nested menu by arrow key
+    #[case::right_arrow(
+        &[KeyCode::Up, KeyCode::Right, KeyCode::Down, KeyCode::Enter],
+        TestAction::Nested2,
+    )]
+    // Navigate back up to a parent layer with the left arrow
+    #[case::left_arrow(
+        &[KeyCode::Up, KeyCode::Right, KeyCode::Left, KeyCode::Up, KeyCode::Enter],
+        TestAction::Shortcutted,
+    )]
+    // Navigate to the nested menu by Enter
+    #[case::enter(
+        &[KeyCode::Up, KeyCode::Enter, KeyCode::Enter],
+        TestAction::Nested1,
+    )]
+    // Navigate to the innermost menu
+    #[case::nested_nested(
+        &[KeyCode::Up, KeyCode::Right, KeyCode::Up, KeyCode::Right, KeyCode::Enter],
+        TestAction::NestedNested1,
+    )]
+    // Shortcuts should work regardless of which layer is active
+    #[case::shortcut_from_other(
+        &[KeyCode::Up, KeyCode::Right, KeyCode::Char('e')],
+        TestAction::Shortcutted,
+    )]
+    fn test_actions_nested(
+        harness: TestHarness,
+        terminal: TestTerminal,
+        #[case] inputs: &[KeyCode],
+        #[case] expected_action: TestAction,
+    ) {
+        let mut component =
+            TestComponent::new(&harness, &terminal, Actionable::default());
+        component
+            .int()
+            .send_key(KeyCode::Char('x'))
+            .send_keys(inputs.iter().copied())
+            .assert_emitted([expected_action]);
+    }
+
+    /// There once was a bug where the select event wasn't handled correctly
+    /// for the pre-selected item in the list. If the first item is a group, it
+    /// should open correctly on first draw.
+    #[rstest]
+    fn test_first_group_selected(harness: TestHarness, terminal: TestTerminal) {
+        let get_actions = |emitter: Emitter<TestAction>| {
+            vec![MenuItem::Group {
+                name: "Nested".into(),
+                children: vec![
+                    emitter.menu(TestAction::Nested1, "Nested 1").into(),
+                    emitter.menu(TestAction::Nested2, "Nested 2").into(),
+                ],
+            }]
+        };
+
+        let mut component = TestComponent::new(
+            &harness,
+            &terminal,
+            Actionable::new(get_actions),
+        );
+
+        // Group should be expanded when the modal is first opened
+        component
+            .int()
+            .send_keys([KeyCode::Char('x'), KeyCode::Right, KeyCode::Enter])
+            .assert_emitted([TestAction::Nested1]);
     }
 }

--- a/crates/tui/src/view/common/modal.rs
+++ b/crates/tui/src/view/common/modal.rs
@@ -3,7 +3,7 @@ use crate::{
     view::{
         Component, UpdateContext,
         component::{Canvas, Child, ComponentId, Draw, DrawMetadata, Portal},
-        event::{Emitter, Event, OptionEvent},
+        event::{Event, OptionEvent},
     },
 };
 use ratatui::{
@@ -115,13 +115,6 @@ impl<T: Component + Modal> Component for ModalQueue<T> {
                 Action::Submit => self.close(context, true),
                 _ => propagate.set(),
             })
-            .emitted_opt(
-                // If this modal type emits ModalEvent, check for that
-                self.active().and_then(Modal::emitter),
-                |event: ModalEvent| match event {
-                    ModalEvent::Submit => self.close(context, true),
-                },
-            )
             .any(|event| match event {
                 // Modals are meant to consume all focus, so don't allow any
                 // events to go to background components
@@ -180,13 +173,6 @@ pub trait Modal {
     /// Dimensions of the modal, relative to the whole screen
     fn dimensions(&self) -> (Constraint, Constraint);
 
-    /// Get an emitter of [ModalEvent]. This allows modal implementations to
-    /// *optionally* provide an emitter to communicate back to their
-    /// [ModalQueue].
-    fn emitter(&self) -> Option<Emitter<ModalEvent>> {
-        None
-    }
-
     /// Callback when the user hits Enter while a modal is open.
     ///
     /// Most modals should use this to handle submissions logic, such as
@@ -198,12 +184,4 @@ pub trait Modal {
         Self: Sized,
     {
     }
-}
-
-/// An emitted event that allows a modal to communicate back to its containing
-/// [ModalQueue].
-#[derive(Debug)]
-pub enum ModalEvent {
-    /// Close the modal *with* submission
-    Submit,
 }

--- a/crates/tui/src/view/common/text_box.rs
+++ b/crates/tui/src/view/common/text_box.rs
@@ -565,7 +565,7 @@ mod tests {
                     KeyCode::Char('W'),
                     KeyModifiers::CTRL | KeyModifiers::SHIFT,
                 )
-                .events(),
+                .propagated(),
             &[Event::Input { .. }]
         );
         assert_state(&component.state, "hi!W", 4);

--- a/crates/tui/src/view/component/exchange_pane.rs
+++ b/crates/tui/src/view/component/exchange_pane.rs
@@ -3,7 +3,7 @@ use crate::{
     http::{RequestMetadata, ResponseMetadata},
     view::{
         Generate, RequestState,
-        common::{Pane, actions::MenuAction, modal::ModalQueue, tabs::Tabs},
+        common::{Pane, actions::MenuItem, modal::ModalQueue, tabs::Tabs},
         component::{
             Canvas, Component, ComponentId, Draw, DrawMetadata,
             internal::{Child, ToChild},
@@ -377,7 +377,7 @@ impl Component for ExchangePaneContent {
             })
     }
 
-    fn menu_actions(&self) -> Vec<MenuAction> {
+    fn menu(&self) -> Vec<MenuItem> {
         let emitter = self.actions_emitter;
         let request = self.state.request();
         let has_request = request.is_some();
@@ -393,47 +393,67 @@ impl Component for ExchangePaneContent {
         let selected_tab = self.tabs.selected();
 
         vec![
-            emitter
-                .menu(ExchangePaneMenuAction::CopyUrl, "Copy URL")
-                .enable(has_request),
-            emitter
-                .menu(
-                    ExchangePaneMenuAction::CopyRequestBody,
-                    "Copy Request Body",
-                )
-                .enable(has_request_body),
-            emitter
-                .menu(
-                    ExchangePaneMenuAction::ViewRequestBody,
-                    "View Request Body",
-                )
-                .enable(has_request_body)
-                .shortcut(
-                    (selected_tab == Tab::Request).then_some(Action::View),
-                ),
-            emitter
-                .menu(
-                    ExchangePaneMenuAction::CopyResponseBody,
-                    "Copy Response Body",
-                )
-                .enable(has_response_body),
-            emitter
-                .menu(
-                    ExchangePaneMenuAction::ViewResponseBody,
-                    "View Response Body",
-                )
-                .enable(has_response_body)
-                .shortcut((selected_tab == Tab::Body).then_some(Action::View)),
-            emitter
-                .menu(
-                    ExchangePaneMenuAction::SaveResponseBody,
-                    "Save Response Body as File",
-                )
-                .enable(has_response_body),
+            MenuItem::Group {
+                name: "Request".into(),
+                children: vec![
+                    emitter
+                        .menu(ExchangePaneMenuAction::CopyUrl, "Copy URL")
+                        .enable(has_request)
+                        .into(),
+                    emitter
+                        .menu(
+                            ExchangePaneMenuAction::CopyRequestBody,
+                            "Copy Body",
+                        )
+                        .enable(has_request_body)
+                        .into(),
+                    emitter
+                        .menu(
+                            ExchangePaneMenuAction::ViewRequestBody,
+                            "View Body",
+                        )
+                        .enable(has_request_body)
+                        .shortcut(
+                            (selected_tab == Tab::Request)
+                                .then_some(Action::View),
+                        )
+                        .into(),
+                ],
+            },
+            MenuItem::Group {
+                name: "Response".into(),
+                children: vec![
+                    emitter
+                        .menu(
+                            ExchangePaneMenuAction::CopyResponseBody,
+                            "Copy Body",
+                        )
+                        .enable(has_response_body)
+                        .into(),
+                    emitter
+                        .menu(
+                            ExchangePaneMenuAction::ViewResponseBody,
+                            "View Body",
+                        )
+                        .enable(has_response_body)
+                        .shortcut(
+                            (selected_tab == Tab::Body).then_some(Action::View),
+                        )
+                        .into(),
+                    emitter
+                        .menu(
+                            ExchangePaneMenuAction::SaveResponseBody,
+                            "Save Body as File",
+                        )
+                        .enable(has_response_body)
+                        .into(),
+                ],
+            },
             emitter
                 .menu(ExchangePaneMenuAction::DeleteRequest, "Delete Request")
                 .enable(has_request)
-                .shortcut(Some(Action::Delete)),
+                .shortcut(Some(Action::Delete))
+                .into(),
         ]
     }
 

--- a/crates/tui/src/view/component/history.rs
+++ b/crates/tui/src/view/component/history.rs
@@ -263,14 +263,14 @@ mod tests {
 
         // Initial state
         let selected = assert_matches!(
-            component.int().drain_draw().events(),
+            component.int().drain_draw().propagated(),
             &[Event::HttpSelectRequest(Some(selected))] => selected,
         );
         assert_eq!(selected, exchanges[0].id);
 
         // Select the next one
         let selected = assert_matches!(
-            component.int().send_key(KeyCode::Down).events(),
+            component.int().send_key(KeyCode::Down).propagated(),
             &[Event::HttpSelectRequest(Some(selected))] => selected,
         );
         assert_eq!(selected, exchanges[1].id);
@@ -308,7 +308,7 @@ mod tests {
 
         // Initial state
         let selected = assert_matches!(
-            component.int().drain_draw().events(),
+            component.int().drain_draw().propagated(),
             &[Event::HttpSelectRequest(Some(selected))] => selected,
         );
         assert_eq!(selected, exchanges[0].id);
@@ -318,7 +318,7 @@ mod tests {
             component
                 .int()
                 .send_keys([KeyCode::Delete, KeyCode::Enter])
-                .events(),
+                .propagated(),
             &[Event::HttpSelectRequest(Some(selected))] => selected,
         );
         assert_eq!(selected, exchanges[1].id);
@@ -328,7 +328,7 @@ mod tests {
             component
                 .int()
                 .send_keys([KeyCode::Delete, KeyCode::Enter])
-                .events(),
+                .propagated(),
             &[Event::HttpSelectRequest(None)],
         );
 

--- a/crates/tui/src/view/component/primary.rs
+++ b/crates/tui/src/view/component/primary.rs
@@ -6,7 +6,7 @@ use crate::{
     util::ResultReported,
     view::{
         Component, ViewContext,
-        common::{actions::MenuAction, modal::ModalQueue},
+        common::{actions::MenuItem, modal::ModalQueue},
         component::{
             Canvas, Child, ComponentId, Draw, DrawMetadata, ToChild,
             collection_select::CollectionSelect,
@@ -352,7 +352,7 @@ impl Component for PrimaryView {
             })
     }
 
-    fn menu_actions(&self) -> Vec<MenuAction> {
+    fn menu(&self) -> Vec<MenuItem> {
         let emitter = self.global_actions_emitter;
         let edit_collection_name = match self.selected_recipe_node() {
             None => "Edit Collection",
@@ -361,7 +361,8 @@ impl Component for PrimaryView {
         };
         vec![
             emitter
-                .menu(PrimaryMenuAction::EditCollection, edit_collection_name),
+                .menu(PrimaryMenuAction::EditCollection, edit_collection_name)
+                .into(),
         ]
     }
 
@@ -543,7 +544,7 @@ mod tests {
         let mut component = TestComponent::new(harness, terminal, view);
         // Initial events
         assert_matches!(
-            component.int().drain_draw().events(),
+            component.int().drain_draw().propagated(),
             &[Event::HttpSelectRequest(None)]
         );
         // Clear template preview messages so we can test what we want

--- a/crates/tui/src/view/component/recipe_list.rs
+++ b/crates/tui/src/view/component/recipe_list.rs
@@ -4,7 +4,7 @@ use crate::{
         Component, Generate, ViewContext,
         common::{
             Pane,
-            actions::MenuAction,
+            actions::MenuItem,
             list::List,
             text_box::{TextBox, TextBoxEvent, TextBoxProps},
         },
@@ -207,8 +207,8 @@ impl Component for RecipeListPane {
             })
     }
 
-    fn menu_actions(&self) -> Vec<MenuAction> {
-        RecipeMenuAction::menu_actions(
+    fn menu(&self) -> Vec<MenuItem> {
+        RecipeMenuAction::menu(
             self.actions_emitter,
             self.selected_recipe_id().is_some(),
         )
@@ -466,7 +466,7 @@ mod tests {
         );
         // Clear initial events
         assert_matches!(
-            component.int().drain_draw().events(),
+            component.int().drain_draw().propagated(),
             &[Event::HttpSelectRequest(None)],
         );
 
@@ -477,7 +477,7 @@ mod tests {
         // Find something. Match should be caseless. Should trigger an event to
         // load the latest request
         assert_matches!(
-            component.int().send_text("2").events(),
+            component.int().send_text("2").propagated(),
             &[Event::HttpSelectRequest(None)]
         );
         let select = &component.select;

--- a/crates/tui/src/view/component/recipe_pane.rs
+++ b/crates/tui/src/view/component/recipe_pane.rs
@@ -12,7 +12,7 @@ use crate::{
     message::RequestConfig,
     view::{
         Component, Generate,
-        common::{Pane, actions::MenuAction},
+        common::{Pane, actions::MenuItem},
         component::{
             Canvas, ComponentId, Draw, DrawMetadata,
             internal::{Child, ToChild},
@@ -89,8 +89,8 @@ impl Component for RecipePane {
             })
     }
 
-    fn menu_actions(&self) -> Vec<MenuAction> {
-        RecipeMenuAction::menu_actions(
+    fn menu(&self) -> Vec<MenuItem> {
+        RecipeMenuAction::menu(
             self.actions_emitter,
             self.recipe_state.borrow().is_some(),
         )
@@ -215,18 +215,20 @@ pub enum RecipeMenuAction {
 impl RecipeMenuAction {
     /// Build a list of these actions. This action is used in multiple
     /// components so the list is centralized here
-    pub fn menu_actions(
-        emitter: Emitter<Self>,
-        has_recipe: bool,
-    ) -> Vec<MenuAction> {
+    pub fn menu(emitter: Emitter<Self>, has_recipe: bool) -> Vec<MenuItem> {
         vec![
-            emitter.menu(Self::CopyUrl, "Copy URL").enable(has_recipe),
+            emitter
+                .menu(Self::CopyUrl, "Copy URL")
+                .enable(has_recipe)
+                .into(),
             emitter
                 .menu(Self::CopyCurl, "Copy as cURL")
-                .enable(has_recipe),
+                .enable(has_recipe)
+                .into(),
             emitter
                 .menu(Self::DeleteRecipe, "Delete Requests")
-                .enable(has_recipe),
+                .enable(has_recipe)
+                .into(),
         ]
     }
 }

--- a/crates/tui/src/view/component/recipe_pane/authentication.rs
+++ b/crates/tui/src/view/component/recipe_pane/authentication.rs
@@ -2,7 +2,7 @@ use crate::{
     context::TuiContext,
     view::{
         Generate,
-        common::{actions::MenuAction, modal::ModalQueue, table::Table},
+        common::{actions::MenuItem, modal::ModalQueue, table::Table},
         component::{
             Canvas, Component, ComponentId, Draw, DrawMetadata, ToChild,
             internal::Child,
@@ -153,16 +153,18 @@ impl Component for AuthenticationDisplay {
             })
     }
 
-    fn menu_actions(&self) -> Vec<MenuAction> {
+    fn menu(&self) -> Vec<MenuItem> {
         let emitter = self.actions_emitter;
         vec![
             emitter
                 .menu(AuthenticationMenuAction::Edit, "Edit Authentication")
-                .shortcut(Some(Action::Edit)),
+                .shortcut(Some(Action::Edit))
+                .into(),
             emitter
                 .menu(AuthenticationMenuAction::Reset, "Reset Authentication")
                 .enable(self.state.is_overridden())
-                .shortcut(Some(Action::Reset)),
+                .shortcut(Some(Action::Reset))
+                .into(),
         ]
     }
 

--- a/crates/tui/src/view/component/recipe_pane/body.rs
+++ b/crates/tui/src/view/component/recipe_pane/body.rs
@@ -4,7 +4,7 @@ use crate::{
     view::{
         Component, ViewContext,
         common::{
-            actions::MenuAction,
+            actions::MenuItem,
             text_window::{ScrollbarMargins, TextWindow, TextWindowProps},
         },
         component::{
@@ -287,20 +287,23 @@ impl Component for TextBody {
             })
     }
 
-    fn menu_actions(&self) -> Vec<MenuAction> {
+    fn menu(&self) -> Vec<MenuItem> {
         let emitter = self.actions_emitter;
         vec![
             emitter
                 .menu(RawBodyMenuAction::View, "View Body")
-                .shortcut(Some(Action::View)),
-            emitter.menu(RawBodyMenuAction::Copy, "Copy Body"),
+                .shortcut(Some(Action::View))
+                .into(),
+            emitter.menu(RawBodyMenuAction::Copy, "Copy Body").into(),
             emitter
                 .menu(RawBodyMenuAction::Edit, "Edit Body")
-                .shortcut(Some(Action::Edit)),
+                .shortcut(Some(Action::Edit))
+                .into(),
             emitter
                 .menu(RawBodyMenuAction::Reset, "Reset Body")
                 .enable(self.body.is_overridden())
-                .shortcut(Some(Action::Reset)),
+                .shortcut(Some(Action::Reset))
+                .into(),
         ]
     }
 

--- a/crates/tui/src/view/component/recipe_pane/table.rs
+++ b/crates/tui/src/view/component/recipe_pane/table.rs
@@ -1,7 +1,7 @@
 use crate::view::{
     Generate,
     common::{
-        actions::MenuAction,
+        actions::MenuItem,
         modal::ModalQueue,
         table::{Table, ToggleRow},
     },
@@ -187,7 +187,7 @@ where
             })
     }
 
-    fn menu_actions(&self) -> Vec<MenuAction> {
+    fn menu(&self) -> Vec<MenuItem> {
         let emitter = self.actions_emitter;
         let noun = self.noun;
         let selected = self.select.selected();
@@ -195,11 +195,13 @@ where
             emitter
                 .menu(RecipeTableMenuAction::Edit, format!("Edit {noun}"))
                 .enable(selected.is_some())
-                .shortcut(Some(Action::Edit)),
+                .shortcut(Some(Action::Edit))
+                .into(),
             emitter
                 .menu(RecipeTableMenuAction::Reset, format!("Reset {noun}"))
                 .enable(selected.is_some_and(|row| row.value.is_overridden()))
-                .shortcut(Some(Action::Reset)),
+                .shortcut(Some(Action::Reset))
+                .into(),
         ]
     }
 

--- a/crates/tui/src/view/component/recipe_pane/url.rs
+++ b/crates/tui/src/view/component/recipe_pane/url.rs
@@ -1,6 +1,6 @@
 use crate::view::{
     UpdateContext,
-    common::{actions::MenuAction, modal::ModalQueue},
+    common::{actions::MenuItem, modal::ModalQueue},
     component::{
         Canvas, Child, Component, ComponentId, Draw, DrawMetadata, ToChild,
         misc::TextBoxModal,
@@ -83,16 +83,18 @@ impl Component for UrlDisplay {
             })
     }
 
-    fn menu_actions(&self) -> Vec<MenuAction> {
+    fn menu(&self) -> Vec<MenuItem> {
         let emitter = self.actions_emitter;
         vec![
             emitter
                 .menu(UrlMenuAction::Edit, "Edit URL")
-                .shortcut(Some(Action::Edit)),
+                .shortcut(Some(Action::Edit))
+                .into(),
             emitter
                 .menu(UrlMenuAction::Reset, "Reset URL")
                 .enable(self.url.is_overridden())
-                .shortcut(Some(Action::Reset)),
+                .shortcut(Some(Action::Reset))
+                .into(),
         ]
     }
 

--- a/crates/tui/src/view/component/root.rs
+++ b/crates/tui/src/view/component/root.rs
@@ -4,7 +4,7 @@ use crate::{
     util::ResultReported,
     view::{
         Component, Confirm, ViewContext,
-        common::{actions::ActionsModal, modal::ModalQueue, text_box::TextBox},
+        common::{actions::ActionsMenu, modal::ModalQueue, text_box::TextBox},
         component::{
             Canvas, Child, ComponentId, Draw, DrawMetadata, ToChild,
             footer::Footer,
@@ -46,7 +46,7 @@ pub struct Root {
     // queues. They use the same implementation, but it's only possible to open
     // multiple modals at a time if the trigger is from the background (e.g.
     // errors or prompts).
-    actions: ModalQueue<ActionsModal>,
+    actions: ActionsMenu,
     cancel_request_confirm: ModalQueue<ConfirmModal>,
     confirms: ModalQueue<ConfirmModal>,
     errors: ModalQueue<ErrorModal>,
@@ -70,7 +70,7 @@ impl Root {
             // Children
             primary_view,
             footer: Footer::default(),
-            actions: ModalQueue::default(),
+            actions: ActionsMenu::default(),
             cancel_request_confirm: ModalQueue::default(),
             confirms: ModalQueue::default(),
             errors: ModalQueue::default(),
@@ -246,7 +246,7 @@ impl Component for Root {
                     let actions = self.primary_view.collect_actions();
                     // Actions can be empty if a modal is already open
                     if !actions.is_empty() {
-                        self.actions.open(ActionsModal::new(actions));
+                        self.actions.open(actions);
                     }
                 }
                 Action::History => self.open_history(context.request_store),

--- a/crates/tui/src/view/state/select.rs
+++ b/crates/tui/src/view/state/select.rs
@@ -738,7 +738,7 @@ mod tests {
             component
                 .int_props(&props_fn)
                 .send_key(KeyCode::Enter)
-                .events(),
+                .propagated(),
             &[Event::Input {
                 action: Some(Action::Submit),
                 ..
@@ -748,7 +748,7 @@ mod tests {
             component
                 .int_props(&props_fn)
                 .send_key(KeyCode::Char(' '))
-                .events(),
+                .propagated(),
             &[Event::Input {
                 action: Some(Action::Toggle),
                 ..

--- a/crates/tui/src/view/styles.rs
+++ b/crates/tui/src/view/styles.rs
@@ -11,6 +11,7 @@ use slumber_config::Theme;
 #[derive(Debug)]
 pub struct Styles {
     pub list: ListStyles,
+    pub menu: MenuStyles,
     pub modal: ModalStyles,
     pub pane: PaneStyles,
     pub status_code: StatusCodeStyles,
@@ -27,6 +28,18 @@ pub struct Styles {
 pub struct ListStyles {
     /// Highlighted item in a list
     pub highlight: Style,
+    /// Disabled item in a list
+    pub disabled: Style,
+}
+
+/// Styles for menus with nested groups
+#[derive(Debug)]
+pub struct MenuStyles {
+    /// Highlighted item in a menu
+    pub highlight: Style,
+    /// Highlight item in an inactive layer in a menu (a different menu group
+    /// is )
+    pub highlight_inactive: Style,
     /// Disabled item in a list
     pub disabled: Style,
 }
@@ -135,6 +148,16 @@ impl Styles {
                 highlight: Style::default()
                     .bg(theme.primary_color)
                     .fg(theme.primary_text_color)
+                    .add_modifier(Modifier::BOLD),
+                disabled: Style::default().add_modifier(Modifier::DIM),
+            },
+            menu: MenuStyles {
+                highlight: Style::default()
+                    .bg(theme.primary_color)
+                    .fg(theme.primary_text_color)
+                    .add_modifier(Modifier::BOLD),
+                highlight_inactive: Style::default()
+                    .bg(Color::DarkGray)
                     .add_modifier(Modifier::BOLD),
                 disabled: Style::default().add_modifier(Modifier::DIM),
             },


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Menu actions can contain groups with nested actions. This will make it easier to organize actions as menus get longer.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

## QA

_How did you test this?_

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
