### PR TITLE
Split request cancelled states

### DIFF
--- a/crates/tui/src/http/tests.rs
+++ b/crates/tui/src/http/tests.rs
@@ -205,7 +205,7 @@ async fn test_life_cycle_building_cancel() {
         Some(cancel_token),
     );
     store.cancel(id);
-    assert_matches!(store.get(id), Some(RequestState::Cancelled { .. }));
+    assert_matches!(store.get(id), Some(RequestState::BuildCancelled { .. }));
     assert!(!future_finished.load(Ordering::Relaxed));
 }
 
@@ -237,7 +237,7 @@ async fn test_life_cycle_loading_cancel() {
     store.loading(exchange.request);
     assert_matches!(store.get(id), Some(RequestState::Loading { .. }));
     store.cancel(id);
-    assert_matches!(store.get(id), Some(RequestState::Cancelled { .. }));
+    assert_matches!(store.get(id), Some(RequestState::LoadingCancelled { .. }));
     assert!(!future_finished.load(Ordering::Relaxed));
 }
 

--- a/crates/tui/src/view/component/history.rs
+++ b/crates/tui/src/view/component/history.rs
@@ -228,11 +228,14 @@ impl Generate for &RequestStateSummary {
         let styles = ViewContext::styles();
         let description: Span = match self {
             RequestStateSummary::Building { .. } => "Initializing...".into(),
+            RequestStateSummary::BuildCancelled { .. }
+            | RequestStateSummary::LoadingCancelled { .. } => {
+                "Cancelled".into()
+            }
             RequestStateSummary::BuildError { .. } => {
                 Span::styled("Build error", styles.text.error)
             }
             RequestStateSummary::Loading { .. } => "Loading...".into(),
-            RequestStateSummary::Cancelled { .. } => "Cancelled".into(),
             RequestStateSummary::Response(exchange) => {
                 exchange.status.generate()
             }


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

You can cancel a request during the build OR while the request is in flight. Previously these shared the same state. I split them. The key difference is in the latter case, a built request is available. With the upcoming resend request feature, it could be useful to resend a cancelled request.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

## QA

_How did you test this?_

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
