### PR TITLE
Calculate action menu width dynamically

### DIFF
--- a/crates/tui/src/view/component/root.rs
+++ b/crates/tui/src/view/component/root.rs
@@ -4,7 +4,7 @@ use crate::{
     util::ResultReported,
     view::{
         Component, Confirm, ViewContext,
-        common::{actions::ActionsMenu, modal::ModalQueue, text_box::TextBox},
+        common::{actions::ActionMenu, modal::ModalQueue, text_box::TextBox},
         component::{
             Canvas, Child, ComponentId, Draw, DrawMetadata, ToChild,
             footer::Footer,
@@ -46,7 +46,7 @@ pub struct Root {
     // queues. They use the same implementation, but it's only possible to open
     // multiple modals at a time if the trigger is from the background (e.g.
     // errors or prompts).
-    actions: ActionsMenu,
+    actions: ActionMenu,
     cancel_request_confirm: ModalQueue<ConfirmModal>,
     confirms: ModalQueue<ConfirmModal>,
     errors: ModalQueue<ErrorModal>,
@@ -70,7 +70,7 @@ impl Root {
             // Children
             primary_view,
             footer: Footer::default(),
-            actions: ActionsMenu::default(),
+            actions: ActionMenu::default(),
             cancel_request_confirm: ModalQueue::default(),
             confirms: ModalQueue::default(),
             errors: ModalQueue::default(),

--- a/crates/tui/src/view/test_util.rs
+++ b/crates/tui/src/view/test_util.rs
@@ -6,7 +6,7 @@ use crate::{
     test_util::{TestHarness, TestTerminal},
     view::{
         UpdateContext,
-        common::actions::{ActionsMenu, MenuItem},
+        common::actions::{ActionMenu, MenuItem},
         component::{
             Canvas, Child, Component, ComponentExt, ComponentId, Draw,
             DrawMetadata, ToChild,
@@ -547,14 +547,14 @@ where
 #[derive(Debug)]
 struct TestWrapper<T> {
     inner: T,
-    actions: ActionsMenu,
+    actions: ActionMenu,
 }
 
 impl<T> TestWrapper<T> {
     pub fn new(component: T) -> Self {
         Self {
             inner: component,
-            actions: ActionsMenu::default(),
+            actions: ActionMenu::default(),
         }
     }
 }


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Before

<img width="888" height="294" alt="image" src="https://github.com/user-attachments/assets/cd0a0f99-f20d-48d3-9532-4a1e216608b0" />


After

<img width="206" height="135" alt="image" src="https://github.com/user-attachments/assets/4c4e2c73-1cd2-4583-a033-3086792a3059" />


## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

## QA

_How did you test this?_

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
