### PR TITLE
Use static YAML file for default config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   - `upper()` and `lower()` convert strings to upper/lower case respectively
   - `replace()` replaces occurrences of one string (or regex) with another
 
+### Changed
+
+- Default config file no longer contains all known configuration fields
+  - Instead it's just a single example field and a link to the docs now
+  - If you have an old default file, it will be replaced by the new one. Any file that's been modified from the default in any way (including just whitespace/comments) will **not** be modified
+  - See [#670](https://github.com/LucasPickering/slumber/pull/670) for more
+
 ## [4.2.1] - 2025-11-26
 
 <!-- ANCHOR: changelog -->

--- a/crates/config/src/default.yml
+++ b/crates/config/src/default.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema={{#schema}}
+# ^ This enables schema validation and autocomplete in your editor
+# https://github.com/redhat-developer/yaml-language-server
+
+# For configuration options, see:
+# https://slumber.lucaspickering.me/api/configuration/index.html
+
+input_bindings:
+  submit: [enter]

--- a/crates/config/src/default_old.yml
+++ b/crates/config/src/default_old.yml
@@ -1,0 +1,88 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/LucasPickering/slumber/refs/tags/v4.2.1/schemas/config.json
+# This config has been prepopulated with default values. For documentation, see:
+# https://slumber.lucaspickering.me/api/configuration/index.html
+editor: null
+ignore_certificate_hosts: []
+large_body_size: 1000000
+follow_redirects: true
+commands:
+  shell:
+  - /bin/sh
+  - -c
+  default_query: {}
+pager: {}
+preview_templates: true
+input_bindings:
+  quit:
+  - q
+  force_quit:
+  - ctrl c
+  scroll_left:
+  - shift left
+  scroll_right:
+  - shift right
+  open_actions:
+  - x
+  open_help:
+  - '?'
+  fullscreen:
+  - f
+  reload_collection:
+  - f5
+  history:
+  - h
+  search:
+  - /
+  export:
+  - ':'
+  previous_pane:
+  - shift tab
+  next_pane:
+  - tab
+  up:
+  - up
+  down:
+  - down
+  left:
+  - left
+  right:
+  - right
+  page_up:
+  - pageup
+  page_down:
+  - pagedown
+  home:
+  - home
+  end:
+  - end
+  submit:
+  - enter
+  toggle:
+  - space
+  cancel:
+  - escape
+  delete:
+  - delete
+  edit:
+  - e
+  reset:
+  - z
+  view:
+  - v
+  select_collection:
+  - f3
+  select_profile_list:
+  - p
+  select_recipe_list:
+  - l
+  select_recipe:
+  - c
+  select_response:
+  - r
+theme:
+  primary_color: Blue
+  primary_text_color: White
+  secondary_color: Yellow
+  success_color: Green
+  error_color: Red
+persist: true

--- a/docs/src/api/configuration/index.md
+++ b/docs/src/api/configuration/index.md
@@ -34,6 +34,10 @@ You can change the location of the config file by setting the environment variab
 SLUMBER_CONFIG_PATH=~/dotfiles/slumber.yml slumber
 ```
 
+## Hidden Fields
+
+Any unknown field in the config file will be rejected, unless it is a **top-level** field beginning with `.`. You can combine this with [YAML anchors](https://yaml.org/spec/1.2.2/#anchors-and-aliases) to define reusable components in your config file.
+
 ## Fields
 
 The following fields are available in `config.yml`:
@@ -127,7 +131,3 @@ Visual customizations for the TUI. [More info](./theme.md)
 **Default:** `less` (Unix), `more` (Windows)
 
 Command to use when opening files for viewing. [More info](../../user_guide/tui/editor.md#paging)
-
-### Ignored Fields
-
-In addition to the above fields, any top-level field beginning with `.` will be ignored. This can be combined with [YAML anchors](https://yaml.org/spec/1.2.2/#anchors-and-aliases) to define reusable components in your config file.


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Instead of dynamically generating the default config file from Config::default(), we now use a static default.yml file. The main reason is to avoid populating the file with ALL fields. While this may be useful to users, it makes it much harder to change default values in the future. Those changes would only be rolled out to new users, and existing users with the default file would continue to have the old values. This is important because I plan to change some default keybindings in version 5.

There's also a step that detects the old default file and replaces it with the new one. This will undo as much of this mistake as possible.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

It won't replace any file that's been modified by the user in any way, so there's minimal risk of it overwriting something the user cares about.

## QA

_How did you test this?_

Couple unit tests, manually tested that the old file gets replaced by switching from master to this branch.

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
