### PR TITLE
Call drain_draw() for all new TestComponents

### DIFF
--- a/crates/tui/src/view/common/actions.rs
+++ b/crates/tui/src/view/common/actions.rs
@@ -716,19 +716,22 @@ mod tests {
         component
             .int()
             .action(&["Action 2"])
-            .assert_emitted([TestAction::Action2]);
+            .assert()
+            .emitted([TestAction::Action2]);
 
         // Actions can be performed by shortcut
         component
             .int()
             .send_keys([KeyCode::Char('x'), KeyCode::Char('e')])
-            .assert_emitted([TestAction::Shortcutted]);
+            .assert()
+            .emitted([TestAction::Shortcutted]);
 
         // Disabled action *cannot* be performed by shortcut
         component
             .int()
             .send_keys([KeyCode::Char('x'), KeyCode::Char('z')])
-            .assert_emitted([]);
+            .assert()
+            .emitted([]);
     }
 
     /// Various input sequences on multiple levels of nested actions
@@ -770,7 +773,8 @@ mod tests {
             .int()
             .send_key(KeyCode::Char('x'))
             .send_keys(inputs.iter().copied())
-            .assert_emitted([expected_action]);
+            .assert()
+            .emitted([expected_action]);
     }
 
     /// There once was a bug where the select event wasn't handled correctly
@@ -798,6 +802,7 @@ mod tests {
         component
             .int()
             .send_keys([KeyCode::Char('x'), KeyCode::Right, KeyCode::Enter])
-            .assert_emitted([TestAction::Nested1]);
+            .assert()
+            .emitted([TestAction::Nested1]);
     }
 }

--- a/crates/tui/src/view/common/component_select.rs
+++ b/crates/tui/src/view/common/component_select.rs
@@ -379,7 +379,7 @@ mod tests {
         );
         assert!(component.is_empty());
         // This shouldn't panic!
-        component.int().drain_draw().assert_empty();
+        component.int().drain_draw().assert().empty();
     }
 
     /// View window calculation and scrolling with variable-height items
@@ -424,7 +424,8 @@ mod tests {
                 ..Default::default()
             })
             .drain_draw()
-            .assert_empty();
+            .assert()
+            .empty();
 
         // Check the state directly first
         let view_height = terminal.area().height;
@@ -497,7 +498,8 @@ mod tests {
                     ..Default::default()
                 })
                 .drain_draw()
-                .assert_empty();
+                .assert()
+                .empty();
 
             // At this point, if the list is empty there isn't anything to test
             if component.is_empty() {

--- a/crates/tui/src/view/common/text_box.rs
+++ b/crates/tui/src/view/common/text_box.rs
@@ -541,7 +541,7 @@ mod tests {
         terminal.assert_buffer_lines([vec![cursor(" "), text("         ")]]);
 
         // Type some text
-        component.int().send_text("hi!").assert_emitted([
+        component.int().send_text("hi!").assert().emitted([
             TextBoxEvent::Change,
             TextBoxEvent::Change,
             TextBoxEvent::Change,
@@ -557,7 +557,8 @@ mod tests {
         component
             .int()
             .send_key_modifiers(KeyCode::Char('W'), KeyModifiers::SHIFT)
-            .assert_emitted([TextBoxEvent::Change]);
+            .assert()
+            .emitted([TextBoxEvent::Change]);
         assert_state(&component.state, "hi!W", 4);
         assert_matches!(
             component
@@ -567,8 +568,7 @@ mod tests {
                     KeyCode::Char('W'),
                     KeyModifiers::CTRL | KeyModifiers::SHIFT,
                 )
-                .into_propagated()
-                .as_slice(),
+                .propagated(),
             &[Event::Input { .. }]
         );
         assert_state(&component.state, "hi!W", 4);
@@ -577,12 +577,14 @@ mod tests {
         component
             .int()
             .send_key(KeyCode::Enter)
-            .assert_emitted([TextBoxEvent::Submit]);
+            .assert()
+            .emitted([TextBoxEvent::Submit]);
 
         component
             .int()
             .send_key(KeyCode::Esc)
-            .assert_emitted([TextBoxEvent::Cancel]);
+            .assert()
+            .emitted([TextBoxEvent::Cancel]);
     }
 
     /// Test text navigation and deleting. [TextState] has its own tests so
@@ -599,7 +601,7 @@ mod tests {
         );
 
         // Type some text
-        component.int().send_text("hello!").assert_emitted([
+        component.int().send_text("hello!").assert().emitted([
             // One change event per letter
             TextBoxEvent::Change,
             TextBoxEvent::Change,
@@ -611,28 +613,30 @@ mod tests {
         assert_state(&component.state, "hello!", 6);
 
         // Move around, delete some text.
-        component.int().send_key(KeyCode::Left).assert_empty();
+        component.int().send_key(KeyCode::Left).assert().empty();
         assert_state(&component.state, "hello!", 5);
 
         component
             .int()
             .send_key(KeyCode::Backspace)
-            .assert_emitted([TextBoxEvent::Change]);
+            .assert()
+            .emitted([TextBoxEvent::Change]);
         assert_state(&component.state, "hell!", 4);
 
         component
             .int()
             .send_key(KeyCode::Delete)
-            .assert_emitted([TextBoxEvent::Change]);
+            .assert()
+            .emitted([TextBoxEvent::Change]);
         assert_state(&component.state, "hell", 4);
 
-        component.int().send_key(KeyCode::Home).assert_empty();
+        component.int().send_key(KeyCode::Home).assert().empty();
         assert_state(&component.state, "hell", 0);
 
-        component.int().send_key(KeyCode::Right).assert_empty();
+        component.int().send_key(KeyCode::Right).assert().empty();
         assert_state(&component.state, "hell", 1);
 
-        component.int().send_key(KeyCode::End).assert_empty();
+        component.int().send_key(KeyCode::End).assert().empty();
         assert_state(&component.state, "hell", 4);
     }
 
@@ -654,7 +658,7 @@ mod tests {
         .build();
 
         // Type some text
-        component.int().send_text("012345").assert_emitted([
+        component.int().send_text("012345").assert().emitted([
             // One change event per letter
             TextBoxEvent::Change,
             TextBoxEvent::Change,
@@ -674,7 +678,8 @@ mod tests {
         component
             .int()
             .send_key(KeyCode::Backspace)
-            .assert_emitted([TextBoxEvent::Change]);
+            .assert()
+            .emitted([TextBoxEvent::Change]);
         terminal.assert_buffer_lines([
             Line::from("   "),
             vec![text("34"), cursor(" ")].into(),
@@ -682,7 +687,7 @@ mod tests {
         ]);
 
         // Back to the beginning
-        component.int().send_key(KeyCode::Home).assert_empty();
+        component.int().send_key(KeyCode::Home).assert().empty();
         terminal.assert_buffer_lines([
             Line::from("   "),
             vec![cursor("0"), text("12")].into(),
@@ -693,7 +698,8 @@ mod tests {
         component
             .int()
             .send_keys([KeyCode::Right, KeyCode::Right])
-            .assert_empty();
+            .assert()
+            .empty();
         terminal.assert_buffer_lines([
             Line::from("   "),
             vec![text("01"), cursor("2")].into(),
@@ -701,7 +707,7 @@ mod tests {
         ]);
 
         // Push the scroll over
-        component.int().send_key(KeyCode::Right).assert_empty();
+        component.int().send_key(KeyCode::Right).assert().empty();
         terminal.assert_buffer_lines([
             Line::from("   "),
             vec![text("12"), cursor("3")].into(),
@@ -709,7 +715,7 @@ mod tests {
         ]);
 
         // Move back doesn't scroll left yet
-        component.int().send_key(KeyCode::Left).assert_empty();
+        component.int().send_key(KeyCode::Left).assert().empty();
         terminal.assert_buffer_lines([
             Line::from("   "),
             vec![text("1"), cursor("2"), text("3")].into(),
@@ -733,7 +739,8 @@ mod tests {
         component
             .int()
             .send_text("hi")
-            .assert_emitted([TextBoxEvent::Change, TextBoxEvent::Change]);
+            .assert()
+            .emitted([TextBoxEvent::Change, TextBoxEvent::Change]);
 
         assert_state(&component.state, "hi", 2);
         terminal.assert_buffer_lines([vec![text("••"), cursor(" ")]]);
@@ -783,7 +790,7 @@ mod tests {
 
         // Unfocused
         component.unfocus();
-        component.int().drain_draw().assert_empty();
+        component.int().drain_draw().assert().empty();
         terminal.assert_buffer_lines([vec![Span::styled(
             "unfocused",
             styles.text.patch(styles.placeholder),
@@ -807,7 +814,8 @@ mod tests {
         component
             .int()
             .send_text("he")
-            .assert_emitted([TextBoxEvent::Change, TextBoxEvent::Change]);
+            .assert()
+            .emitted([TextBoxEvent::Change, TextBoxEvent::Change]);
         terminal.assert_buffer_lines([vec![
             text("he"),
             cursor(" "),
@@ -817,15 +825,20 @@ mod tests {
         component
             .int()
             .send_key(KeyCode::Enter)
-            .assert_emitted([TextBoxEvent::Submit]);
+            .assert()
+            .emitted([TextBoxEvent::Submit]);
 
         // Invalid text, styling changes and no events are emitted
-        component.int().send_text("llo").assert_emitted([]);
+        component.int().send_text("llo").assert().emitted([]);
         terminal.assert_buffer_lines([vec![
             Span::styled("hello", TuiContext::get().styles.text_box.invalid),
             cursor(" "),
         ]]);
-        component.int().send_key(KeyCode::Enter).assert_emitted([]);
+        component
+            .int()
+            .send_key(KeyCode::Enter)
+            .assert()
+            .emitted([]);
     }
 
     #[test]

--- a/crates/tui/src/view/common/text_window.rs
+++ b/crates/tui/src/view/common/text_window.rs
@@ -349,7 +349,8 @@ mod tests {
         component
             .int_props(|| props.clone())
             .send_key(KeyCode::Down)
-            .assert_empty();
+            .assert()
+            .empty();
         terminal.assert_buffer_lines([
             vec![line_num(2), " line 2 ▲".into()],
             vec![line_num(3), " line 3 █".into()],
@@ -362,7 +363,8 @@ mod tests {
             .int_props(|| props.clone())
             // Second does nothing
             .send_keys([KeyCode::Up, KeyCode::Up])
-            .assert_empty();
+            .assert()
+            .empty();
         terminal.assert_buffer_lines([
             vec![line_num(1), " line 1 ▲".into()],
             vec![line_num(2), " line 2 █".into()],
@@ -376,7 +378,8 @@ mod tests {
             .send_key_modifiers(KeyCode::Right, KeyModifiers::SHIFT)
             .send_key_modifiers(KeyCode::Right, KeyModifiers::SHIFT)
             .send_key_modifiers(KeyCode::Right, KeyModifiers::SHIFT)
-            .assert_empty();
+            .assert()
+            .empty();
         terminal.assert_buffer_lines([
             vec![line_num(1), " e 1    ▲".into()],
             vec![line_num(2), " e 2 is █".into()],
@@ -392,7 +395,8 @@ mod tests {
             .send_key_modifiers(KeyCode::Left, KeyModifiers::SHIFT)
             // Does nothing
             .send_key_modifiers(KeyCode::Left, KeyModifiers::SHIFT)
-            .assert_empty();
+            .assert()
+            .empty();
         terminal.assert_buffer_lines([
             vec![line_num(1), " line 1 ▲".into()],
             vec![line_num(2), " line 2 █".into()],
@@ -486,7 +490,8 @@ mod tests {
                 },
             })
             .drain_draw()
-            .assert_empty();
+            .assert()
+            .empty();
 
         assert_eq!(component.offset_x.get(), 8);
         assert_eq!(component.offset_y.get(), 1);
@@ -516,7 +521,8 @@ mod tests {
         component
             .int_props(|| props.clone())
             .drain_draw()
-            .assert_empty();
+            .assert()
+            .empty();
 
         // Scroll out a bit
         component.scroll_down(2);
@@ -528,7 +534,8 @@ mod tests {
         component
             .int_props(|| props.clone())
             .drain_draw()
-            .assert_empty();
+            .assert()
+            .empty();
 
         assert_eq!(component.offset_x.get(), 8);
         assert_eq!(component.offset_y.get(), 1);

--- a/crates/tui/src/view/component/command_text_box.rs
+++ b/crates/tui/src/view/component/command_text_box.rs
@@ -332,28 +332,30 @@ mod tests {
 
         // Scroll back
         assert_eq!(component.text(), "");
-        component.int().send_key(KeyCode::Up).assert_empty();
+        component.int().send_key(KeyCode::Up).assert().empty();
         assert_eq!(component.text(), "three");
 
         // Scroll forward
         component
             .int()
             .send_keys([KeyCode::Up, KeyCode::Up, KeyCode::Down])
-            .assert_empty();
+            .assert()
+            .empty();
         assert_eq!(component.text(), "two");
 
         // Submit
         component
             .int()
             .send_key(KeyCode::Enter)
-            .assert_emitted([CommandTextBoxEvent::Submit]);
+            .assert()
+            .emitted([CommandTextBoxEvent::Submit]);
         assert_eq!(component.text(), "two");
 
         // Submission resets scrollback state, so now when we go back from two
         // we get three instead of one
-        component.int().send_key(KeyCode::Up).assert_empty();
+        component.int().send_key(KeyCode::Up).assert().empty();
         assert_eq!(component.text(), "three");
-        component.int().send_key(KeyCode::Up).assert_empty();
+        component.int().send_key(KeyCode::Up).assert().empty();
         assert_eq!(component.text(), "one");
     }
 
@@ -379,7 +381,8 @@ mod tests {
             .int()
             .send_text("t")
             .send_key_modifiers(KeyCode::Char('r'), KeyModifiers::CTRL)
-            .assert_empty();
+            .assert()
+            .empty();
         assert_eq!(component.text(), "t");
         assert_eq!(get_search_items(&component).unwrap(), &["three", "two"]);
         terminal.assert_buffer_lines([
@@ -395,7 +398,7 @@ mod tests {
         ]);
 
         // Modifying while in search mode should update what's visible
-        component.int().send_text("h").assert_empty();
+        component.int().send_text("h").assert().empty();
         assert_eq!(component.text(), "th");
         assert_eq!(get_search_items(&component).unwrap(), &["three"]);
 
@@ -403,7 +406,8 @@ mod tests {
         component
             .int()
             .send_key(KeyCode::Enter)
-            .assert_emitted([CommandTextBoxEvent::Submit]);
+            .assert()
+            .emitted([CommandTextBoxEvent::Submit]);
         assert_eq!(component.text(), "three");
     }
 
@@ -426,7 +430,8 @@ mod tests {
             .int()
             .send_text("t")
             .send_key_modifiers(KeyCode::Char('r'), KeyModifiers::CTRL)
-            .assert_empty();
+            .assert()
+            .empty();
         assert_eq!(get_search_items(&component).unwrap(), &["three", "two"]);
 
         // Escape exits without modifying the text. This exits both the search
@@ -434,7 +439,8 @@ mod tests {
         component
             .int()
             .send_key(KeyCode::Esc)
-            .assert_emitted([CommandTextBoxEvent::Cancel]);
+            .assert()
+            .emitted([CommandTextBoxEvent::Cancel]);
         assert_eq!(component.text(), "t");
     }
 
@@ -458,7 +464,8 @@ mod tests {
             .int()
             .send_text("teefs")
             .send_key_modifiers(KeyCode::Char('r'), KeyModifiers::CTRL)
-            .assert_empty();
+            .assert()
+            .empty();
         assert_eq!(component.text(), "teefs");
         assert_eq!(get_search_items(&component), None);
     }

--- a/crates/tui/src/view/component/help.rs
+++ b/crates/tui/src/view/component/help.rs
@@ -191,14 +191,17 @@ mod tests {
         // Open help
         component
             .int()
-            .drain_draw() // Clear initial events
             .send_key(KeyCode::Char('?'))
-            .assert_empty();
+            .assert()
+            .empty();
         assert!(component.open);
 
         // Any key should close. Events are *not* handled by anyone else
-        //
-        component.int().send_key(KeyCode::Char('x')).assert_empty();
+        component
+            .int()
+            .send_key(KeyCode::Char('x'))
+            .assert()
+            .empty();
         assert!(!component.open);
     }
 }

--- a/crates/tui/src/view/component/history.rs
+++ b/crates/tui/src/view/component/history.rs
@@ -341,12 +341,12 @@ mod tests {
         component.refresh(&mut harness.request_store_mut());
 
         // Initial state
-        component.int().drain_draw().assert_broadcast([
+        component.int().drain_draw().assert().broadcast([
             BroadcastEvent::SelectedRequest(Some(exchanges[0].id)),
         ]);
 
         // Select the next one
-        component.int().send_key(KeyCode::Down).assert_broadcast([
+        component.int().send_key(KeyCode::Down).assert().broadcast([
             BroadcastEvent::SelectedRequest(Some(exchanges[1].id)),
         ]);
     }

--- a/crates/tui/src/view/component/override_template.rs
+++ b/crates/tui/src/view/component/override_template.rs
@@ -400,12 +400,17 @@ mod tests {
             .send_keys(iter::repeat_n(KeyCode::Backspace, 10))
             .send_text("override")
             .send_key(KeyCode::Enter)
-            .assert_empty();
+            .assert()
+            .empty();
         assert_eq!(component.template(), &"override".into());
         assert_eq!(PersistentStore::get_session(&Key), Some("override".into()));
 
         // Clear the override; should be removed from the store
-        component.int().send_key(KeyCode::Char('z')).assert_empty();
+        component
+            .int()
+            .send_key(KeyCode::Char('z'))
+            .assert()
+            .empty();
         component.persist(&mut PersistentStore::new(harness.database));
         assert_eq!(component.template(), &"default".into());
         assert_eq!(PersistentStore::get_session(&Key), None);

--- a/crates/tui/src/view/component/primary.rs
+++ b/crates/tui/src/view/component/primary.rs
@@ -653,7 +653,7 @@ mod tests {
         http::RequestConfig,
         message::{Message, RecipeCopyTarget},
         test_util::{TestHarness, TestTerminal, harness, terminal},
-        view::{event::BroadcastEvent, test_util::TestComponent},
+        view::test_util::TestComponent,
     };
     use rstest::rstest;
     use slumber_core::http::BuildOptions;
@@ -665,18 +665,22 @@ mod tests {
         harness: &mut TestHarness,
         terminal: &'term TestTerminal,
     ) -> TestComponent<'term, PrimaryView> {
-        let mut component =
-            TestComponent::new(harness, terminal, PrimaryView::new());
-        // Initial events
         let recipe_id = harness.collection.first_recipe_id().clone();
         let profile_id = harness.collection.first_profile_id().clone();
-        component.int().drain_draw().assert_broadcast([
-            BroadcastEvent::SelectedRecipe(Some(recipe_id)),
-            BroadcastEvent::SelectedProfile(Some(profile_id)),
-            // The two events above each trigger a request selection
-            BroadcastEvent::SelectedRequest(None),
-            BroadcastEvent::SelectedRequest(None),
-        ]);
+        let component =
+            TestComponent::builder(harness, terminal, PrimaryView::new())
+                .with_default_props()
+                // Initial events
+                .with_assert_events(|assert| {
+                    assert.broadcast([
+                        BroadcastEvent::SelectedRecipe(Some(recipe_id)),
+                        BroadcastEvent::SelectedProfile(Some(profile_id)),
+                        // Two events above each trigger a request selection
+                        BroadcastEvent::SelectedRequest(None),
+                        BroadcastEvent::SelectedRequest(None),
+                    ]);
+                })
+                .build();
         // Clear template preview messages so we can test what we want
         harness.messages().clear();
         component
@@ -710,12 +714,12 @@ mod tests {
     #[rstest]
     fn test_edit_recipe(mut harness: TestHarness, terminal: TestTerminal) {
         let mut component = create_component(&mut harness, &terminal);
-        component.int().drain_draw().assert_empty();
+        component.int().drain_draw().assert().empty();
         harness.messages().clear(); // Clear init junk
         let expected_location =
             harness.collection.first_recipe().location.clone();
 
-        component.int().action(&["Edit Recipe"]).assert_empty();
+        component.int().action(&["Edit Recipe"]).assert().empty();
         // Event should be converted into a message appropriately
         let location = assert_matches!(
             harness.messages().pop_now(),
@@ -728,12 +732,12 @@ mod tests {
     #[rstest]
     fn test_edit_profile(mut harness: TestHarness, terminal: TestTerminal) {
         let mut component = create_component(&mut harness, &terminal);
-        component.int().drain_draw().assert_empty();
+        component.int().drain_draw().assert().empty();
         harness.messages().clear(); // Clear init junk
         let expected_location =
             harness.collection.first_profile().location.clone();
 
-        component.int().action(&["Edit Profile"]).assert_empty();
+        component.int().action(&["Edit Profile"]).assert().empty();
         // Event should be converted into a message appropriately
         let location = assert_matches!(
             harness.messages().pop_now(),
@@ -761,7 +765,8 @@ mod tests {
             .int()
             .send_key(KeyCode::Char('1')) // Select recipe detail
             .action(&["Copy", label])
-            .assert_empty();
+            .assert()
+            .empty();
 
         let actual_target = assert_matches!(
             harness.messages().pop_now(),
@@ -773,7 +778,8 @@ mod tests {
             .int()
             .send_key(KeyCode::Char('r')) // Select recipe list
             .action(&["Copy", label])
-            .assert_empty();
+            .assert()
+            .empty();
 
         let actual_target = assert_matches!(
             harness.messages().pop_now(),

--- a/crates/tui/src/view/component/profile.rs
+++ b/crates/tui/src/view/component/profile.rs
@@ -373,7 +373,8 @@ mod tests {
             .send_text("123")
             .send_key(KeyCode::Enter)
             // Tell all other previews to re-render
-            .assert_broadcast([BroadcastEvent::RefreshPreviews]);
+            .assert()
+            .broadcast([BroadcastEvent::RefreshPreviews]);
         let field = &component.select[1];
         assert_eq!(field.template.template(), &"def123".into());
     }

--- a/crates/tui/src/view/component/prompt_form.rs
+++ b/crates/tui/src/view/component/prompt_form.rs
@@ -520,7 +520,8 @@ mod tests {
             .send_key_modifiers(KeyCode::Up, KeyModifiers::SHIFT) // Wrap to pw
             .send_text("456") // Modify password
             .send_key(KeyCode::Enter) // Submit
-            .assert_empty();
+            .assert()
+            .empty();
 
         let (actual_request_id, replies) = assert_matches!(
             harness.messages().pop_now(),
@@ -568,7 +569,8 @@ mod tests {
             .send_text("user") // Enter username
             .send_key(KeyCode::Tab) // Switch to Select
             .send_key(KeyCode::Down) // Select second item
-            .assert_empty();
+            .assert()
+            .empty();
 
         // Values should be in the session store
         assert_eq!(
@@ -586,7 +588,7 @@ mod tests {
             &terminal,
             PromptForm::new(request_id, &prompts),
         );
-        component.int().send_key(KeyCode::Enter).assert_empty();
+        component.int().send_key(KeyCode::Enter).assert().empty();
 
         // Our previous values were submitted
         let replies = assert_matches!(
@@ -632,7 +634,8 @@ mod tests {
             .send_text("12") // Modify username
             .send_key(KeyCode::Tab) // Switch to password
             .send_text("2") // Modify password
-            .assert_empty();
+            .assert()
+            .empty();
 
         // Check terminal contents
         let styles = &TuiContext::get().styles;
@@ -654,7 +657,8 @@ mod tests {
             .int()
             // Done editing, then submit
             .send_keys([KeyCode::Enter, KeyCode::Enter])
-            .assert_empty();
+            .assert()
+            .empty();
         let replies = assert_matches!(
             harness.messages().pop_now(),
             Message::Http(HttpMessage::FormSubmit {
@@ -696,7 +700,8 @@ mod tests {
             .int()
             .drain_draw() // Draw so children are visible
             .send_key(KeyCode::Down)
-            .assert_empty();
+            .assert()
+            .empty();
 
         // Check terminal contents
         let styles = &TuiContext::get().styles;
@@ -710,7 +715,7 @@ mod tests {
         ]);
 
         // Submit
-        component.int().send_key(KeyCode::Enter).assert_empty();
+        component.int().send_key(KeyCode::Enter).assert().empty();
         let replies = assert_matches!(
             harness.messages().pop_now(),
             Message::Http(HttpMessage::FormSubmit {

--- a/crates/tui/src/view/component/queryable_body.rs
+++ b/crates/tui/src/view/component/queryable_body.rs
@@ -557,7 +557,11 @@ mod tests {
         ]);
 
         // Type something into the query box
-        component.int().send_key(KeyCode::Char('/')).assert_empty();
+        component
+            .int()
+            .send_key(KeyCode::Char('/'))
+            .assert()
+            .empty();
         // The subprocess uses local tasks, so we need to run in a local set.
         // When this future exits, all tasks are done
         run_local(async {
@@ -565,11 +569,12 @@ mod tests {
                 .int()
                 .send_text("head -c 1")
                 .send_key(KeyCode::Enter)
-                .assert_empty();
+                .assert()
+                .empty();
         })
         .await;
         // Command is done, handle its resulting event
-        component.int().drain_draw().assert_empty();
+        component.int().drain_draw().assert().empty();
 
         // Make sure state updated correctly
         assert_eq!(component.last_executed_query.as_deref(), Some("head -c 1"));
@@ -577,12 +582,17 @@ mod tests {
         assert_eq!(component.command_focus, CommandFocus::None);
 
         // Cancelling out of the text box should reset the query value
-        component.int().send_key(KeyCode::Char('/')).assert_empty();
+        component
+            .int()
+            .send_key(KeyCode::Char('/'))
+            .assert()
+            .empty();
         component
             .int()
             .send_text("more text")
             .send_key(KeyCode::Esc)
-            .assert_empty();
+            .assert()
+            .empty();
         assert_eq!(component.last_executed_query.as_deref(), Some("head -c 1"));
         assert_eq!(component.query_text_box.text(), "head -c 1");
         assert_eq!(component.command_focus, CommandFocus::None);
@@ -622,7 +632,7 @@ mod tests {
         .await;
 
         // After the command is done, there's a subsequent event with the result
-        component.int().drain_draw().assert_empty();
+        component.int().drain_draw().assert().empty();
 
         assert_eq!(component.last_executed_query.as_deref(), Some("head -c 1"));
         assert_eq!(&component.visible_text().to_string(), "{");
@@ -702,10 +712,11 @@ mod tests {
             .int()
             .send_key(KeyCode::Char(':'))
             .send_text(&command)
-            .assert_empty();
+            .assert()
+            .empty();
         // Triggers the background task
         run_local(async {
-            component.int().send_key(KeyCode::Enter).assert_empty();
+            component.int().send_key(KeyCode::Enter).assert().empty();
         })
         .await;
         // Success should push a notification
@@ -719,12 +730,13 @@ mod tests {
             .int()
             .send_key(KeyCode::Char(':'))
             .send_text("bad!")
-            .assert_empty();
+            .assert()
+            .empty();
         run_local(async {
-            component.int().send_key(KeyCode::Enter).assert_empty();
+            component.int().send_key(KeyCode::Enter).assert().empty();
         })
         .await;
-        component.int().drain_draw().assert_empty();
+        component.int().drain_draw().assert().empty();
         assert_matches!(harness.messages().pop_now(), Message::Error { .. });
     }
 }

--- a/crates/tui/src/view/component/recipe/authentication.rs
+++ b/crates/tui/src/view/component/recipe/authentication.rs
@@ -313,11 +313,11 @@ mod tests {
         // Edit username
         component
             .int()
-            .drain_draw() // Clear initial messages
             .send_key(KeyCode::Char('e'))
             .send_text("!!!")
             .send_key(KeyCode::Enter)
-            .assert_empty();
+            .assert()
+            .empty();
         assert_eq!(
             component.override_value(),
             Some(Authentication::Basic {
@@ -327,7 +327,11 @@ mod tests {
         );
 
         // Reset username
-        component.int().send_key(KeyCode::Char('z')).assert_empty();
+        component
+            .int()
+            .send_key(KeyCode::Char('z'))
+            .assert()
+            .empty();
         assert_eq!(component.override_value(), None);
 
         // Edit password
@@ -336,7 +340,8 @@ mod tests {
             .send_keys([KeyCode::Down, KeyCode::Char('e')])
             .send_text("???")
             .send_key(KeyCode::Enter)
-            .assert_empty();
+            .assert()
+            .empty();
         assert_eq!(
             component.override_value(),
             Some(Authentication::Basic {
@@ -346,7 +351,11 @@ mod tests {
         );
 
         // Reset password
-        component.int().send_key(KeyCode::Char('z')).assert_empty();
+        component
+            .int()
+            .send_key(KeyCode::Char('z'))
+            .assert()
+            .empty();
         assert_eq!(component.override_value(), None);
     }
 
@@ -369,9 +378,9 @@ mod tests {
         // Edit password
         component
             .int()
-            .drain_draw() // Clear initial messages
             .send_keys([KeyCode::Down, KeyCode::Char('e'), KeyCode::Enter])
-            .assert_empty();
+            .assert()
+            .empty();
         // There's no override because the password wasn't actually modified
         assert_eq!(component.override_value(), None);
     }
@@ -397,7 +406,8 @@ mod tests {
             .send_key(KeyCode::Char('e'))
             .send_text("!!!")
             .send_key(KeyCode::Enter)
-            .assert_empty();
+            .assert()
+            .empty();
         assert_eq!(
             component.override_value(),
             Some(Authentication::Bearer {
@@ -406,7 +416,11 @@ mod tests {
         );
 
         // Reset token
-        component.int().send_key(KeyCode::Char('z')).assert_empty();
+        component
+            .int()
+            .send_key(KeyCode::Char('z'))
+            .assert()
+            .empty();
         assert_eq!(component.override_value(), None);
     }
 
@@ -426,7 +440,8 @@ mod tests {
             .int()
             .action(&["Edit Token"])
             .send_keys([KeyCode::Char('!'), KeyCode::Enter])
-            .assert_empty();
+            .assert()
+            .empty();
         assert_eq!(
             component.override_value(),
             Some(Authentication::Bearer {
@@ -434,7 +449,7 @@ mod tests {
             })
         );
 
-        component.int().action(&["Reset Token"]).assert_empty();
+        component.int().action(&["Reset Token"]).assert().empty();
         assert_eq!(component.override_value(), None);
     }
 

--- a/crates/tui/src/view/component/recipe/body.rs
+++ b/crates/tui/src/view/component/recipe/body.rs
@@ -491,7 +491,11 @@ mod tests {
         assert_eq!(persisted, Some("goodbye!".into()));
 
         // Reset edited state
-        component.int().send_key(KeyCode::Char('z')).assert_empty();
+        component
+            .int()
+            .send_key(KeyCode::Char('z'))
+            .assert()
+            .empty();
         assert_eq!(component.override_value(), None);
     }
 
@@ -582,7 +586,11 @@ mod tests {
         assert_eq!(persisted, Some(override_text.into()));
 
         // Reset edited state
-        component.int().send_key(KeyCode::Char('z')).assert_empty();
+        component
+            .int()
+            .send_key(KeyCode::Char('z'))
+            .assert()
+            .empty();
         assert_eq!(component.override_value(), None);
     }
 
@@ -675,7 +683,11 @@ mod tests {
         content: &str,
     ) {
         harness.messages().clear();
-        component.int().send_key(KeyCode::Char('e')).assert_empty();
+        component
+            .int()
+            .send_key(KeyCode::Char('e'))
+            .assert()
+            .empty();
         let (file, on_complete) = assert_matches!(
             harness.messages().pop_now(),
             Message::FileEdit {
@@ -690,6 +702,6 @@ mod tests {
         fs::write(file.path(), content).unwrap();
         on_complete(file);
         // Handle completion event
-        component.int().drain_draw().assert_empty();
+        component.int().drain_draw().assert().empty();
     }
 }

--- a/crates/tui/src/view/component/recipe/recipe.rs
+++ b/crates/tui/src/view/component/recipe/recipe.rs
@@ -297,7 +297,8 @@ mod tests {
             .int()
             .drain_draw() // Drain initial events
             .send_key(KeyCode::Right)
-            .assert_empty();
+            .assert()
+            .empty();
         assert_eq!(component.tabs.selected(), Tab::Query);
 
         // Test persistence of both disable and override state, with a mixture
@@ -311,7 +312,8 @@ mod tests {
             // Disable+override (p1,v2)
             .send_keys([KeyCode::Down, KeyCode::Char(' '), KeyCode::Char('e')])
             .send_text("xxx")
-            .assert_empty();
+            .assert()
+            .empty();
 
         let expected = IndexMap::<_, _>::from_iter([
             (("p1".to_owned(), 0), BuildFieldOverride::Omit),

--- a/crates/tui/src/view/component/recipe/table.rs
+++ b/crates/tui/src/view/component/recipe/table.rs
@@ -483,9 +483,9 @@ mod tests {
         // Disable the second row
         component
             .int_props(props_factory)
-            .drain_draw() // Clear initial events
             .send_keys([KeyCode::Down, KeyCode::Char(' ')])
-            .assert_empty();
+            .assert()
+            .empty();
         let selected_row = component.select.selected().unwrap();
         assert_eq!(&selected_row.key, "row1");
         assert!(!selected_row.enabled);
@@ -501,7 +501,8 @@ mod tests {
         component
             .int_props(props_factory)
             .send_key(KeyCode::Char(' '))
-            .assert_empty();
+            .assert()
+            .empty();
         let selected_row = component.select.selected().unwrap();
         assert!(selected_row.enabled);
         assert_eq!(component.to_build_overrides(), IndexMap::new());
@@ -530,12 +531,12 @@ mod tests {
         // Edit the second row
         component
             .int_props(props_factory)
-            .drain_draw() // Clear initial events
             // Open the modal
             .send_keys([KeyCode::Down, KeyCode::Char('e')])
             .send_text("!!!")
             .send_key(KeyCode::Enter)
-            .assert_empty();
+            .assert()
+            .empty();
 
         let selected_row = component.select.selected().unwrap();
         assert_eq!(&selected_row.key, "row1");
@@ -553,7 +554,8 @@ mod tests {
         component
             .int_props(props_factory)
             .send_key(KeyCode::Char('z'))
-            .assert_empty();
+            .assert()
+            .empty();
         let selected_row = component.select.selected().unwrap();
         assert!(!selected_row.value.is_overridden());
     }
@@ -574,10 +576,10 @@ mod tests {
 
         component
             .int_props(props_factory)
-            .drain_draw() // Clear initial events
             .action(&["Edit Row"])
             .send_keys([KeyCode::Char('!'), KeyCode::Enter])
-            .assert_empty();
+            .assert()
+            .empty();
 
         let selected_row = component.select.selected().unwrap();
         assert_eq!(selected_row.value.template().display(), "value0!");

--- a/crates/tui/src/view/component/recipe/url.rs
+++ b/crates/tui/src/view/component/recipe/url.rs
@@ -97,14 +97,19 @@ mod tests {
             .send_key(KeyCode::Char('e'))
             .send_text("!!!")
             .send_key(KeyCode::Enter)
-            .assert_empty();
+            .assert()
+            .empty();
         assert_eq!(
             component.override_value(),
             Some("/users/{{ username }}!!!".into())
         );
 
         // Reset token
-        component.int().send_key(KeyCode::Char('z')).assert_empty();
+        component
+            .int()
+            .send_key(KeyCode::Char('z'))
+            .assert()
+            .empty();
         assert_eq!(component.override_value(), None);
     }
 
@@ -128,14 +133,15 @@ mod tests {
             .int()
             .action(&["Edit URL"])
             .send_keys([KeyCode::Char('!'), KeyCode::Enter])
-            .assert_empty();
+            .assert()
+            .empty();
         assert_eq!(
             component.override_value(),
             Some("/users/{{ username }}!".into())
         );
 
         // Edit URL
-        component.int().action(&["Reset URL"]).assert_empty();
+        component.int().action(&["Reset URL"]).assert().empty();
         assert_eq!(component.override_value(), None);
     }
 

--- a/crates/tui/src/view/component/response_view.rs
+++ b/crates/tui/src/view/component/response_view.rs
@@ -292,12 +292,13 @@ mod tests {
                     .send_key(KeyCode::Char('/'))
                     .send_text(query)
                     .send_key(KeyCode::Enter)
-                    .assert_empty();
+                    .assert()
+                    .empty();
                 // Wait for the command to finish, pass results back to the
                 // component
             })
             .await;
-            component.int().drain_draw().assert_empty();
+            component.int().drain_draw().assert().empty();
         }
 
         component.save_response_body();

--- a/crates/tui/src/view/component/root.rs
+++ b/crates/tui/src/view/component/root.rs
@@ -321,7 +321,7 @@ mod tests {
 
         let mut component =
             TestComponent::new(&harness, &terminal, Root::new());
-        component.int().drain_draw().assert_empty();
+        component.int().drain_draw().assert().empty();
 
         // Make sure profile+recipe were preselected correctly
         let primary = &component.primary_view;
@@ -355,7 +355,7 @@ mod tests {
 
         let mut component =
             TestComponent::new(&harness, &terminal, Root::new());
-        component.int().drain_draw().assert_empty();
+        component.int().drain_draw().assert().empty();
 
         // Make sure everything was preselected correctly
         let primary = &component.primary_view;
@@ -386,7 +386,7 @@ mod tests {
 
         let mut component =
             TestComponent::new(&harness, &terminal, Root::new());
-        component.int().drain_draw().assert_empty();
+        component.int().drain_draw().assert().empty();
 
         assert_eq!(
             component.primary_view.selected_request_id(),
@@ -417,7 +417,7 @@ mod tests {
 
         let mut component =
             TestComponent::new(&harness, &terminal, Root::new());
-        component.int().drain_draw().assert_empty();
+        component.int().drain_draw().assert().empty();
 
         assert_eq!(
             component.primary_view.selected_request_id(),
@@ -428,7 +428,8 @@ mod tests {
         component
             .int()
             .send_keys([KeyCode::Char('r'), KeyCode::Down])
-            .assert_empty();
+            .assert()
+            .empty();
         assert_eq!(
             component.primary_view.selected_request_id(),
             Some(exchange2.id)
@@ -458,7 +459,7 @@ mod tests {
 
         let mut component =
             TestComponent::new(&harness, &terminal, Root::new());
-        component.int().drain_draw().assert_empty();
+        component.int().drain_draw().assert().empty();
 
         assert_eq!(
             component.primary_view.selected_request_id(),
@@ -469,7 +470,8 @@ mod tests {
         component
             .int()
             .send_keys([KeyCode::Char('p'), KeyCode::Down, KeyCode::Enter])
-            .assert_empty();
+            .assert()
+            .empty();
         // The exchange from profile2 should be selected now
         assert_eq!(
             component.primary_view.selected_request_id(),
@@ -499,7 +501,8 @@ mod tests {
             .int()
             .drain_draw()
             .send_key(KeyCode::Char('h'))
-            .assert_empty();
+            .assert()
+            .empty();
 
         // Sanity check for initial state
         assert_eq!(
@@ -514,7 +517,8 @@ mod tests {
             .action(action_path)
             // Decline
             .send_keys([KeyCode::Left, KeyCode::Enter])
-            .assert_empty();
+            .assert()
+            .empty();
 
         // Same request is still selected
         assert_eq!(
@@ -528,7 +532,8 @@ mod tests {
             .action(action_path)
             // Confirm
             .send_keys([KeyCode::Enter])
-            .assert_empty();
+            .assert()
+            .empty();
 
         // It'd be nice to test that the request is actually deleted, but I
         // haven't figured out a way to test messages in the event loop.
@@ -564,7 +569,8 @@ mod tests {
             .int()
             .drain_draw()
             .send_key(KeyCode::Char('2'))
-            .assert_empty();
+            .assert()
+            .empty();
 
         // Sanity check for initial state
         assert_eq!(
@@ -577,7 +583,8 @@ mod tests {
             .int()
             .action(&["Delete Request"])
             .send_keys([KeyCode::Left, KeyCode::Enter]) // Decline
-            .assert_empty();
+            .assert()
+            .empty();
 
         // Same request is still selected
         assert_eq!(
@@ -589,7 +596,8 @@ mod tests {
             .int()
             .action(&["Delete Request"])
             .send_keys([KeyCode::Enter]) // Confirm
-            .assert_empty();
+            .assert()
+            .empty();
 
         // It'd be nice to test that the request is actually deleted, but I
         // haven't figured out a way to test messages in the event loop.


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

When a component is first built, it's common to generate an event during startup that immediately triggers some state update. Automatically handling these updates reduces boilerplate and debugging time when writing new tests.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

## QA

_How did you test this?_

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
