### PR TITLE
Explicit editing in prompt form

### DIFF
--- a/crates/tui/src/input.rs
+++ b/crates/tui/src/input.rs
@@ -36,7 +36,7 @@ impl InputEngine {
     /// action is unbound, use a placeholder string instead
     pub fn binding_display(&self, action: Action) -> String {
         self.binding(action)
-            .map(|binding| format!("{binding}"))
+            .map(|binding| format!("[{binding}]"))
             .unwrap_or_else(|| "<unbound>".to_owned())
     }
 

--- a/crates/tui/src/view/component/queryable_body.rs
+++ b/crates/tui/src/view/component/queryable_body.rs
@@ -528,7 +528,7 @@ mod tests {
     #[tokio::test]
     async fn test_text_body(
         harness: TestHarness,
-        #[with(26, 3)] terminal: TestTerminal,
+        #[with(27, 3)] terminal: TestTerminal,
         response: Arc<ResponseRecord>,
     ) {
         let mut component = TestComponent::new(
@@ -543,14 +543,11 @@ mod tests {
         let styles = &TuiContext::get().styles.text_box;
         terminal.assert_buffer_lines([
             vec![gutter("1"), " {\"greeting\":\"hello\"}".into()],
-            vec![gutter(" "), "                       ".into()],
-            vec![
-                Span::styled(
-                    "/ to query, : to export",
-                    styles.text.patch(styles.placeholder),
-                ),
-                Span::styled("   ", styles.text),
-            ],
+            vec![gutter(" "), "".into()],
+            vec![Span::styled(
+                "[/] to query, [:] to export",
+                styles.text.patch(styles.placeholder),
+            )],
         ]);
 
         // Type something into the query box
@@ -586,9 +583,9 @@ mod tests {
 
         // Check the view again
         terminal.assert_buffer_lines([
-            vec![gutter("1"), " {                  ".into()],
-            vec![gutter(" "), "                    ".into()],
-            vec![Span::styled("head -c 1                 ", styles.text)],
+            vec![gutter("1"), " {                   ".into()],
+            vec![gutter(" "), "                     ".into()],
+            vec![Span::styled("head -c 1                  ", styles.text)],
         ]);
     }
 

--- a/crates/tui/src/view/styles.rs
+++ b/crates/tui/src/view/styles.rs
@@ -148,6 +148,7 @@ impl Styles {
             form: FormStyles {
                 title: Style::default().add_modifier(Modifier::UNDERLINED),
                 title_highlight: Style::default()
+                    .fg(theme.primary_color)
                     .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
             },
             list: ListStyles {

--- a/docs/src/api/configuration/input_bindings.md
+++ b/docs/src/api/configuration/input_bindings.md
@@ -53,7 +53,7 @@ input_bindings:
 | `toggle`              | `space`         | Toggle a checkbox on/off                              |
 | `cancel`              | `esc`           | Cancel current dialog or request                      |
 | `delete`              | `delete`        | Delete the selected object (e.g. a request)           |
-| `edit`                | `e`             | Apply a temporary override to a recipe value          |
+| `edit`                | `e`             | Edit a template or form field                         |
 | `reset`               | `r`             | Reset temporary recipe override to its default        |
 | `view`                | `v`             | Open the selected content (e.g. body) in your pager   |
 | `history`             | `h`             | Open request history for a recipe                     |


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

You have to explicitly enter edit mode on the prompt form. TBD if it should be in edit mode by default.

By allowing the user to exit edit mode, it makes it easier to navigate outside the form without closing it.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

The added edit step may be annoying. Mitigated by retaining edit mode when switching fields.

## QA

_How did you test this?_

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
