### PR TITLE
Do not propagate click events from modals

### DIFF
--- a/crates/tui/src/view/common/actions.rs
+++ b/crates/tui/src/view/common/actions.rs
@@ -15,7 +15,7 @@ use crate::{
 use itertools::Itertools;
 use ratatui::{
     buffer::Buffer,
-    layout::Constraint,
+    layout::{Constraint, Position},
     prelude::Rect,
     style::Style,
     text::Span,
@@ -132,6 +132,12 @@ impl Component for ActionMenu {
                 Event::Input { .. } => None,
                 _ => Some(event),
             })
+    }
+
+    fn contains_cursor(&self, _position: Position) -> bool {
+        // We want to receive clicks in the background, but we can't draw to
+        // that space or it would actually cover everything up
+        true
     }
 
     fn children(&mut self) -> Vec<Child<'_>> {

--- a/crates/tui/src/view/common/modal.rs
+++ b/crates/tui/src/view/common/modal.rs
@@ -7,7 +7,7 @@ use crate::{
     },
 };
 use ratatui::{
-    layout::{Constraint, Margin, Rect},
+    layout::{Constraint, Margin, Position, Rect},
     text::Line,
     widgets::{Block, Borders},
 };
@@ -121,6 +121,12 @@ impl<T: Component + Modal> Component for ModalQueue<T> {
                 Event::Input { .. } => None,
                 _ => Some(event),
             })
+    }
+
+    fn contains_cursor(&self, _position: Position) -> bool {
+        // We want to receive clicks in the background, but we can't draw to
+        // that space or it would actually cover everything up
+        true
     }
 
     fn children(&mut self) -> Vec<Child<'_>> {


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

More semi-jank. Modals and menus now receive and eat all mouse events.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

## QA

_How did you test this?_

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
