### PR TITLE
Add TUI action to resend a request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ The breaking changes in this release are mostly limited to CLI commands. The onl
   - Up/down to cycle through past commands
   - Ctrl-r to search
   - Command history is specific to each collection and capped at 100 commands per collection
+- Add action to resend a previous request [#702](https://github.com/LucasPickering/slumber/issues/702)
+  - Request/Response pane > Actions menu (x) > Resend Request
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3504,6 +3504,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "serde_yaml",
  "shell-words",
  "slumber_config",
  "slumber_core",
@@ -3519,6 +3520,7 @@ dependencies = [
  "tree-sitter-json",
  "unicode-width",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/core/src/database.rs
+++ b/crates/core/src/database.rs
@@ -542,7 +542,8 @@ impl CollectionDatabase {
     ) -> Result<(), DatabaseError> {
         debug!(
             id = %exchange.id,
-            url = %exchange.request.url,
+            status = exchange.response.status.as_u16(),
+            recipe = %exchange.request.recipe_id,
             "Adding exchange to database",
         );
         self.database

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -46,7 +46,9 @@ env-lock = {workspace = true}
 pretty_assertions = {workspace = true}
 proptest = {workspace = true}
 rstest = {workspace = true}
+serde_yaml = {workspace = true}
 slumber_core = {workspace = true, features = ["test"]}
+wiremock = {workspace = true}
 
 [lints]
 workspace = true

--- a/crates/tui/src/http/tests.rs
+++ b/crates/tui/src/http/tests.rs
@@ -76,7 +76,7 @@ fn test_get() {
     let id = exchange.id;
     store
         .requests
-        .insert(exchange.id, RequestState::response(exchange));
+        .insert(exchange.id, RequestState::new_response(exchange));
 
     // This is a bit jank, but since we can't clone exchanges, the only way
     // to get the value back for comparison is to access the map directly
@@ -140,9 +140,9 @@ async fn test_life_cycle_build_error() {
             id,
             start_time: Utc::now(),
             end_time: Utc::now(),
-            error: RequestBuildErrorKind::UrlRender(
+            error: Box::new(RequestBuildErrorKind::UrlRender(
                 RenderError::FunctionUnknown,
-            ),
+            )),
         }
         .into(),
     );
@@ -249,7 +249,7 @@ fn test_load(mut store: RequestStore) {
     let present_id = present_exchange.id;
     store
         .requests
-        .insert(present_id, RequestState::response(present_exchange));
+        .insert(present_id, RequestState::new_response(present_exchange));
 
     let missing_exchange = Exchange::factory(());
     let missing_id = missing_exchange.id;
@@ -323,7 +323,7 @@ async fn test_load_summaries(mut store: RequestStore) {
     let response_id = exchange.id;
     store
         .requests
-        .insert(exchange.id, RequestState::response(exchange));
+        .insert(exchange.id, RequestState::new_response(exchange));
 
     let building_id = RequestId::new();
     store.start(
@@ -343,9 +343,9 @@ async fn test_load_summaries(mut store: RequestStore) {
                 id: build_error_id,
                 start_time: Utc::now(),
                 end_time: Utc::now(),
-                error: RequestBuildErrorKind::UrlRender(
+                error: Box::new(RequestBuildErrorKind::UrlRender(
                     RenderError::FunctionUnknown,
-                ),
+                )),
             }
             .into(),
         },

--- a/crates/tui/src/message.rs
+++ b/crates/tui/src/message.rs
@@ -181,6 +181,8 @@ impl From<HttpMessage> for Message {
 pub enum HttpMessage {
     /// Build and send an HTTP request based on the current recipe/profile state
     Begin,
+    /// Build and send an HTTP request as a clone of a previous request
+    Resend(RequestId),
     /// An HTTP request was triggered by another request, and is now being built
     Triggered {
         request_id: RequestId,

--- a/crates/tui/src/view/component/request_view.rs
+++ b/crates/tui/src/view/component/request_view.rs
@@ -18,7 +18,7 @@ use crate::{
 use ratatui::{layout::Layout, prelude::Constraint, text::Text};
 use slumber_config::Action;
 use slumber_core::{
-    http::{RequestBody, RequestRecord, content_type::ContentType},
+    http::{RequestBody, RequestId, RequestRecord, content_type::ContentType},
     util::MaybeStr,
 };
 use std::sync::Arc;
@@ -42,6 +42,10 @@ impl RequestView {
             request,
             body_text_window: text.map(TextWindow::new),
         }
+    }
+
+    pub fn request_id(&self) -> RequestId {
+        self.request.id
     }
 
     pub fn has_body(&self) -> bool {

--- a/crates/tui/tests/test_collection.rs
+++ b/crates/tui/tests/test_collection.rs
@@ -134,7 +134,7 @@ async fn test_reload_error(backend: TestBackend, data_dir: DataDir) {
         .run_until(fs::write(&collection_path, "requests: 3"))
         .await
         // Error is shown in a modal
-        .wait_for_content("Expected mapping", (12, 9).into())
+        .wait_for_content("Expected mapping", (14, 9).into())
         .await
         .done()
         .await;
@@ -204,7 +204,7 @@ requests: {"r1": {"method": "GET", "url": "http://localhost"}}"#,
         .assert_buffer_contains("GET http://localhost", (1, 3).into());
 }
 
-/// Create an empty collection file and return its path
+/// Create a collection file and return its path
 async fn collection_file(directory: &Path, content: &str) -> PathBuf {
     let path = directory.join("slumber.yml");
     fs::write(&path, content).await.unwrap();

--- a/crates/tui/tests/test_request.rs
+++ b/crates/tui/tests/test_request.rs
@@ -1,0 +1,89 @@
+//! Test sending requests in the TUI. Important stuff!
+
+use crate::common::{Runner, TestBackend, backend, collection_file};
+use rstest::rstest;
+use slumber_core::{
+    collection::{Collection, Recipe, RecipeId},
+    database::ProfileFilter,
+    http::HttpMethod,
+    test_util::by_id,
+};
+use slumber_tui::Tui;
+use slumber_util::{DataDir, Factory, data_dir};
+use std::sync::Arc;
+use terminput::KeyCode;
+use wiremock::{Mock, MockServer, ResponseTemplate, matchers};
+
+mod common;
+
+/// Resend a previous request
+#[rstest]
+#[tokio::test]
+async fn test_resend(backend: TestBackend, data_dir: DataDir) {
+    /// Build the HTTP mock. We have to make the same mock twice because we
+    /// wait for it to complete after each test
+    fn mock() -> Mock {
+        Mock::given(matchers::method("POST"))
+            .and(matchers::path("/data"))
+            .respond_with(ResponseTemplate::new(200))
+    }
+
+    // Set up HTTP mock
+    let server = MockServer::start().await;
+    let host = server.uri();
+
+    // Create a collection file to be loaded
+    let recipe_id: RecipeId = "textBody".into();
+    let collection = Collection {
+        recipes: by_id([Recipe {
+            id: recipe_id.clone(),
+            url: format!("{host}/data").parse().unwrap(),
+            method: HttpMethod::Post,
+            body: Some("body data".into()),
+            ..Recipe::factory(())
+        }])
+        .into(),
+        ..Collection::factory(())
+    };
+    let collection_path = collection_file(&data_dir, &collection);
+    // Rev up those fryers!!
+    let tui = Tui::new(backend.clone(), Some(collection_path)).unwrap();
+
+    // Run the first request
+    let mock_guard = mock().mount_as_scoped(&server).await;
+    let tui = Runner::new(tui)
+        .send_key(KeyCode::Enter) // Send the request
+        .wait_for_request(mock_guard)
+        .await
+        .done()
+        .await;
+    let exchange1 = tui
+        .database()
+        .get_latest_request(ProfileFilter::All, &recipe_id)
+        .unwrap()
+        .expect("Request not in DB");
+    assert_eq!(exchange1.request.body, b"body data".as_slice().into());
+
+    // Resend that request
+    let mock_guard = mock().mount_as_scoped(&server).await;
+    let tui = Runner::new(tui)
+        .send_key(KeyCode::Char('2')) // Select Request/Response pane
+        .action(4) // Resend Request action
+        .wait_for_request(mock_guard)
+        .await
+        .done()
+        .await;
+    let exchange2 = tui
+        .database()
+        .get_latest_request(ProfileFilter::All, &recipe_id)
+        .unwrap()
+        .expect("Request not in DB");
+
+    // IDs are different, but the requests are identical
+    assert_ne!(exchange1.id, exchange2.id);
+    // To do the ID-agnostic comparison, we need to set the IDs to be identical.
+    // That requires an owned request value
+    let mut request2 = Arc::try_unwrap(exchange2.request).unwrap();
+    request2.id = exchange1.id;
+    assert_eq!(*exchange1.request, request2);
+}

--- a/crates/util/src/test_util.rs
+++ b/crates/util/src/test_util.rs
@@ -162,7 +162,7 @@ pub fn assert_result<TA, TE, E>(
 
 /// Enable tracing output. Call this in a test to enable logging
 #[deprecated(note = "Debugging only; remove when done")]
-pub fn initialize_tracing() {
+pub fn initialize_tracing(level: LevelFilter) {
     let subscriber = tracing_subscriber::fmt::layer()
         .with_writer(io::stderr)
         .with_target(false)
@@ -170,7 +170,7 @@ pub fn initialize_tracing() {
         .without_time()
         .with_filter(
             Targets::new()
-                .with_target("slumber", LevelFilter::TRACE)
+                .with_target("slumber", level)
                 .with_default(LevelFilter::WARN),
         );
     tracing_subscriber::registry().with(subscriber).init();


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Resend a past request from history with a TUI action. This works as long as the request's body was stored in history. 

<img width="641" height="687" alt="image" src="https://github.com/user-attachments/assets/4099929f-c223-4e4a-97f4-d1d9fce9f1f4" />


Closes #702

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

There are two scenarios where we don't store bodies:
- The body was larger than the large_body_size threshold (1MB by default)
- The body was streamed (e.g. from a file) 

Most bodies do *not* fall into either category so this should be pretty widely usable.

## QA

_How did you test this?_

Added unit tests for the engine aspects, and a TUI integration test for the full workflow. 

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
