### PR TITLE
Clean up TUI state tests

### DIFF
--- a/crates/tui/src/tui_state.rs
+++ b/crates/tui/src/tui_state.rs
@@ -825,7 +825,7 @@ mod tests {
         ($harness:expr, $state:expr, [$($expected:pat), *$(,)?]) => {
             // For each expected message, pop from the queue and handle it
             $(
-                match $harness.pop_message_wait().await {
+                match $harness.messages().pop_wait().await {
                     Some(message @ $expected) => {
                         $state.handle_message(message).unwrap();
                     }
@@ -840,7 +840,7 @@ mod tests {
                 }
             )*
             // We got all the messages
-            $harness.assert_messages_empty();
+            $harness.messages().assert_empty();
         }
     }
 
@@ -1010,7 +1010,7 @@ requests:
         TuiState::load(
             harness.database.clone(),
             collection_file,
-            harness.messages_tx().clone(),
+            harness.messages_tx(),
         )
     }
 

--- a/crates/tui/src/view.rs
+++ b/crates/tui/src/view.rs
@@ -295,7 +295,7 @@ mod tests {
         let mut view = View::new(
             &collection.into(),
             harness.database.clone(),
-            harness.messages_tx().clone(),
+            harness.messages_tx(),
         );
 
         // Initial events

--- a/crates/tui/src/view/common/template_preview.rs
+++ b/crates/tui/src/view/common/template_preview.rs
@@ -301,11 +301,11 @@ mod tests {
         TemplatePreview::new(template, None, false, false);
         if should_send {
             assert_matches!(
-                harness.pop_message_now(),
+                harness.messages().pop_now(),
                 Message::TemplatePreview { .. }
             );
         } else {
-            harness.assert_messages_empty();
+            harness.messages().assert_empty();
         }
     }
 

--- a/crates/tui/src/view/component/primary.rs
+++ b/crates/tui/src/view/component/primary.rs
@@ -617,7 +617,7 @@ mod tests {
             ]
         );
         // Clear template preview messages so we can test what we want
-        harness.clear_messages();
+        harness.messages().clear();
         component
     }
 
@@ -650,14 +650,14 @@ mod tests {
     fn test_edit_recipe(mut harness: TestHarness, terminal: TestTerminal) {
         let mut component = create_component(&mut harness, &terminal);
         component.int().drain_draw().assert_empty();
-        harness.clear_messages(); // Clear init junk
+        harness.messages().clear(); // Clear init junk
         let expected_location =
             harness.collection.first_recipe().location.clone();
 
         component.int().action(&["Edit Recipe"]).assert_empty();
         // Event should be converted into a message appropriately
         let location = assert_matches!(
-            harness.pop_message_now(),
+            harness.messages().pop_now(),
             Message::CollectionEdit { location: Some(location) } => location
         );
         assert_eq!(location, expected_location);
@@ -668,14 +668,14 @@ mod tests {
     fn test_edit_profile(mut harness: TestHarness, terminal: TestTerminal) {
         let mut component = create_component(&mut harness, &terminal);
         component.int().drain_draw().assert_empty();
-        harness.clear_messages(); // Clear init junk
+        harness.messages().clear(); // Clear init junk
         let expected_location =
             harness.collection.first_profile().location.clone();
 
         component.int().action(&["Edit Profile"]).assert_empty();
         // Event should be converted into a message appropriately
         let location = assert_matches!(
-            harness.pop_message_now(),
+            harness.messages().pop_now(),
             Message::CollectionEdit { location: Some(location) } => location
         );
         assert_eq!(location, expected_location);
@@ -703,7 +703,7 @@ mod tests {
             .assert_empty();
 
         let actual_target = assert_matches!(
-            harness.pop_message_now(),
+            harness.messages().pop_now(),
             Message::CopyRecipe(target) => target
         );
         assert_eq!(actual_target, expected_target);
@@ -715,7 +715,7 @@ mod tests {
             .assert_empty();
 
         let actual_target = assert_matches!(
-            harness.pop_message_now(),
+            harness.messages().pop_now(),
             Message::CopyRecipe(target) => target
         );
         assert_eq!(actual_target, expected_target);

--- a/crates/tui/src/view/component/prompt_form.rs
+++ b/crates/tui/src/view/component/prompt_form.rs
@@ -523,7 +523,7 @@ mod tests {
             .assert_empty();
 
         let (actual_request_id, replies) = assert_matches!(
-            harness.pop_message_now(),
+            harness.messages().pop_now(),
             Message::Http(HttpMessage::FormSubmit {
                 request_id,
                 replies,
@@ -590,7 +590,7 @@ mod tests {
 
         // Our previous values were submitted
         let replies = assert_matches!(
-            harness.pop_message_now(),
+            harness.messages().pop_now(),
             Message::Http(HttpMessage::FormSubmit {
                 replies,
                 ..
@@ -656,7 +656,7 @@ mod tests {
             .send_keys([KeyCode::Enter, KeyCode::Enter])
             .assert_empty();
         let replies = assert_matches!(
-            harness.pop_message_now(),
+            harness.messages().pop_now(),
             Message::Http(HttpMessage::FormSubmit {
                 request_id,
                 replies,
@@ -712,7 +712,7 @@ mod tests {
         // Submit
         component.int().send_key(KeyCode::Enter).assert_empty();
         let replies = assert_matches!(
-            harness.pop_message_now(),
+            harness.messages().pop_now(),
             Message::Http(HttpMessage::FormSubmit {
                 request_id,
                 replies,

--- a/crates/tui/src/view/component/queryable_body.rs
+++ b/crates/tui/src/view/component/queryable_body.rs
@@ -708,7 +708,7 @@ mod tests {
         })
         .await;
         // Success should push a notification
-        assert_matches!(harness.pop_message_now(), Message::Notify(_));
+        assert_matches!(harness.messages().pop_now(), Message::Notify(_));
         let file_content = fs::read_to_string(&path).await.unwrap();
         assert_eq!(file_content, TEXT);
 
@@ -724,6 +724,6 @@ mod tests {
         })
         .await;
         component.int().drain_draw().assert_empty();
-        assert_matches!(harness.pop_message_now(), Message::Error { .. });
+        assert_matches!(harness.messages().pop_now(), Message::Error { .. });
     }
 }

--- a/crates/tui/src/view/component/recipe/body.rs
+++ b/crates/tui/src/view/component/recipe/body.rs
@@ -433,10 +433,10 @@ mod tests {
         terminal.assert_buffer_lines([vec![gutter("1"), " hello!  ".into()]]);
 
         // Open the editor
-        harness.clear_messages();
+        harness.messages().clear();
         component.int().send_key(KeyCode::Char('e')).assert_empty();
         let (file, on_complete) = assert_matches!(
-            harness.pop_message_now(),
+            harness.messages().pop_now(),
             Message::FileEdit {
                 file,
                 on_complete,
@@ -500,10 +500,10 @@ mod tests {
         ]]);
 
         // Open the editor
-        harness.clear_messages();
+        harness.messages().clear();
         component.int().send_key(KeyCode::Char('e')).assert_empty();
         let (file, on_complete) = assert_matches!(
-            harness.pop_message_now(),
+            harness.messages().pop_now(),
             Message::FileEdit {
                 file,
                 on_complete,

--- a/crates/tui/src/view/component/response_view.rs
+++ b/crates/tui/src/view/component/response_view.rs
@@ -217,7 +217,7 @@ mod tests {
 
         component.copy_body();
         let body = assert_matches!(
-            harness.pop_message_now(),
+            harness.messages().pop_now(),
             Message::CopyText(body) => body,
         );
         assert_eq!(body, expected_body);
@@ -302,7 +302,7 @@ mod tests {
 
         component.save_response_body();
         let (request_id, data) = assert_matches!(
-            harness.pop_message_now(),
+            harness.messages().pop_now(),
             Message::SaveResponseBody { request_id, data } => (request_id, data),
         );
         assert_eq!(request_id, exchange.id);

--- a/crates/tui/src/view/context.rs
+++ b/crates/tui/src/view/context.rs
@@ -174,11 +174,11 @@ mod tests {
         ViewContext::send_message(Message::CollectionStartReload);
         ViewContext::send_message(Message::CollectionEdit { location: None });
         assert_matches!(
-            harness.pop_message_now(),
+            harness.messages().pop_now(),
             Message::CollectionStartReload
         );
         assert_matches!(
-            harness.pop_message_now(),
+            harness.messages().pop_now(),
             Message::CollectionEdit { .. }
         );
     }


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Add a macro `drain!` to handle plumbing messages for `TuiState` tests. Also add a `MessageQueue` wrapper for tests to handle all message-related handling. Allows the `save_file` test to work with the message queue without needing an entire `TestHarness`

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

## QA

_How did you test this?_

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
