### PR TITLE
Route TemplatePreview render through event queue

### DIFF
--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -218,9 +218,6 @@ impl Tui {
                 Ok(())
             }
 
-            // This message exists just to trigger a draw
-            Message::Draw => Ok(()),
-
             // Force quit short-circuits the view/message cycle, to make sure
             // it doesn't get ate by text boxes
             Message::Input(InputEvent::Key {

--- a/crates/tui/src/message.rs
+++ b/crates/tui/src/message.rs
@@ -74,10 +74,6 @@ pub enum Message {
     /// Copy some text to the clipboard
     CopyText(String),
 
-    /// Trigger a redraw. This should be called whenever we have reason to
-    /// believe the UI may have changed due to a background task
-    Draw,
-
     /// An error occurred in some async process and should be shown to the user
     Error { error: anyhow::Error },
 

--- a/crates/tui/src/tui_state.rs
+++ b/crates/tui/src/tui_state.rs
@@ -398,8 +398,7 @@ impl LoadedState {
             // get here
             Message::CollectionSelect(_)
             | Message::ClearTerminal
-            | Message::Quit
-            | Message::Draw => {
+            | Message::Quit => {
                 panic!(
                     "Unexpected message in TuiState; should have been handled \
                     by parent: {message:?}"

--- a/crates/tui/src/util.rs
+++ b/crates/tui/src/util.rs
@@ -180,11 +180,6 @@ pub fn yield_terminal(
     initialize_terminal()?; // Take it back over
     drop(span);
 
-    // Redraw immediately. The main loop will probably be in the tick
-    // timeout when we go back to it, so that adds a 250ms delay to
-    // redrawing the screen that we want to skip.
-    messages_tx.send(Message::Draw);
-
     command_result
 }
 
@@ -271,11 +266,7 @@ pub async fn signals() -> anyhow::Result<()> {
 pub fn spawn(future: impl 'static + Future<Output = ()>) -> JoinHandle<()> {
     task::spawn_local(async move {
         select! {
-            () = future => {
-                // Assume the task updated _something_ visible to the user,
-                // so trigger a redraw here
-                ViewContext::messages_tx().send(Message::Draw);
-            },
+            () = future => {},
             () = CANCEL_TOKEN.cancelled() => {},
         }
     })

--- a/crates/tui/src/view/component/queryable_body.rs
+++ b/crates/tui/src/view/component/queryable_body.rs
@@ -724,8 +724,6 @@ mod tests {
         })
         .await;
         component.int().drain_draw().assert_empty();
-        // First message is for a redraw from the local task. Then the error
-        assert_matches!(harness.pop_message_now(), Message::Draw);
         assert_matches!(harness.pop_message_now(), Message::Error { .. });
     }
 }

--- a/crates/tui/src/view/component/recipe/body.rs
+++ b/crates/tui/src/view/component/recipe/body.rs
@@ -195,7 +195,7 @@ impl TextBody {
 
     /// Open rendered body in the pager
     fn view_body(&self) {
-        view_text(&self.body.preview().text(), self.mime.clone());
+        view_text(self.body.preview().text(), self.mime.clone());
     }
 
     /// Send a message to open the body in an external editor. We have to write
@@ -311,9 +311,7 @@ impl Draw for TextBody {
         canvas.draw(
             &self.text_window,
             TextWindowProps {
-                // Do *not* call generate, because that clones the text and
-                // we only need a reference
-                text: &self.body.preview().text(),
+                text: self.body.preview().text(),
                 margins: ScrollbarMargins {
                     right: 1,
                     bottom: 1,
@@ -444,9 +442,9 @@ mod tests {
         ]]);
 
         // Persistence store should be updated
-        let persisted = PersistentStore::get_session(&TemplateOverrideKey::body(
-            recipe.id.clone(),
-        ));
+        let persisted = PersistentStore::get_session(
+            &TemplateOverrideKey::body(recipe.id.clone()),
+        );
         assert_eq!(persisted, Some("goodbye!".into()));
 
         // Reset edited state
@@ -513,9 +511,9 @@ mod tests {
         ]]);
 
         // Persistence store should be updated
-        let persisted = PersistentStore::get_session(&TemplateOverrideKey::body(
-            recipe.id.clone(),
-        ));
+        let persisted = PersistentStore::get_session(
+            &TemplateOverrideKey::body(recipe.id.clone()),
+        );
         assert_eq!(persisted, Some(override_text.into()));
 
         // Reset edited state

--- a/crates/tui/src/view/component/response_view.rs
+++ b/crates/tui/src/view/component/response_view.rs
@@ -297,8 +297,6 @@ mod tests {
                 // component
             })
             .await;
-            // Background task sends a message to redraw
-            assert_matches!(harness.pop_message_now(), Message::Draw);
             component.int().drain_draw().assert_empty();
         }
 


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Instead of using Mutex to write the result of template preview, this routes it through the event queue instead. The mutex was a pretty old solution and became inconsistent with the rest of the app architecture. Using an event also means we don't have to send Message::Draw from every spawned task. It was the only task that actually needed it.

For now I'm emitting the callback event directly from the background task. This works because the task is run on the main thread, as it's in a LocalSet. It's possible we may want to push some or all of the work into a background thread because it may be slow for large bodies. In this case we'll need to route the callback through a Message instead.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

I removed the `Message::Draw` variant, which was also being used to immediately refresh when returning from an external editor. I tested it out and didn't notice any draw delay when returning, so it's possible there was another change at some point that made that defunct. I didn't dig too hard. The max delay is also only 250ms so it might just not matter that much.

## QA

_How did you test this?_

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
