### PR TITLE
Persist prompt values within session

### DIFF
--- a/crates/tui/src/test_util.rs
+++ b/crates/tui/src/test_util.rs
@@ -4,7 +4,7 @@ use crate::{
     context::TuiContext,
     http::RequestStore,
     message::{Message, MessageSender},
-    view::{PersistentKey, PersistentStore, SessionKey, ViewContext},
+    view::{ViewContext, persistent::PersistentStore},
 };
 use ratatui::{
     Frame, Terminal,
@@ -66,19 +66,9 @@ impl TestHarness {
         }
     }
 
-    /// Persist a value in the database. Useful for testing persistence
-    /// restoration.
-    pub fn set_persisted<K: PersistentKey>(&self, key: &K, value: &K::Value) {
-        PersistentStore::new(&self.database).set(key, value);
-    }
-
-    /// Persist a value in the [session store](PersistentStore)
-    pub fn set_persisted_session<K: SessionKey>(
-        &self,
-        key: K,
-        value: K::Value,
-    ) {
-        PersistentStore::new(&self.database).set_session(key, value);
+    /// Get a [PersistentStore] pointing at the test database
+    pub fn persistent_store(&self) -> PersistentStore {
+        PersistentStore::new(self.database.clone())
     }
 
     /// Get the message sender

--- a/crates/tui/src/tui_state.rs
+++ b/crates/tui/src/tui_state.rs
@@ -5,7 +5,10 @@ use crate::{
         Callback, HttpMessage, Message, MessageSender, RecipeCopyTarget,
     },
     util::{self, ResultReported},
-    view::{ComponentMap, PreviewPrompter, TuiPrompter, UpdateContext, View},
+    view::{
+        ComponentMap, PreviewPrompter, TuiPrompter, UpdateContext, View,
+        persistent::PersistentStore,
+    },
 };
 use anyhow::{Context, anyhow, bail};
 use bytes::Bytes;
@@ -149,11 +152,14 @@ impl TuiState {
             TuiStateInner::Loaded(state) => {
                 let handled = state.view.handle_events(UpdateContext {
                     component_map: &state.component_map,
+                    persistent_store: &mut PersistentStore::new(
+                        state.database.clone(),
+                    ),
                     request_store: &mut state.request_store,
                 });
                 // Persist state after changes
                 if handled {
-                    state.view.persist(&state.database);
+                    state.view.persist(state.database.clone());
                 }
                 handled
             }

--- a/crates/tui/src/view/common/fixed_select.rs
+++ b/crates/tui/src/view/common/fixed_select.rs
@@ -5,7 +5,7 @@ use crate::view::{
     component::{Canvas, Component, ComponentId, Draw, DrawMetadata},
     context::UpdateContext,
     event::{Emitter, Event, EventMatch, ToEmitter},
-    util::persistent::PersistentKey,
+    persistent::PersistentKey,
 };
 use itertools::Itertools;
 use ratatui::widgets::ListState;

--- a/crates/tui/src/view/common/select.rs
+++ b/crates/tui/src/view/common/select.rs
@@ -6,7 +6,7 @@ use crate::{
         component::{Canvas, Component, ComponentId, Draw, DrawMetadata},
         context::UpdateContext,
         event::{Emitter, Event, EventMatch, ToEmitter},
-        util::persistent::{PersistentKey, PersistentStore},
+        persistent::{PersistentKey, PersistentStore},
     },
 };
 use itertools::Itertools;
@@ -132,7 +132,6 @@ impl<Item, State> SelectBuilder<Item, State> {
     }
 
     /// Set the index that should be initially selected
-    #[cfg(test)]
     pub fn preselect_index(mut self, index: usize) -> Self {
         // If the index is invalid, it will be replaced by 0 in the build()
         self.preselect_index = index;
@@ -1152,7 +1151,7 @@ mod tests {
             }
         }
 
-        harness.set_persisted(&Key, &persisted_id.into());
+        harness.persistent_store().set(&Key, &persisted_id.into());
 
         // Second profile should be pre-selected because of persistence
         let select: Select<ProfileItem> = Select::builder(vec![

--- a/crates/tui/src/view/common/tabs.rs
+++ b/crates/tui/src/view/common/tabs.rs
@@ -7,7 +7,7 @@ use crate::{
         component::{Canvas, Component, ComponentId, Draw, DrawMetadata},
         context::UpdateContext,
         event::{Event, EventMatch},
-        util::persistent::{PersistentKey, PersistentStore},
+        persistent::{PersistentKey, PersistentStore},
     },
 };
 use ratatui::{style::Style, text::Line};

--- a/crates/tui/src/view/component/exchange_pane.rs
+++ b/crates/tui/src/view/component/exchange_pane.rs
@@ -17,7 +17,8 @@ use crate::{
         },
         context::UpdateContext,
         event::{Emitter, Event, EventMatch},
-        util::{format_byte_size, persistent::PersistentKey},
+        persistent::PersistentKey,
+        util::format_byte_size,
     },
 };
 use derive_more::Display;

--- a/crates/tui/src/view/component/internal.rs
+++ b/crates/tui/src/view/component/internal.rs
@@ -8,7 +8,8 @@ use crate::{
         common::actions::MenuItem,
         context::UpdateContext,
         event::{Event, EventMatch},
-        util::{format_type_name, persistent::PersistentStore},
+        persistent::PersistentStore,
+        util::format_type_name,
     },
 };
 use derive_more::Display;
@@ -879,6 +880,7 @@ mod tests {
 
                 let mut update_context = UpdateContext {
                     component_map: &component_map,
+                    persistent_store: &mut harness.persistent_store(),
                     request_store: &mut harness.request_store.borrow_mut(),
                 };
 
@@ -959,6 +961,7 @@ mod tests {
 
         let mut update_context = UpdateContext {
             component_map: &component_map,
+            persistent_store: &mut harness.persistent_store(),
             request_store: &mut harness.request_store.borrow_mut(),
         };
 

--- a/crates/tui/src/view/component/primary.rs
+++ b/crates/tui/src/view/component/primary.rs
@@ -23,7 +23,7 @@ use crate::{
         },
         context::UpdateContext,
         event::{Emitter, Event, EventMatch, ToEmitter},
-        util::persistent::{PersistentKey, PersistentStore},
+        persistent::{PersistentKey, PersistentStore},
     },
 };
 use ratatui::{
@@ -595,7 +595,7 @@ mod tests {
         let mut view = ViewState::default();
         view.select_exchange_pane();
         view.toggle_fullscreen();
-        harness.set_persisted(&ViewStateKey, &view);
+        harness.persistent_store().set(&ViewStateKey, &view);
 
         let component = create_component(&mut harness, &terminal);
         assert_eq!(component.view, view);

--- a/crates/tui/src/view/component/profile.rs
+++ b/crates/tui/src/view/component/profile.rs
@@ -10,7 +10,7 @@ use crate::{
             Canvas, Component, ComponentId, Draw, DrawMetadata,
             sidebar_list::{SidebarListItem, SidebarListState},
         },
-        util::persistent::PersistentKey,
+        persistent::PersistentKey,
     },
 };
 use anyhow::anyhow;

--- a/crates/tui/src/view/component/queryable_body.rs
+++ b/crates/tui/src/view/component/queryable_body.rs
@@ -14,12 +14,9 @@ use crate::{
         },
         context::UpdateContext,
         event::{Emitter, Event, EventMatch, ToEmitter},
+        persistent::{PersistentKey, PersistentStore},
         state::Identified,
-        util::{
-            highlight,
-            persistent::{PersistentKey, PersistentStore},
-            str_to_text,
-        },
+        util::{highlight, str_to_text},
     },
 };
 use anyhow::Context;
@@ -606,7 +603,9 @@ mod tests {
         response: Arc<ResponseRecord>,
     ) {
         // Add initial query to the DB
-        harness.set_persisted(&Key, &"head -c 1".to_owned());
+        harness
+            .persistent_store()
+            .set(&Key, &"head -c 1".to_owned());
 
         // On init, we'll start executing the command in a local task. Wait for
         // that to finish
@@ -657,7 +656,7 @@ mod tests {
         terminal: TestTerminal,
         response: Arc<ResponseRecord>,
     ) {
-        harness.set_persisted(&Key, &String::new());
+        harness.persistent_store().set(&Key, &String::new());
 
         // Local task is spawned to execute the initial subprocess
         let component = run_local(async {

--- a/crates/tui/src/view/component/recipe.rs
+++ b/crates/tui/src/view/component/recipe.rs
@@ -24,7 +24,7 @@ use crate::{
         },
         context::UpdateContext,
         event::{Emitter, Event, EventMatch, ToEmitter},
-        util::persistent::{PersistentKey, PersistentStore},
+        persistent::{PersistentKey, PersistentStore},
     },
 };
 use itertools::{Itertools, Position};

--- a/crates/tui/src/view/component/recipe/authentication.rs
+++ b/crates/tui/src/view/component/recipe/authentication.rs
@@ -487,11 +487,11 @@ mod tests {
     #[rstest]
     fn test_persisted_load_basic(harness: TestHarness, terminal: TestTerminal) {
         let recipe_id = RecipeId::factory(());
-        harness.set_persisted_session(
+        harness.persistent_store().set_session(
             RecipeOverrideKey::auth_basic_username(recipe_id.clone()),
             "user".into(),
         );
-        harness.set_persisted_session(
+        harness.persistent_store().set_session(
             RecipeOverrideKey::auth_basic_password(recipe_id.clone()),
             "hunter2".into(),
         );
@@ -521,7 +521,7 @@ mod tests {
         terminal: TestTerminal,
     ) {
         let recipe_id = RecipeId::factory(());
-        harness.set_persisted_session(
+        harness.persistent_store().set_session(
             RecipeOverrideKey::auth_bearer_token(recipe_id.clone()),
             "token".into(),
         );

--- a/crates/tui/src/view/component/recipe/body.rs
+++ b/crates/tui/src/view/component/recipe/body.rs
@@ -17,7 +17,8 @@ use crate::{
         },
         context::UpdateContext,
         event::{Emitter, Event, EventMatch},
-        util::{persistent::PersistentKey, view_text},
+        persistent::PersistentKey,
+        util::view_text,
     },
 };
 use anyhow::Context;
@@ -385,7 +386,7 @@ mod tests {
     use crate::{
         context::TuiContext,
         test_util::{TestHarness, TestTerminal, harness, terminal},
-        view::{test_util::TestComponent, util::persistent::PersistentStore},
+        view::{persistent::PersistentStore, test_util::TestComponent},
     };
     use ratatui::{
         style::{Color, Styled},
@@ -534,7 +535,7 @@ mod tests {
             body: Some(RecipeBody::Raw("".into())),
             ..Recipe::factory(())
         };
-        harness.set_persisted_session(
+        harness.persistent_store().set_session(
             RecipeOverrideKey::body(recipe.id.clone()),
             "hello!".into(),
         );

--- a/crates/tui/src/view/component/recipe/override_template.rs
+++ b/crates/tui/src/view/component/recipe/override_template.rs
@@ -10,7 +10,7 @@ use crate::view::{
         Canvas, Child, Component, ComponentId, Draw, DrawMetadata, ToChild,
     },
     event::{Event, EventMatch, ToEmitter},
-    util::persistent::{PersistentStore, SessionKey},
+    persistent::{PersistentStore, SessionKey},
 };
 use serde::Serialize;
 use slumber_config::Action;
@@ -378,7 +378,9 @@ mod tests {
     fn test_persistence(harness: TestHarness, terminal: TestTerminal) {
         let recipe_id = RecipeId::factory(());
         let key = RecipeOverrideKey::url(recipe_id);
-        harness.set_persisted_session(key.clone(), "persisted".into());
+        harness
+            .persistent_store()
+            .set_session(key.clone(), "persisted".into());
         let mut component = TestComponent::new(
             &harness,
             &terminal,
@@ -402,7 +404,7 @@ mod tests {
 
         // Clear the override; should be removed from the store
         component.int().send_key(KeyCode::Char('z')).assert_empty();
-        component.persist(&mut PersistentStore::new(&harness.database));
+        component.persist(&mut PersistentStore::new(harness.database));
         assert_eq!(component.template(), &"default".into());
         assert_eq!(PersistentStore::get_session(&key), None);
     }

--- a/crates/tui/src/view/component/recipe/recipe.rs
+++ b/crates/tui/src/view/component/recipe/recipe.rs
@@ -12,7 +12,7 @@ use crate::view::{
             url::UrlDisplay,
         },
     },
-    util::persistent::PersistentKey,
+    persistent::PersistentKey,
 };
 use derive_more::Display;
 use ratatui::{layout::Layout, prelude::Constraint, widgets::Paragraph};

--- a/crates/tui/src/view/component/recipe/table.rs
+++ b/crates/tui/src/view/component/recipe/table.rs
@@ -16,7 +16,7 @@ use crate::{
         },
         context::UpdateContext,
         event::{Emitter, Event, EventMatch, ToEmitter},
-        util::persistent::{PersistentKey, PersistentStore},
+        persistent::{PersistentKey, PersistentStore},
     },
 };
 use ratatui::{
@@ -597,11 +597,11 @@ mod tests {
     #[rstest]
     fn test_persisted_override(harness: TestHarness, terminal: TestTerminal) {
         let recipe_id = RecipeId::factory(());
-        harness.set_persisted_session(
+        harness.persistent_store().set_session(
             RecipeOverrideKey::query_param(recipe_id.clone(), 0),
             "p0".into(),
         );
-        harness.set_persisted_session(
+        harness.persistent_store().set_session(
             RecipeOverrideKey::query_param(recipe_id.clone(), 1),
             "p1".into(),
         );

--- a/crates/tui/src/view/component/recipe/url.rs
+++ b/crates/tui/src/view/component/recipe/url.rs
@@ -175,7 +175,7 @@ mod tests {
     #[rstest]
     fn test_persisted_load(harness: TestHarness, terminal: TestTerminal) {
         let recipe_id = RecipeId::factory(());
-        harness.set_persisted_session(
+        harness.persistent_store().set_session(
             RecipeOverrideKey::url(recipe_id.clone()),
             "persisted/url".into(),
         );

--- a/crates/tui/src/view/component/response_view.rs
+++ b/crates/tui/src/view/component/response_view.rs
@@ -12,7 +12,8 @@ use crate::{
         },
         context::UpdateContext,
         event::{Event, EventMatch},
-        util::{persistent::PersistentKey, view_text},
+        persistent::PersistentKey,
+        util::view_text,
     },
 };
 use mime::Mime;

--- a/crates/tui/src/view/component/root.rs
+++ b/crates/tui/src/view/component/root.rs
@@ -16,7 +16,7 @@ use crate::{
         },
         context::UpdateContext,
         event::{Event, EventMatch},
-        util::persistent::{PersistentKey, PersistentStore},
+        persistent::{PersistentKey, PersistentStore},
     },
 };
 use ratatui::{layout::Layout, prelude::Constraint};
@@ -417,7 +417,9 @@ mod tests {
             Exchange::factory((Some(profile_id.clone()), recipe_id.clone()));
         harness.database.insert_exchange(&old_exchange).unwrap();
         harness.database.insert_exchange(&new_exchange).unwrap();
-        harness.set_persisted(&SelectedRequestKey, &old_exchange.id);
+        harness
+            .persistent_store()
+            .set(&SelectedRequestKey, &old_exchange.id);
 
         let mut component =
             TestComponent::new(&harness, &terminal, Root::new());
@@ -451,7 +453,9 @@ mod tests {
         harness.database.insert_exchange(&old_exchange).unwrap();
         harness.database.insert_exchange(&new_exchange).unwrap();
         // Put a random ID in the DB
-        harness.set_persisted(&SelectedRequestKey, &RequestId::new());
+        harness
+            .persistent_store()
+            .set(&SelectedRequestKey, &RequestId::new());
 
         let mut component =
             TestComponent::new(&harness, &terminal, Root::new());

--- a/crates/tui/src/view/component/sidebar_list.rs
+++ b/crates/tui/src/view/component/sidebar_list.rs
@@ -11,7 +11,7 @@ use crate::{
             Canvas, Child, Component, ComponentId, Draw, DrawMetadata, ToChild,
         },
         event::{Emitter, Event, EventMatch, ToEmitter},
-        util::persistent::{PersistentKey, PersistentStore},
+        persistent::{PersistentKey, PersistentStore},
     },
 };
 use ratatui::{

--- a/crates/tui/src/view/context.rs
+++ b/crates/tui/src/view/context.rs
@@ -4,6 +4,7 @@ use crate::{
     view::{
         component::ComponentMap,
         event::{Event, EventQueue},
+        persistent::PersistentStore,
     },
 };
 use slumber_core::{collection::Collection, database::CollectionDatabase};
@@ -138,6 +139,10 @@ impl ViewContext {
 pub struct UpdateContext<'a> {
     /// Visible components from the last draw phase
     pub component_map: &'a ComponentMap,
+    /// Access to the persistent and session stores. Most interactions with
+    /// this are done in [Component::persist], but sometimes components
+    /// need to directly modify the store.
+    pub persistent_store: &'a mut PersistentStore,
     /// Request state
     pub request_store: &'a mut RequestStore,
 }

--- a/crates/tui/src/view/persistent.rs
+++ b/crates/tui/src/view/persistent.rs
@@ -32,13 +32,13 @@ use tracing::error;
 /// DB.
 ///
 /// Unlike the DB store, the session store doesn't serialize the key and value.
-/// The key and value are both stored as`Box<dyn Any>`. This is possible because
-/// we're storing it in a thread local.
-pub struct PersistentStore<'a> {
-    database: &'a CollectionDatabase,
+/// The key and value are both stored as `Box<dyn Any>`. This is possible
+/// because we're storing it in a thread local.
+pub struct PersistentStore {
+    database: CollectionDatabase,
 }
 
-impl<'a> PersistentStore<'a> {
+impl PersistentStore {
     thread_local! {
         /// Static instance for the session store. Persistence is handled in the
         /// main view thread, so we only even need this in one thread. We could
@@ -48,10 +48,10 @@ impl<'a> PersistentStore<'a> {
         static SESSION: RefCell<Vec<SessionEntry>> = RefCell::default();
     }
 
-    /// Create a new store from a database. This is a cheap operation, as it
-    /// just requires a reference to the database. The store should be recreated
+    /// Create a new store from a database. This is a cheap operation, as the
+    /// database connection is reference-counted. The store should be recreated
     /// for each update phase.
-    pub fn new(database: &'a CollectionDatabase) -> Self {
+    pub fn new(database: CollectionDatabase) -> Self {
         Self { database }
     }
 

--- a/crates/tui/src/view/util.rs
+++ b/crates/tui/src/view/util.rs
@@ -1,7 +1,6 @@
 //! Helper structs and functions for building components
 
 pub mod highlight;
-pub mod persistent;
 
 use crate::{
     message::{HttpMessage, Message, MessageSender},


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Use the session store to persist prompt values. Switching away from a prompt then coming back will retain the old value now.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

## QA

_How did you test this?_

Wrote a unit test

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
