### PR TITLE
Only run Python build CI for some files

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -5,6 +5,25 @@ on:
     tags:
       - "**[0-9]+.[0-9]+.[0-9]+*"
   pull_request:
+    # On PRs, only run for paths that can affect the Python build. This is the
+    # slowest CI step, and it's annoying to wait for it for PRs that only
+    # modify the CLI or TUI.
+    #
+    # There's a risk of false negatives here. We could use a paths-ignore filter
+    # instead, but that list is much longer. Worst case scenario, there's an
+    # error in the build that won't don't see until release time. Annoying, but
+    # we won't actually ship anything broken.
+    paths:
+      - ".github/workflows/python.yml"
+      - "crates/config/**"
+      - "crates/core/**"
+      - "crates/macros/**"
+      - "crates/python/**"
+      - "crates/template/**"
+      - "crates/util/**"
+      # Taking a risk here and excluding Cargo.lock. It's unlikely a change
+      # there will break the Python build, and it'll hit a lot of unrelated
+      # changes.
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION

## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

This step is really slow and I hate waiting for it on PRs that can't ever affect the Python build.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

There's a risk of false negatives here. We could use a paths-ignore filter instead, but that list is much longer. Worst case scenario, there's an error in the build that won't don't see until release time. Annoying, but we won't actually ship anything broken.

## QA

_How did you test this?_

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
