### PR TITLE
Add `default` kwarg to env()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 <!-- ANCHOR: changelog -->
 
+### Added
+
+- Add `default` keyword arg to `env()`
+
 ## [4.2.1] - 2025-11-26
 
 <!-- ANCHOR: changelog -->

--- a/crates/core/src/render/functions.rs
+++ b/crates/core/src/render/functions.rs
@@ -274,16 +274,18 @@ pub fn debug(value: Value) -> Value {
 /// **Parameters**
 ///
 /// - `variable`: Name of the environment variable to read
+/// - `default`: Value to return when the environment variable is not present
 ///
 /// **Examples**
 ///
 /// ```sh
 /// {{ env("HOME") }} => "/home/username"
-/// {{ env("NONEXISTENT") }} => null
+/// {{ env("NONEXISTENT") }} => ""
+/// {{ env("NONEXISTENT", default="default") }} => "default"
 /// ```
 #[template]
-pub fn env(variable: String) -> String {
-    env::var(variable).unwrap_or_default()
+pub fn env(variable: String, #[kwarg] default: String) -> String {
+    env::var(variable).unwrap_or(default)
 }
 
 /// Load contents of a file. While the output type is `bytes`,

--- a/crates/core/src/render/tests.rs
+++ b/crates/core/src/render/tests.rs
@@ -267,14 +267,20 @@ async fn test_concat(
 
 /// `env()`
 #[rstest]
-#[case::set("CARGO_PKG_NAME", Ok("slumber_core"))]
-#[case::unset("NOT_A_REAL_ENV_VAR", Ok(""))]
+#[case::set("CARGO_PKG_NAME", None, Ok("slumber_core"))]
+#[case::unset("NOT_A_REAL_ENV_VAR", None, Ok(""))]
+#[case::unset_default("NOT_A_REAL_ENV_VAR", Some("default"), Ok("default"))]
 #[tokio::test]
 async fn test_env(
     #[case] variable: &str,
+    #[case] default: Option<&str>,
     #[case] expected: Result<&str, &str>,
 ) {
-    let template = Template::function_call("env", [variable.into()], []);
+    let template = Template::function_call(
+        "env",
+        [variable.into()],
+        [("default", default.map(Expression::from))],
+    );
     assert_result(
         template
             .render_bytes(&TemplateContext::factory(()).streaming(false))


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

`env()` now takes a `default` kwarg that specifies what string to return when the env var isn't present.

I wanted to implement this with an `or()` function instead, like `env('VAR') | or('default')`, but the arg order doesn't work with the pipe operator. This is a simple solution that doesn't prevent any future improvement so I'm going with it for now.

Closes #652

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

- Only supports strings
- Could be redundant with `or()` or `coalesce()` or similar in the future

## QA

_How did you test this?_

Unit test

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
