### PR TITLE
Add --header flag to override headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ The breaking changes in this release are mostly limited to CLI commands. Unless 
 
 - Add `Copy as CLI` action to generate a `slumber request` CLI command for the selected recipe/profile
 - Add `Copy as Python` action to generate Python code that uses the [slumber-python](https://pypi.org/project/slumber-python/) API to make a request with the selected recipe/profile
+- Add flags to override various parts of a recipe from the CLI
+  - `--header header=value` (`-H`) overrides a header
 - Add `slumber config` command (replaces `slumber show config`)
 - Add `slumber collection` command (replaces `slumber show collection`)
 - Add `slumber db --path` flag (replaces `slumber show paths db`)

--- a/crates/cli/src/completions.rs
+++ b/crates/cli/src/completions.rs
@@ -190,7 +190,8 @@ mod tests {
                 "jsonBody",
                 "fileBody",
                 "multipart",
-                "chained"
+                "chained",
+                "override",
             ]
         );
     }
@@ -228,6 +229,7 @@ mod tests {
                 "fileBody",
                 "multipart",
                 "chained",
+                "override",
                 &id2.to_string(),
                 &id1.to_string()
             ]

--- a/crates/cli/tests/slumber.yml
+++ b/crates/cli/tests/slumber.yml
@@ -7,12 +7,14 @@ profiles:
     name: Profile 1
     default: true
     data:
-      host: http://server
+      host: "{{ env('HOST', default='http://server') }}"
       username: username1
+      a: 0
+      b: 0
   profile2:
     name: Profile 2
     data:
-      host: http://server
+      host: "{{ env('HOST', default='http://server') }}"
       username: username2
 
 requests:
@@ -77,3 +79,15 @@ requests:
   chained:
     method: GET
     url: "{{ host }}/chained/{{ response('getUser', trigger='always') | jsonpath('$.username') }}"
+
+  override:
+    method: POST
+    url: "{{ host }}/override"
+    query:
+      foo: bar
+      many: [baz, blorp]
+    headers:
+      X-Test: test
+    body:
+      type: json
+      data: { "a": "{{ a }}", "b": "{{ b }}" }


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

You can now override the headers of a request in the CLI, with:

```sh
slumber request my-recipe -H X-Header=value
```

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

I matched the flag from curl so this should be familiar, but the format is different (curl uses `Header: value` to match the HTTP format). The `=` sign will be more consistent with other overrides (profile fields, query params, form fields).

## QA

_How did you test this?_

Added some integration tests

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
