### PR TITLE
format curl output command by applying new lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
-- Improve readability of generated curl commands by formatting them as multiline if the command exceeds 100 characters
+- Add line breaks to cURL command output if length is >100 characters (@fgebhart, [#678](https://github.com/LucasPickering/slumber/issues/678))
 
 ## [4.3.0] - 2025-12-12
 


### PR DESCRIPTION
## Description

This change formats the output of "Copy as cURL" for the sake of readability. It changes it from a single line to multi line and applies indentation for a nested json payload. This was discussed in and closes https://github.com/LucasPickering/slumber/issues/678 .

Note, that I'm proposing to change `CurlBuilder.command` to `CurlBuilder.gorups` of commands. Inserting new lines is then much easier and allows to avoid having to implement a heuristic like [I tried here](https://github.com/LucasPickering/slumber/compare/master...fgebhart:slumber:multiline-curl-command-output?expand=1). Let me know what you prefer.

Thanks for the hints 👍 

## Known Risks

The output curl is valid as before and should works as before.

## QA

I adapted existing tests and added a new test to provide an example for a largish json payload. Taken from https://github.com/LucasPickering/slumber/issues/678 .

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
