### PR TITLE
Remove data dir env var

### DIFF
--- a/crates/cli/src/commands/new.rs
+++ b/crates/cli/src/commands/new.rs
@@ -70,7 +70,6 @@ mod tests {
     };
     use slumber_util::{Factory, TempDir, temp_dir, yaml::SourceLocation};
     use std::fs;
-    use tracing::level_filters::LevelFilter;
 
     /// Test creating a new collection file, specifying the path in various ways
     #[rstest]
@@ -94,8 +93,7 @@ mod tests {
         };
         let global_args = GlobalArgs {
             file: global_file_arg.map(PathBuf::from),
-            log_level: LevelFilter::OFF,
-            print_log_path: false,
+            ..Default::default()
         };
 
         command.execute(global_args).await.unwrap();

--- a/crates/cli/src/completions.rs
+++ b/crates/cli/src/completions.rs
@@ -179,12 +179,10 @@ fn get_candidates<T: Into<String>>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use env_lock::{CurrentDirGuard, EnvGuard};
+    use env_lock::CurrentDirGuard;
     use rstest::{fixture, rstest};
     use slumber_core::http::{Exchange, RequestId};
-    use slumber_util::{
-        Factory, TempDir, paths::DATA_DIRECTORY_ENV_VARIABLE, temp_dir,
-    };
+    use slumber_util::{DataDir, Factory, data_dir};
     use std::path::{Path, PathBuf};
 
     /// Complete profile IDs from the collection
@@ -313,26 +311,19 @@ mod tests {
 
     struct TestDatabase {
         database: Database,
-        // Hang onto these so the env isn't reset/dir isn't deleted until the
-        // end of the test
-        _temp_dir: TempDir,
-        _env_guard: EnvGuard<'static>,
+        /// Hang onto this dir isn't deleted until the end of the test
+        _data_dir: DataDir,
     }
 
     /// Create a DB in the temp dir. We don't want an in-memory DB because we
     /// want to test real world behavior. Returns the env guard as well because
     /// the env variable needs to remain set until the end of the test
     #[fixture]
-    fn database(temp_dir: TempDir) -> TestDatabase {
-        let env_guard = env_lock::lock_env([(
-            DATA_DIRECTORY_ENV_VARIABLE,
-            Some(temp_dir.to_str().unwrap()),
-        )]);
+    fn database(data_dir: DataDir) -> TestDatabase {
         let database = Database::load().unwrap();
         TestDatabase {
             database,
-            _temp_dir: temp_dir,
-            _env_guard: env_guard,
+            _data_dir: data_dir,
         }
     }
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -103,6 +103,18 @@ impl GlobalArgs {
     }
 }
 
+impl Default for GlobalArgs {
+    fn default() -> Self {
+        Self {
+            file: None,
+            log_level: LevelFilter::OFF,
+            print_log_path: false,
+            #[cfg(debug_assertions)]
+            data_dir: None,
+        }
+    }
+}
+
 /// A CLI subcommand
 #[derive(Clone, Debug, clap::Subcommand)]
 pub enum CliCommand {
@@ -122,6 +134,12 @@ impl CliCommand {
         if global.print_log_path {
             let path = paths::log_file();
             println!("Logging to {}", path.display());
+        }
+
+        // The --data-dir flag is used in integration tests to isolate files
+        #[cfg(debug_assertions)]
+        if let Some(path) = global.data_dir.as_deref() {
+            paths::set_data_directory(path.to_owned());
         }
 
         match self {

--- a/crates/cli/tests/common.rs
+++ b/crates/cli/tests/common.rs
@@ -2,7 +2,7 @@
 
 use assert_cmd::{Command, cargo::cargo_bin_cmd};
 use slumber_core::collection::CollectionFile;
-use slumber_util::{TempDir, paths::DATA_DIRECTORY_ENV_VARIABLE, temp_dir};
+use slumber_util::{TempDir, temp_dir};
 use std::{
     env,
     ops::Deref,

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -14,7 +14,7 @@ version = {workspace = true}
 tag = false
 
 [dependencies]
-derive_more = {workspace = true, features = ["display", "from"]}
+derive_more = {workspace = true, features = ["deref", "display", "from"]}
 dirs = {workspace = true}
 indexmap = {workspace = true}
 itertools = {workspace = true}


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Replace the `SLUMBER_DB` env var with a thread local. This allows the TUI integration tests to run in parallel. Env vars are shared across an entire process.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Code is a bit more complicated and, dare I say, spaghetti. Good thing I'm the only one who has to deal with it.

## QA

_How did you test this?_

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
