### PR TITLE
Add import feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,9 +117,10 @@ tracing = {workspace = true}
 tracing-subscriber = {workspace = true}
 
 [features]
-default = ["cli", "tui"]
-# TUI and CLI can be disabled in dev to speed compilation while not in use
+default = ["cli", "import", "tui"]
+# TUI and CLI can be disabled in dev to speed up compilation while not in use
 cli = ["dep:slumber_cli"]
+import = ["slumber_cli/import"]
 tui = ["dep:slumber_tui"]
 # Enable tokio-console tracing
 tokio_tracing = ["dep:console-subscriber"]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -30,7 +30,7 @@ serde_json = {workspace = true, optional = true}
 serde_yaml = {workspace = true}
 slumber_config = {workspace = true}
 slumber_core = {workspace = true}
-slumber_import = {workspace = true}
+slumber_import = {workspace = true, optional = true}
 slumber_template = {workspace = true}
 slumber_util = {workspace = true}
 tokio = {workspace = true, features = ["rt", "macros"]}
@@ -49,6 +49,10 @@ slumber_core = {workspace = true, features = ["test"]}
 slumber_util = {workspace = true, features = ["test"]}
 uuid = {workspace = true}
 wiremock = {workspace = true}
+
+[features]
+# Import can be disabled in dev for speed. It has a big dep tree
+import = ["dep:slumber_import"]
 
 [lints]
 workspace = true

--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -2,6 +2,7 @@ pub mod collection;
 pub mod config;
 pub mod db;
 pub mod generate;
+#[cfg(feature = "import")]
 pub mod import;
 pub mod new;
 pub mod request;

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -10,11 +10,12 @@ mod util;
 
 pub use util::print_error;
 
+#[cfg(feature = "import")]
+use crate::commands::import::ImportCommand;
 use crate::{
     commands::{
         collection::CollectionCommand, config::ConfigCommand, db::DbCommand,
-        generate::GenerateCommand, import::ImportCommand, new::NewCommand,
-        request::RequestCommand,
+        generate::GenerateCommand, new::NewCommand, request::RequestCommand,
     },
     completions::{complete_collection_path, complete_log_level},
 };
@@ -104,6 +105,7 @@ pub enum CliCommand {
     Config(ConfigCommand),
     Db(DbCommand),
     Generate(GenerateCommand),
+    #[cfg(feature = "import")]
     Import(ImportCommand),
     New(NewCommand),
     Request(RequestCommand),
@@ -122,6 +124,7 @@ impl CliCommand {
             Self::Config(command) => command.execute(global).await,
             Self::Db(command) => command.execute(global).await,
             Self::Generate(command) => command.execute(global).await,
+            #[cfg(feature = "import")]
             Self::Import(command) => command.execute(global).await,
             Self::New(command) => command.execute(global).await,
             Self::Request(command) => command.execute(global).await,

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tasks.cli]
 description = "Run a CLI command"
 quiet = true
-run = "cargo run --no-default-features --features cli --"
+run = "cargo run --no-default-features --features cli"
 
 [tasks.docs]
 description = "Build and serve docs"


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Add a new flag to disable the import subcommand. The import crate as a big dep tree, and I don't use it very often in dev. Disabling it will speed up compilation a bit.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

- More effort to run the import command now. You need `mise cli --features import -- <cmd>`
- Potentially more confusing for newcomers looking at the features

## QA

_How did you test this?_

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
