### PR TITLE
Add BodyOverride enum

### DIFF
--- a/crates/core/src/util.rs
+++ b/crates/core/src/util.rs
@@ -1,7 +1,7 @@
 //! Miscellaneous utility constants/types/functions
 
 use dialoguer::Confirm;
-use std::{fmt, fmt::Display};
+use std::fmt::{self, Display};
 
 /// Show the user a confirmation prompt
 pub fn confirm(prompt: impl Into<String>) -> bool {


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

This makes the `body` override field more explicit. When the TUI is specifying an override for a JSON body, it should be valid JSON. By pre-parsing it in the TUI, it makes the HTTP engine logic simpler. Previously, the TUI had to parse as a Template, then the HTTP engine would restringify and re-parse as a JsonTemplate.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

- Adds more code
- The JSON override generation in the TUI is uglier now, but really I just shifted complexity around. It'll make it easier to finally refactor in #627 

## QA

_How did you test this?_

Unit tests!

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
