### PR TITLE
Fix verbose flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ The breaking changes in this release are mostly limited to CLI commands. Unless 
   - CLI commands that fail will automatically print the log path. You can also pass `--print-log-path` to have it always print
 - Remove `left_click` and `right_click` mappable actions
   - Mouse clicks can no longer be mapped to keys
+- Replace the `RUST_LOG` environment variable with a `--log-level` argument
+  - ERROR/WARN log output is not longer shown in stderr for CLI commands
 
 ### Added
 
@@ -42,8 +44,6 @@ The breaking changes in this release are mostly limited to CLI commands. Unless 
 - Add `slumber config` command (replaces `slumber show config`)
 - Add `slumber collection` command (replaces `slumber show collection`)
 - Add `slumber db --path` flag (replaces `slumber show paths db`)
-- Add `--verbose` flag to increase logging output in the CLI
-  - ERROR/WARN logging is no longer shown by default
 - You can now search command history in the query/export command text box
   - Up/down to cycle through past commands
   - Ctrl-r to search

--- a/crates/cli/src/commands/new.rs
+++ b/crates/cli/src/commands/new.rs
@@ -70,6 +70,7 @@ mod tests {
     };
     use slumber_util::{Factory, TempDir, temp_dir, yaml::SourceLocation};
     use std::fs;
+    use tracing::level_filters::LevelFilter;
 
     /// Test creating a new collection file, specifying the path in various ways
     #[rstest]
@@ -93,7 +94,8 @@ mod tests {
         };
         let global_args = GlobalArgs {
             file: global_file_arg.map(PathBuf::from),
-            ..Default::default()
+            log_level: LevelFilter::OFF,
+            print_log_path: false,
         };
 
         command.execute(global_args).await.unwrap();

--- a/crates/cli/src/completions.rs
+++ b/crates/cli/src/completions.rs
@@ -15,6 +15,7 @@ use slumber_core::{
     database::Database,
 };
 use std::{ffi::OsStr, ops::Deref};
+use tracing::level_filters::LevelFilter;
 
 /// Build a completer for profile IDs from the default collection
 pub fn complete_profile() -> ArgValueCompleter {
@@ -101,6 +102,25 @@ pub fn complete_collection_specifier() -> ArgValueCompleter {
                 .unwrap_or_default(),
         );
         completions
+    })
+}
+
+/// Complete --log-level
+pub fn complete_log_level() -> ArgValueCompleter {
+    ArgValueCompleter::new(|current: &OsStr| {
+        get_candidates(
+            [
+                LevelFilter::OFF,
+                LevelFilter::ERROR,
+                LevelFilter::WARN,
+                LevelFilter::INFO,
+                LevelFilter::DEBUG,
+                LevelFilter::TRACE,
+            ]
+            .into_iter()
+            .map(|l| l.to_string()),
+            current,
+        )
     })
 }
 

--- a/docs/src/troubleshooting/logs.md
+++ b/docs/src/troubleshooting/logs.md
@@ -12,16 +12,19 @@ Once you have the path to a log file, you can watch the logs with `tail -f <log 
 
 ## Increasing Verbosity
 
-In some scenarios, the default logging level is not verbose enough to debug issues. To increase the verbosity, set the `RUST_LOG` environment variable when starting Slumber:
+In some scenarios, the default logging level is not verbose enough to debug issues. To increase the verbosity, use the `--log-level` argument:
 
 ```sh
-RUST_LOG=slumber=<level> slumber ...
+slumber --log-level <level> ...
 ```
 
-The `slumber=` filter applies this level only to Slumber's internal logging, instead of all libraries, to cut down on verbosity that will likely not be helpful. The available log levels are, in increasing verbosity:
+The available log levels are, in increasing verbosity:
 
+- `off`
 - `error`
 - `warn`
 - `info`
 - `debug`
 - `trace`
+
+This argument applies to both the CLI and TUI. If omitted, the default is `off`, however logging cannot be set below `warn` for file output. That means stderr output is disabled by default, but file output is always _at least_ `warn`.

--- a/mise-tasks/tui.sh
+++ b/mise-tasks/tui.sh
@@ -9,7 +9,7 @@ if [ "$TRACING" = "true" ]; then
   RUSTFLAGS="--cfg=tokio_unstable"
 fi
 
-RUST_LOG=slumber=${LOG:-DEBUG} RUSTFLAGS="$RUSTFLAGS" \
+RUSTFLAGS="$RUSTFLAGS" \
     exec watchexec --restart --no-process-group \
     --watch Cargo.toml --watch Cargo.lock --watch src/ --watch crates/ \
     -- \

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tasks.cli]
 description = "Run a CLI command"
 quiet = true
-run = "RUST_LOG=slumber=${LOG:-DEBUG} cargo run --no-default-features --features cli --"
+run = "cargo run --no-default-features --features cli --"
 
 [tasks.docs]
 description = "Build and serve docs"


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Replace `--verbose` with `--log-level`. I forgot we're already using `--verbose` within the `request` subcommand. This also replaces the `RUST_LOG` env var.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

## QA

_How did you test this?_

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
