### PR TITLE
Add --url override flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The breaking changes in this release are mostly limited to CLI commands. Unless 
 - Add `Copy as CLI` action to generate a `slumber request` CLI command for the selected recipe/profile
 - Add `Copy as Python` action to generate Python code that uses the [slumber-python](https://pypi.org/project/slumber-python/) API to make a request with the selected recipe/profile
 - Add flags to override various parts of a recipe from the CLI
+  - `--url <url>` overrides the entire URL
   - `--header <header=value>` (`-H`) overrides a header
   - `--basic <username:password>` sets basic authentication
   - `--bearer <token>` sets bearer authentication

--- a/crates/cli/src/commands/request.rs
+++ b/crates/cli/src/commands/request.rs
@@ -153,6 +153,15 @@ pub struct BuildRequestCommand {
         value_name = "token",
     )]
     bearer: Option<Template>,
+
+    /// Set the URL for the request
+    ///
+    /// The URL is parsed and rendered as a template. This will override the
+    /// `url` field of the recipe entirely. Query parameters from the recipe
+    /// will *not* be replaced; they will be appended to the rendered URL
+    /// override.
+    #[clap(long, value_hint = ValueHint::Other)]
+    url: Option<Template>,
 }
 
 /// Helper for any subcommand that prints exchange (request/response)
@@ -279,6 +288,7 @@ impl BuildRequestCommand {
             }
         };
         let build_options = BuildOptions {
+            url: self.url,
             authentication,
             headers: IndexMap::from_iter(self.header),
             ..Default::default()


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

`--url` can override the entire request URL

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

I wanted to test overriding URL fragments, but it looks like the fragment gets lost in wiremock. It'd be pretty hard to break that though.

## QA

_How did you test this?_

Added an integration test

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
