### PR TITLE
Move cancellation token into MessageSender

### DIFF
--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -19,7 +19,7 @@ use crate::{
     input::InputEvent,
     message::{Message, MessageSender},
     tui_state::TuiState,
-    util::{CANCEL_TOKEN, ResultReported},
+    util::ResultReported,
 };
 use anyhow::Context;
 use crossterm::event::{self, EventStream};
@@ -288,7 +288,7 @@ where
     /// Spawn a task to listen in the background for quit signals
     fn listen_for_signals(&self) {
         let messages_tx = self.messages_tx();
-        util::spawn(async move {
+        self.messages_tx.spawn(async move {
             util::signals().await.reported(&messages_tx);
             messages_tx.send(Message::Quit);
         });
@@ -299,7 +299,7 @@ where
         info!("Initiating graceful shutdown");
         self.should_run = false;
         // Kill all background tasks
-        CANCEL_TOKEN.cancel();
+        self.messages_tx.cancel();
     }
 
     /// Draw the view onto the screen.

--- a/crates/tui/src/test_util.rs
+++ b/crates/tui/src/test_util.rs
@@ -105,7 +105,10 @@ impl MessageQueue {
     /// Open a new MPSC channel
     pub fn new() -> Self {
         let (tx, rx) = mpsc::unbounded_channel();
-        Self { rx, tx: tx.into() }
+        Self {
+            rx,
+            tx: MessageSender::new(tx),
+        }
     }
 
     /// Get a new message sender

--- a/crates/tui/src/view/component/footer.rs
+++ b/crates/tui/src/view/component/footer.rs
@@ -1,14 +1,11 @@
-use crate::{
-    util,
-    view::{
-        UpdateContext,
-        component::{
-            Canvas, Child, Component, ComponentId, Draw, DrawMetadata, ToChild,
-            collection_select::CollectionSelect, help::Help,
-        },
-        event::{Emitter, Event, EventMatch},
-        state::Notification,
+use crate::view::{
+    UpdateContext, ViewContext,
+    component::{
+        Canvas, Child, Component, ComponentId, Draw, DrawMetadata, ToChild,
+        collection_select::CollectionSelect, help::Help,
     },
+    event::{Emitter, Event, EventMatch},
+    state::Notification,
 };
 use ratatui::layout::{Constraint, Layout};
 use tokio::time;
@@ -40,7 +37,7 @@ impl Footer {
         // accidental complexity. Since this task is a fixed length, it slows
         // tests down a lot.
         if !cfg!(test) {
-            util::spawn(async move {
+            ViewContext::spawn(async move {
                 time::sleep(Notification::DURATION).await;
                 emitter.emit(ClearNotification(id));
             });

--- a/crates/tui/src/view/component/queryable_body.rs
+++ b/crates/tui/src/view/component/queryable_body.rs
@@ -218,7 +218,7 @@ impl<K> QueryableBody<K> {
         body: Bytes,
         on_complete: impl 'static + FnOnce(String, anyhow::Result<Vec<u8>>),
     ) -> AbortHandle {
-        util::spawn(async move {
+        ViewContext::spawn(async move {
             // Store the command in history. Query and export commands are
             // stored together. We can toss the error; it gets traced by the DB
             let _ =

--- a/crates/tui/src/view/context.rs
+++ b/crates/tui/src/view/context.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use slumber_core::{collection::Collection, database::CollectionDatabase};
 use std::{cell::RefCell, sync::Arc};
+use tokio::task::JoinHandle;
 use tracing::debug;
 
 /// Thread-local context container, which stores mutable state needed in the
@@ -117,6 +118,13 @@ impl ViewContext {
     /// Send an async message on the channel
     pub fn send_message(message: impl Into<Message>) {
         Self::with(|context| context.messages_tx.send(message));
+    }
+
+    /// Spawn a task on the main thread
+    ///
+    /// The task will be automatically cancelled on TUI shutdown.
+    pub fn spawn(future: impl 'static + Future<Output = ()>) -> JoinHandle<()> {
+        Self::with(|context| context.messages_tx.spawn(future))
     }
 }
 


### PR DESCRIPTION




## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Previously, the task cancellation token was stored in a static. This turned out to be problematic with integration tests, because once the TUI exited once, the cancel token was stuck set for all future tests/runs. We need to get rid of statics to make tests work.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

I jammed the cancellation token into MessageSender, since that's already available throughout the app. It's a bit of a hack but it was easy, and I think easier to follow than plumbing a whole other thing around. Maybe I should rename MessageSender now, but I didn't.

## QA

_How did you test this?_

Tests pass!

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
