### PR TITLE
Fix crash when previewing JSON body with escaped quote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 <!-- ANCHOR: changelog -->
 
+### Fixed
+
+- Fix crash when previewing a JSON body that contains an escaped quote [#646](https://github.com/LucasPickering/slumber/issues/646)
+
 ## [4.2.0] - 2025-10-14
 
 <!-- ANCHOR: changelog -->


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

When a JSON template has double quotes inside it, the stringification during preview generation escapes those quotes. The escaped quotes create an invalid template. Previously this caused a crash. I made it fall back to a raw template instead. The preview template will be incorrect, but it's better than crashing. I don't feel like fixing this properly; it all needs to be replaced in #627. The whole stringify-and-reparse thing was a hack to begin with.

Closes #646

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

We're showing an incorrect preview, which will be confusing. It's better than crashing though and not worth fixing IMO.


## QA

_How did you test this?_

Added unit tests

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
