### PR TITLE
Retain invalid override after editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ The breaking changes in this release are mostly limited to CLI commands. Unless 
 
 ### Fixed
 
+- Invalid body override template is displayed instead of being thrown away [#531](https://github.com/LucasPickering/slumber/issues/531)
 - Fix panic when SIGTERM is sent to a TUI process that failed to start and is display a collection error
 - Fix indentation in TUI display of multi-line errors
 

--- a/crates/template/src/error.rs
+++ b/crates/template/src/error.rs
@@ -12,16 +12,31 @@ use thiserror::Error;
 use tracing::error;
 use winnow::error::{ContextError, ParseError};
 
-/// An error while parsing a template. The string is provided by winnow
+/// An error while parsing a template
 #[derive(Debug, Error)]
-#[error("{0}")]
-pub struct TemplateParseError(String);
+#[error("{error}")]
+pub struct TemplateParseError {
+    /// The string that failed to parse
+    input: String,
+    /// Error message, provided by winnow
+    error: String,
+}
+
+impl TemplateParseError {
+    /// Get the invalid template
+    pub fn input(&self) -> &str {
+        &self.input
+    }
+}
 
 /// Convert winnow's error type into ours. This stringifies the error so we can
 /// dump the reference to the input
 impl From<ParseError<&str, ContextError>> for TemplateParseError {
     fn from(error: ParseError<&str, ContextError>) -> Self {
-        Self(error.to_string())
+        Self {
+            input: (*error.input()).to_string(),
+            error: error.to_string(),
+        }
     }
 }
 

--- a/crates/tui/src/view/common/actions.rs
+++ b/crates/tui/src/view/common/actions.rs
@@ -249,9 +249,8 @@ impl ActionMenuContent {
 
     /// Get the area for each open layer, starting from the given position
     ///
-    /// Each area will include margin for a border. This is used by both
-    /// both [ModalQueue] and our own [Draw::draw] to get consistent area
-    /// calculations.
+    /// Each area will include margin for a border. This is used in multiple
+    /// places to get consistent results.
     fn areas(&self, position: Position) -> Vec<Rect> {
         fn layer_width(layer: &Select<MenuItemDisplay>) -> u16 {
             // Get the longest item

--- a/crates/tui/src/view/common/template_preview.rs
+++ b/crates/tui/src/view/common/template_preview.rs
@@ -92,8 +92,8 @@ impl TemplatePreview {
         slf
     }
 
-    pub fn text(&self) -> &Identified<Text<'static>> {
-        &self.text
+    pub fn text(&self) -> Identified<&Text<'static>> {
+        self.text.as_ref()
     }
 
     /// Send a message triggering a render of this template. The rendered

--- a/crates/tui/src/view/common/text_window.rs
+++ b/crates/tui/src/view/common/text_window.rs
@@ -216,7 +216,7 @@ impl<'a> Draw<TextWindowProps<'a>> for TextWindow {
         );
 
         // Draw the text content
-        self.render_chars(props.text, canvas.buffer_mut(), text_area);
+        self.render_chars(*props.text, canvas.buffer_mut(), text_area);
 
         // Scrollbars
         if has_vertical_scroll {
@@ -252,7 +252,7 @@ pub struct TextWindowProps<'a> {
     /// This uses `Identified` as a wrapper so that each text object has a
     /// unique ID attached. When the text content changes, the ID will change.
     /// We use that to detect when the text dimensions need to be recalculated.
-    pub text: &'a Identified<Text<'a>>,
+    pub text: Identified<&'a Text<'a>>,
     pub margins: ScrollbarMargins,
 }
 
@@ -289,7 +289,7 @@ struct TextSize {
 
 impl TextSize {
     /// Calculate dimensions of the given text
-    fn new(text: &Identified<Text>) -> Self {
+    fn new(text: Identified<&Text>) -> Self {
         // Note: Paragraph has methods for this, but that requires an
         // owned copy of Text, which involves a lot of cloning
 
@@ -323,11 +323,11 @@ mod tests {
         #[with(10, 4)] terminal: TestTerminal,
         harness: TestHarness,
     ) {
-        let text =
+        let text: Identified<_> =
             Text::from("line 1\nline 2 is longer\nline 3\nline 4\nline 5")
                 .into();
         let props = TextWindowProps {
-            text: &text,
+            text: text.as_ref(),
             // Don't overflow the frame
             margins: ScrollbarMargins {
                 right: 0,
@@ -406,11 +406,11 @@ mod tests {
         #[with(35, 3)] terminal: TestTerminal,
         harness: TestHarness,
     ) {
-        let text =
+        let text: Identified<_> =
             Text::from("intro\n💚💙💜 this is a longer line\noutro").into();
         TestComponent::builder(&harness, &terminal, TextWindow::default())
             .with_props(TextWindowProps {
-                text: &text,
+                text: text.as_ref(),
                 // Don't overflow the frame
                 margins: ScrollbarMargins {
                     right: 0,
@@ -430,10 +430,10 @@ mod tests {
         #[with(10, 2)] terminal: TestTerminal,
         harness: TestHarness,
     ) {
-        let text = Text::raw("💚💙💜💚💙💜").into();
+        let text: Identified<_> = Text::raw("💚💙💜💚💙💜").into();
         TestComponent::builder(&harness, &terminal, TextWindow::default())
             .with_props(TextWindowProps {
-                text: &text,
+                text: text.as_ref(),
                 // Don't overflow the frame
                 margins: ScrollbarMargins {
                     right: 0,
@@ -454,13 +454,13 @@ mod tests {
         #[with(10, 3)] terminal: TestTerminal,
         harness: TestHarness,
     ) {
-        let text =
+        let text: Identified<_> =
             Text::from_iter(["1 this is a long line", "2", "3", "4", "5"])
                 .into();
         let mut component =
             TestComponent::builder(&harness, &terminal, TextWindow::default())
                 .with_props(TextWindowProps {
-                    text: &text,
+                    text: text.as_ref(),
                     // Don't overflow the frame
                     margins: ScrollbarMargins {
                         right: 0,
@@ -475,10 +475,11 @@ mod tests {
         assert_eq!(component.offset_x.get(), 10);
         assert_eq!(component.offset_y.get(), 2);
 
-        let text = Text::from_iter(["1 less long line", "2", "3", "4"]).into();
+        let text: Identified<_> =
+            Text::from_iter(["1 less long line", "2", "3", "4"]).into();
         component
             .int_props(|| TextWindowProps {
-                text: &text,
+                text: text.as_ref(),
                 margins: ScrollbarMargins {
                     right: 0,
                     bottom: 0,
@@ -495,11 +496,11 @@ mod tests {
     /// automatically be clamped to match
     #[rstest]
     fn test_grow_window(terminal: TestTerminal, harness: TestHarness) {
-        let text =
+        let text: Identified<_> =
             Text::from_iter(["1 this is a long line", "2", "3", "4", "5"])
                 .into();
         let props = TextWindowProps {
-            text: &text,
+            text: text.as_ref(),
             // Don't overflow the frame
             margins: ScrollbarMargins {
                 right: 0,

--- a/crates/tui/src/view/component/queryable_body.rs
+++ b/crates/tui/src/view/component/queryable_body.rs
@@ -327,7 +327,7 @@ impl<K: PersistentKey<Value = String>> Draw for QueryableBody<K> {
             canvas.draw(
                 &self.text_window,
                 TextWindowProps {
-                    text: &self.text_state.text,
+                    text: self.text_state.text.as_ref(),
                     margins: ScrollbarMargins {
                         bottom: 2, // Extra margin to jump over the search box
                         ..Default::default()

--- a/crates/tui/src/view/component/request_view.rs
+++ b/crates/tui/src/view/component/request_view.rs
@@ -120,7 +120,7 @@ impl Draw for RequestView {
             canvas.draw(
                 &self.body_text_window,
                 TextWindowProps {
-                    text: body,
+                    text: body.as_ref(),
                     margins: Default::default(),
                 },
                 body_area,

--- a/crates/tui/src/view/state.rs
+++ b/crates/tui/src/view/state.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 /// A uniquely identified immutable value. Useful for detecting changes in
 /// values that are expensive to do full comparisons on (e.g. large blocks of
 /// text).
-#[derive(Debug, Deref)]
+#[derive(Copy, Clone, Debug, Deref)]
 pub struct Identified<T> {
     id: Uuid,
     #[deref]
@@ -24,6 +24,24 @@ impl<T> Identified<T> {
 
     pub fn id(&self) -> Uuid {
         self.id
+    }
+}
+
+impl<T> Identified<T> {
+    /// Map the internal `T` into a `U`, retaining the same ID
+    pub fn map<U>(self, f: impl FnOnce(T) -> U) -> Identified<U> {
+        Identified {
+            id: self.id,
+            value: f(self.value),
+        }
+    }
+
+    /// Map the internal `T` into `&T`, retaining the same ID
+    pub fn as_ref(&self) -> Identified<&T> {
+        Identified {
+            id: self.id,
+            value: &self.value,
+        }
     }
 }
 

--- a/crates/tui/src/view/styles.rs
+++ b/crates/tui/src/view/styles.rs
@@ -225,7 +225,7 @@ impl Styles {
                 hint: Style::default().fg(Color::DarkGray),
                 primary: Style::default().fg(theme.primary_color),
                 edited: Style::default().add_modifier(Modifier::ITALIC),
-                error: Style::default().bg(theme.error_color),
+                error: Style::default().fg(theme.error_color),
                 title: Style::default().add_modifier(Modifier::BOLD),
             },
             text_box: TextBoxStyle {


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

If editing an override and you submit an invalid template, it will now retain that template and show it as invalid. Previously, it would just throw it away and go back to the default template. This is only relevant for body overrides because all other templates are edited inline, where the text box validator prevents you from submitting an invalid template.

Closes #531

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Persistence for overrides is managed in `OverrideTemplate`. Since I added this behavior in `RecipeBodyDisplay`, persistence doesn't work for invalid templates. The invalid template will be lost when the collection is changed.

## QA

_How did you test this?_

- Manually tested in the TUI by making an invalid override
- Added a unit test

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
