### PR TITLE
Don't close sidebar on Enter

### DIFF
--- a/crates/tui/src/view/component/primary.rs
+++ b/crates/tui/src/view/component/primary.rs
@@ -13,7 +13,7 @@ use crate::{
             Canvas, Child, ComponentExt, ComponentId, Draw, DrawMetadata,
             ToChild,
             exchange_pane::ExchangePane,
-            history::{History, HistoryEvent},
+            history::History,
             primary::view_state::{
                 DefaultPane, PrimaryLayout, Sidebar, SidebarPane, ViewState,
             },
@@ -535,9 +535,6 @@ impl Component for PrimaryView {
                     ));
                 }
                 SidebarListEvent::Close => self.view.close_sidebar(),
-            })
-            .emitted(self.history.to_emitter(), |event| match event {
-                HistoryEvent::Close => self.view.close_sidebar(),
             })
             // Handle our own menu action type
             .emitted(self.global_actions_emitter, |menu_action| {


### PR DESCRIPTION



## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

I was getting really annoying by Enter closing the recipe sidebar. Sometimes I want to leave the sidebar open and switch back and forth between recipes.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_


I'm not sure if this will feel weird for the Profile and History lists. We'll see.

## QA

_How did you test this?_

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
