### PR TITLE
Merge borders between panes

### DIFF
--- a/crates/tui/src/test_util.rs
+++ b/crates/tui/src/test_util.rs
@@ -108,7 +108,7 @@ pub fn terminal(width: u16, height: u16) -> TestTerminal {
 /// Terminal width in chars, for injection to [terminal] fixture
 #[fixture]
 fn width() -> u16 {
-    40
+    50
 }
 
 /// Terminal height in chars, for injection to [terminal] fixture

--- a/crates/tui/src/view/common.rs
+++ b/crates/tui/src/view/common.rs
@@ -26,6 +26,7 @@ use chrono::{DateTime, Duration, Utc};
 use itertools::{Itertools, Position};
 use ratatui::{
     prelude::{Buffer, Rect},
+    symbols::merge::MergeStrategy,
     text::{Line, Span, Text},
     widgets::{Block, Borders, Paragraph, Widget, Wrap},
 };
@@ -55,6 +56,7 @@ impl Generate for Pane<'_> {
             .borders(Borders::ALL)
             .border_type(border_type)
             .border_style(border_style)
+            .merge_borders(MergeStrategy::Fuzzy)
             .title(self.title)
     }
 }

--- a/crates/tui/src/view/component/primary.rs
+++ b/crates/tui/src/view/component/primary.rs
@@ -30,7 +30,7 @@ use crate::{
 };
 use derive_more::Display;
 use ratatui::{
-    layout::Layout,
+    layout::{Layout, Spacing},
     prelude::{Constraint, Rect},
 };
 use serde::{Deserialize, Serialize};
@@ -169,15 +169,20 @@ impl PrimaryView {
                     Constraint::Max(40),
                     Constraint::Min(40),
                 ])
+                // Overlap so pane borders merge
+                .spacing(Spacing::Overlap(1))
                 .areas(area);
 
                 let [profile_area, recipe_list_area] = Layout::vertical([
                     Constraint::Length(3),
                     Constraint::Min(0),
                 ])
+                // Overlap so pane borders merge
+                .spacing(Spacing::Overlap(1))
                 .areas(left_area);
                 let [recipe_area, exchange_area] =
                     self.get_right_column_layout(right_area);
+
                 Panes {
                     profile: PaneState {
                         area: profile_area,
@@ -207,12 +212,10 @@ impl PrimaryView {
             PrimaryPane::Recipe => (2, 1),
             PrimaryPane::Exchange | PrimaryPane::RecipeList => (1, 2),
         };
-        let denominator = top + bottom;
-        Layout::vertical([
-            Constraint::Ratio(top, denominator),
-            Constraint::Ratio(bottom, denominator),
-        ])
-        .areas(area)
+        Layout::vertical([Constraint::Fill(top), Constraint::Fill(bottom)])
+            // Overlap so pane borders merge
+            .spacing(Spacing::Overlap(1))
+            .areas(area)
     }
 
     /// Send a request for the currently selected recipe


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

<img width="1277" height="687" alt="image" src="https://github.com/user-attachments/assets/d2251d90-e766-4e38-b45d-119614f0a46a" />


## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

The double border gets reverted to a single border for the recipe list/recipe panes because it gets drawn over by following panes. Need to adjust the draw order to fix. I'm going to be making bigger refactors though so I'm punting for now.

## QA

_How did you test this?_

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
