### PR TITLE
Fix file watcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,8 @@ The breaking changes in this release are mostly limited to CLI commands. The onl
 - Invalid body override template is displayed instead of being thrown away [#531](https://github.com/LucasPickering/slumber/issues/531)
 - Fix panic when SIGTERM is sent to a TUI process that failed to start and is display a collection error
 - Fix indentation in TUI display of multi-line errors
+- Fix collection file watching for vim, helix, and other editors that swap instead of writing [#706](https://github.com/LucasPickering/slumber/issues/706)
+  - Previously, the file watching would break after the first write because these editors replace the edited file (specifically, the inode) instead of just writing to it
 
 ## [4.3.1] - 2026-01-02
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,15 +934,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "file-id"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1fc6a637b6dc58414714eddd9170ff187ecb0933d4c7024d1abbd23a3cc26e9"
-dependencies = [
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "filedescriptor"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1013,15 +1004,6 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
-name = "fsevent-sys"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "futures"
@@ -1960,7 +1942,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
  "bitflags 2.10.0",
- "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",
@@ -1969,19 +1950,6 @@ dependencies = [
  "notify-types",
  "walkdir",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "notify-debouncer-full"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375bd3a138be7bfeff3480e4a623df4cbfb55b79df617c055cd810ba466fa078"
-dependencies = [
- "file-id",
- "log",
- "notify",
- "notify-types",
- "walkdir",
 ]
 
 [[package]]
@@ -3592,7 +3560,6 @@ dependencies = [
  "itertools",
  "mime",
  "notify",
- "notify-debouncer-full",
  "pretty_assertions",
  "proptest",
  "ratatui",

--- a/crates/core/src/database.rs
+++ b/crates/core/src/database.rs
@@ -705,7 +705,7 @@ impl CollectionDatabase {
                 "Querying UI state key `{key:?}`"
             )))
             .traced()?;
-        debug!(?key, ?value, "Fetched UI state");
+        trace!(?key, ?value, "Fetched UI state");
         Ok(value)
     }
 
@@ -716,7 +716,7 @@ impl CollectionDatabase {
         key: &str,
         value: &str,
     ) -> Result<(), DatabaseError> {
-        debug!(?key, ?value, "Setting UI state");
+        trace!(?key, ?value, "Setting UI state");
         self.database
             .connection()
             .execute(

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -21,8 +21,7 @@ futures = {workspace = true}
 indexmap = {workspace = true}
 itertools = {workspace = true}
 mime = {workspace = true}
-notify = {version = "8.0.0", default-features = false, features = ["macos_kqueue"]}
-notify-debouncer-full = {version = "0.6.0", default-features = false}
+notify = {version = "8.0.0", default-features = false}
 ratatui = {version = "0.30.0-alpha.5", default-features = false, features = ["crossterm", "underline-color", "unstable-widget-ref"]}
 reqwest = {workspace = true}
 serde = {workspace = true}


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Fix file watching for vim/helix

Vim and helix (and I'm sure other editors as well) usually save a file by swapping it with its backup. This means whenever you write, it changes the inode that the path points to. This breaks the file watcher, because the watcher is looking at that specific inode. After the first edit of the session, subsequent edits will be lost.

See [this comment on notify](https://github.com/notify-rs/notify/issues/113#issuecomment-281836995) for a better explanation.

I tried to implement directory-based watching for this, but couldn't get it to work. I wasn't receiving events on the watched child. Instead, I just switched to polling. Since we're only watching a single file, it should be very cheap. I checked the idle CPU usage and it's sitting at 0. Checking a single file's metadata every 100ms is very cheap.

Another benefit of this is that we can remove notify_full_debouncer. With polling, no debouncery is necessary.

Closes #706

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Potential high CPU usage from polling. The idle CPU usage is still sitting at 0% for me.

## QA

_How did you test this?_

Added a new check to an existing test.

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
