### PR TITLE
Refactor ValueTemplate: unpacking is more explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Set extension on temporary file when editing recipe body in TUI
   - When editing a JSON body in the TUI, the created temp file will have `.json` as the extension, so your editor can use syntax highlighting and other language-specific features.
 
+### Fixed
+
+- Fix crash when previewing a profile value that returns a binary value
+
 ## [5.2.4] - 2026-03-30
 
 <!-- ANCHOR: changelog -->

--- a/crates/core/src/collection.rs
+++ b/crates/core/src/collection.rs
@@ -11,7 +11,7 @@ mod value_template;
 pub use cereal::HasId;
 pub use models::*;
 pub use recipe_tree::*;
-pub use value_template::ValueTemplate;
+pub use value_template::{RenderedValue, ValueTemplate};
 
 use itertools::Itertools;
 use std::{

--- a/crates/core/src/collection/cereal.rs
+++ b/crates/core/src/collection/cereal.rs
@@ -409,10 +409,11 @@ impl DeserializeYaml for ValueTemplate {
             YamlData::Value(Scalar::FloatingPoint(f)) => Ok(Self::Float(f.0)),
             // Parse string as a template
             YamlData::Value(Scalar::String(s)) => {
-                let template = s.parse::<Template>().map_err(|error| {
+                // Template will be unpacked here if appropriate
+                let template = s.parse::<Self>().map_err(|error| {
                     LocatedError::other(error, yaml.location)
                 })?;
-                Ok(Self::String(template))
+                Ok(template)
             }
             YamlData::Sequence(sequence) => {
                 let values = sequence

--- a/crates/core/src/collection/value_template.rs
+++ b/crates/core/src/collection/value_template.rs
@@ -1,9 +1,13 @@
 use crate::render::TemplateContext;
-use futures::{FutureExt, future};
-use serde::Serialize;
+use bytes::BytesMut;
+use futures::{FutureExt, TryStreamExt, future};
+use serde::{Serialize, Serializer};
 use slumber_template::{
-    RenderError, RenderedChunks, Template, Value, ValueStream,
+    Context, Expression, RenderError, RenderValue, RenderedChunk,
+    RenderedChunks, Template, TemplateChunk, TemplateParseError, Value,
+    ValueStream,
 };
+use std::str::FromStr;
 
 /// A templated [Value]
 ///
@@ -18,6 +22,14 @@ pub enum ValueTemplate {
     Boolean(bool),
     Integer(i64),
     Float(f64),
+    /// An unpacked single-chunk template
+    #[serde(serialize_with = "serialize_expression")]
+    #[cfg_attr(feature = "schema", schemars(with = "String"))]
+    Expression(Expression),
+    /// A template that has not been unpacked
+    ///
+    /// This is either a single raw chunk or a multi-chunk template
+    #[from(ignore)]
     String(Template),
     #[from(ignore)]
     Array(Vec<Self>),
@@ -51,6 +63,7 @@ impl ValueTemplate {
             | Self::Boolean(_)
             | Self::Integer(_)
             | Self::Float(_) => false,
+            Self::Expression(_) => true,
             Self::String(template) => template.is_dynamic(),
             Self::Array(array) => array.iter().any(Self::is_dynamic),
             Self::Object(object) => object
@@ -59,33 +72,35 @@ impl ValueTemplate {
         }
     }
 
-    /// Render to chunks with eager values
+    /// Render to a value or chunks with eager values
     ///
-    /// The return value is *usually* a single chunk, but if `self` is a
+    /// The return value is *usually* a single value, but if `self` is a
     /// multi-chunk template string, then its multi-chunk output will be the
     /// output for this.
     ///
     /// Use this for cases where streaming is *not* allowed.
-    pub async fn render_chunks(
+    pub async fn render_value(
         &self,
         context: &TemplateContext,
-    ) -> RenderedChunks<Value> {
+    ) -> RenderedValue<Value> {
         self.render_chunks_inner(context, Template::render_chunks)
+            .boxed_local() // Box for recursion
             .await
     }
 
-    /// Render to chunks with stream values
+    /// Render to a value or chunks with stream values
     ///
-    /// The return value is *usually* a single chunk, but if `self` is a
+    /// The return value is *usually* a single value, but if `self` is a
     /// multi-chunk template string, then its multi-chunk output will be the
     /// output for this.
     ///
     /// Use this for cases where streaming is allowed.
-    pub async fn render_chunks_stream(
+    pub async fn render_value_stream(
         &self,
         context: &TemplateContext,
-    ) -> RenderedChunks<ValueStream> {
+    ) -> RenderedValue<ValueStream> {
         self.render_chunks_inner(context, Template::render_chunks_stream)
+            .boxed_local() // Box for recursion
             .await
     }
 
@@ -97,38 +112,45 @@ impl ValueTemplate {
             &Template,
             &TemplateContext,
         ) -> RenderedChunks<V>,
-    ) -> RenderedChunks<V>
+    ) -> RenderedValue<V>
     where
-        V: From<Value>,
+        V: RenderValue,
+        TemplateContext: Context<V>,
     {
         match self {
             Self::Null => Value::Null.into(),
             Self::Boolean(b) => Value::Boolean(*b).into(),
             Self::Integer(i) => Value::Integer(*i).into(),
             Self::Float(f) => Value::Float(*f).into(),
-            Self::String(template) => render_string(template, context).await,
+            Self::Expression(expression) => {
+                let result = expression.render(context).await;
+                RenderedValue::Value(result)
+            }
+            Self::String(template) => {
+                RenderedValue::Chunks(render_string(template, context).await)
+            }
             Self::Array(array) => {
                 // Render each value and collection into an Array
                 future::try_join_all(array.iter().map(|value| {
                     value
-                        .render_chunks(context)
-                        .map(RenderedChunks::try_into_value)
+                        .render_value(context)
+                        .map(RenderedValue::try_into_value)
                 }))
                 .await
-                .map(Value::from)
-                .into() // Wrap into RenderedOutput
+                .map(Value::Array)
+                .into() // Wrap into RenderedValue
             }
             Self::Object(map) => {
                 // Render each key/value and collect into an Object
                 future::try_join_all(map.iter().map(|(key, value)| async {
                     let key = key.render_string(context).await?;
                     let value =
-                        value.render_chunks(context).await.try_into_value()?;
+                        value.render_value(context).await.try_into_value()?;
                     Ok::<_, RenderError>((key, value))
                 }))
                 .await
                 .map(Value::from)
-                .into() // Wrap into RenderedOutput
+                .into() // Wrap into RenderedValue
             }
         }
     }
@@ -138,8 +160,7 @@ impl ValueTemplate {
 #[cfg(any(test, feature = "test"))]
 impl From<&str> for ValueTemplate {
     fn from(value: &str) -> Self {
-        let template = value.parse().unwrap();
-        Self::String(template)
+        value.parse().unwrap()
     }
 }
 
@@ -160,4 +181,127 @@ impl<T: Into<ValueTemplate>> From<Vec<(&str, T)>> for ValueTemplate {
                 .collect(),
         )
     }
+}
+
+/// A value rendered from a [ValueTemplate]
+#[derive(Debug)]
+pub enum RenderedValue<V> {
+    /// A single-chunk dynamic template unpacked to a single value (or error)
+    Value(Result<V, RenderError>),
+    /// A raw or multi-chunk template that can be stitched into a string
+    Chunks(RenderedChunks<V>),
+}
+
+impl RenderedValue<Value> {
+    /// Collect the rendered value into a [Value] by these rules:
+    /// - If the value is a [RenderedValue::Value], return that value directly
+    /// - Any other template will be rendered to a string by stringifying each
+    ///   dynamic chunk and concatenating them all together
+    /// - If rendering to a string fails because the bytes are not valid UTF-8,
+    ///   concatenate into a bytes object instead
+    pub fn try_into_value(self) -> Result<Value, RenderError> {
+        let value = match self {
+            RenderedValue::Value(result) => result?,
+            RenderedValue::Chunks(chunks) => {
+                // Render to bytes
+                let bytes = chunks.try_into_bytes()?;
+                Value::Bytes(bytes)
+            }
+        };
+        Ok(value.decode_bytes())
+    }
+}
+
+impl RenderedValue<ValueStream> {
+    /// Does this output contain *any* stream chunks?
+    pub fn has_stream(&self) -> bool {
+        match self {
+            Self::Value(Ok(ValueStream::Stream { .. })) => true,
+            Self::Value(Ok(ValueStream::Value(_)) | Err(_)) => false,
+            Self::Chunks(chunks) => chunks.iter().any(|chunk| match chunk {
+                RenderedChunk::Raw(_)
+                | RenderedChunk::Dynamic(ValueStream::Value(_))
+                | RenderedChunk::Error(_) => false,
+                RenderedChunk::Dynamic(ValueStream::Stream { .. }) => true,
+            }),
+        }
+    }
+
+    /// Collect the rendered chunks into a [Value] by these rules:
+    /// - If the value is a [RenderedValue::Value], return that value directly
+    /// - If there are any streams, resolve them to bytes
+    /// - Any other template will be rendered to a string by stringifying each
+    ///   dynamic chunk and concatenating them all together
+    /// - If rendering to a string fails because the bytes are not valid UTF-8,
+    ///   concatenate into a bytes object instead
+    pub async fn try_collect_value(self) -> Result<Value, RenderError> {
+        // If we only have one chunk, unpack it into a value
+        let value = match self {
+            Self::Value(Ok(ValueStream::Value(value))) => value,
+            Self::Value(Ok(stream @ ValueStream::Stream { .. })) => {
+                stream.resolve().await?
+            }
+            Self::Value(Err(error)) => return Err(error),
+            Self::Chunks(chunks) => {
+                // Render to bytes
+                let bytes = chunks
+                    .try_into_stream()?
+                    .try_collect::<BytesMut>()
+                    .await?
+                    .into();
+                Value::Bytes(bytes)
+            }
+        };
+
+        // Try to convert bytes to string, because that's generally more
+        // useful to the consumer
+        Ok(value.decode_bytes())
+    }
+}
+
+/// Create render output of a single chunk with a value
+impl<V: RenderValue> From<Value> for RenderedValue<V> {
+    fn from(value: Value) -> Self {
+        Self::Value(Ok(V::from_value(value)))
+    }
+}
+
+/// Create render output of a single chunk that may have failed
+impl<V: RenderValue> From<Result<Value, RenderError>> for RenderedValue<V> {
+    fn from(result: Result<Value, RenderError>) -> Self {
+        Self::Value(result.map(V::from_value))
+    }
+}
+
+impl From<Template> for ValueTemplate {
+    fn from(template: Template) -> Self {
+        // Single dynamic chunk is unpacked
+        match <[_; 1]>::try_from(template.into_chunks()) {
+            Ok([TemplateChunk::Expression(expression)]) => {
+                Self::Expression(expression)
+            }
+            Ok(chunks) => Self::String(Template::from_chunks(chunks.into())),
+            Err(chunks) => Self::String(Template::from_chunks(chunks)),
+        }
+    }
+}
+
+/// Parse a template string to [ValueTemplate]
+///
+/// This will unpack the template to an expression if possible.
+impl FromStr for ValueTemplate {
+    type Err = TemplateParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let template: Template = s.parse()?;
+        Ok(template.into())
+    }
+}
+
+/// Serialize an expression as `{{ expression }}`
+fn serialize_expression<S: Serializer>(
+    expression: &Expression,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    serializer.serialize_str(&Template::display_expression(expression))
 }

--- a/crates/core/src/http.rs
+++ b/crates/core/src/http.rs
@@ -766,7 +766,7 @@ impl Recipe {
             | (Some(RecipeBody::Json(_)), Some(BodyOverride::Json(json))) => {
                 // Render the value
                 let rendered_value = json
-                    .render_chunks(context)
+                    .render_value(context)
                     .await
                     .try_into_value()
                     .map_err(RequestBuildErrorKind::BodyRender)?;

--- a/crates/core/src/http/models.rs
+++ b/crates/core/src/http/models.rs
@@ -30,7 +30,6 @@ use std::{
 };
 use strum::{EnumDiscriminants, EnumIter, IntoEnumIterator};
 use thiserror::Error;
-use tracing::error;
 use uuid::Uuid;
 
 /// Unique ID for a single request. Can also be used to refer to the

--- a/crates/core/src/render.rs
+++ b/crates/core/src/render.rs
@@ -10,7 +10,9 @@ mod util;
 #[cfg(any(test, feature = "test"))]
 use crate::collection::Recipe;
 use crate::{
-    collection::{Collection, Profile, ProfileId, RecipeId, ValueTemplate},
+    collection::{
+        Collection, Profile, ProfileId, RecipeId, RenderedValue, ValueTemplate,
+    },
     http::{
         Exchange, RequestSeed, ResponseRecord, StoredRequestError,
         TriggeredRequestError,
@@ -222,7 +224,7 @@ impl Context<Value> for TemplateContext {
             FieldCacheOutcome::Miss(guard) => guard,
         };
         let template = self.get_field_template(field)?;
-        let chunks = template.render_chunks(self).await; // Render the nested template
+        let chunks = template.render_value(self).await; // Render the nested template
         let value = chunks
             .try_into_value()
             .map_err(|error| field_error(error, field))?;
@@ -253,21 +255,21 @@ impl Context<ValueStream> for TemplateContext {
         let template = self.get_field_template(field)?;
 
         // Render the nested template
-        let chunks = template.render_chunks_stream(self).await;
+        let output = template.render_value_stream(self).await;
 
         // If the output is a value, we can cache it. If it's a stream, it can't
         // be cloned so it can't be cached. In practice there's probably no
         // reason to include the same stream field twice in a single body, but
         // if that happens we'll have to compute it twice. This saves us a lot
         // of annoying machinery though.
-        if chunks.has_stream() {
+        if output.has_stream() {
             // If the nested template rendered to a single chunk, we can unpack
             // it out of its chunk list. If it had multiple chunks, we need to
             // keep all of them to provide both a correct preview and the final
             // stream
-            match chunks.unpack() {
-                Ok(stream) => Ok(stream),
-                Err(chunks) => {
+            match output {
+                RenderedValue::Value(result) => result,
+                RenderedValue::Chunks(chunks) => {
                     let stream = chunks
                         .try_into_stream()
                         .map_err(|error| field_error(error, field))?;
@@ -278,7 +280,7 @@ impl Context<ValueStream> for TemplateContext {
                 }
             }
         } else {
-            let value = chunks
+            let value = output
                 .try_collect_value()
                 .await
                 .map_err(|error| field_error(error, field))?;

--- a/crates/core/src/render/tests.rs
+++ b/crates/core/src/render/tests.rs
@@ -45,7 +45,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate, matchers};
 #[case::array_stream("{{ array_stream }}", vec!["first"].into(), false)]
 #[tokio::test]
 async fn test_profile(
-    #[case] template: Template,
+    #[case] template: ValueTemplate,
     #[case] expected: Value,
     #[case] expected_has_stream: bool,
 ) {
@@ -71,7 +71,7 @@ async fn test_profile(
     };
     let context = TemplateContext::factory((by_id([profile]), IndexMap::new()));
 
-    let chunks = template.render_chunks_stream(&context).await;
+    let chunks = template.render_value_stream(&context).await;
     assert_eq!(chunks.has_stream(), expected_has_stream);
     assert_eq!(chunks.try_collect_value().await.unwrap(), expected);
 }
@@ -142,12 +142,10 @@ async fn test_base64(
 #[case::array_filled(vec!["1", "2"].into(), true)]
 #[tokio::test]
 async fn test_boolean(#[case] input: Expression, #[case] expected: bool) {
-    let template = Template::function_call("boolean", [input], []);
     assert_result(
-        template
-            .render_chunks(&TemplateContext::factory(()))
-            .await
-            .try_into_value(),
+        Expression::call("boolean", [input], [])
+            .render::<_, Value>(&TemplateContext::factory(()))
+            .await,
         Ok(Value::Boolean(expected)),
     );
 }
@@ -376,12 +374,10 @@ async fn test_float(
     #[case] input: Expression,
     #[case] expected: Result<f64, &str>,
 ) {
-    let template = Template::function_call("float", [input], []);
     assert_result(
-        template
-            .render_chunks(&TemplateContext::factory(()))
-            .await
-            .try_into_value(),
+        Expression::call("float", [input], [])
+            .render::<_, Value>(&TemplateContext::factory(()))
+            .await,
         expected.map(Value::from),
     );
 }
@@ -403,12 +399,10 @@ async fn test_index(
     #[case] index: i64,
     #[case] expected: Option<Value>,
 ) {
-    let template = Template::function_call("index", [index.into(), value], []);
     assert_eq!(
-        template
-            .render_chunks(&TemplateContext::factory(()))
+        Expression::call("index", [index.into(), value], [])
+            .render::<_, Value>(&TemplateContext::factory(()))
             .await
-            .try_into_value()
             .unwrap(),
         expected.into(),
     );
@@ -435,12 +429,10 @@ async fn test_integer(
     #[case] input: Expression,
     #[case] expected: Result<i64, &str>,
 ) {
-    let template = Template::function_call("integer", [input], []);
     assert_result(
-        template
-            .render_chunks(&TemplateContext::factory(()))
-            .await
-            .try_into_value(),
+        Expression::call("integer", [input], [])
+            .render::<_, Value>(&TemplateContext::factory(()))
+            .await,
         expected.map(Value::from),
     );
 }
@@ -528,16 +520,14 @@ async fn test_jq(
             .map(Expression::from)
             .collect()
     });
-    let template = Template::function_call(
-        "jq",
-        [query.into(), json],
-        [("mode", mode.map(Expression::from))],
-    );
     assert_result(
-        template
-            .render_chunks(&TemplateContext::factory(()))
-            .await
-            .try_into_value(),
+        Expression::call(
+            "jq",
+            [query.into(), json],
+            [("mode", mode.map(Expression::from))],
+        )
+        .render::<_, Value>(&TemplateContext::factory(()))
+        .await,
         expected,
     );
 }
@@ -554,12 +544,10 @@ async fn test_json_parse(
     #[case] json: &'static [u8],
     #[case] expected: Result<Value, &str>,
 ) {
-    let template = Template::function_call("json_parse", [json.into()], []);
     assert_result(
-        template
-            .render_chunks(&TemplateContext::factory(()))
-            .await
-            .try_into_value(),
+        Expression::call("json_parse", [json.into()], [])
+            .render::<_, Value>(&TemplateContext::factory(()))
+            .await,
         expected,
     );
 }
@@ -614,16 +602,14 @@ async fn test_jsonpath(
             .map(Expression::from)
             .collect()
     });
-    let template = Template::function_call(
-        "jsonpath",
-        [query.into(), json],
-        [("mode", mode.map(Expression::from))],
-    );
     assert_result(
-        template
-            .render_chunks(&TemplateContext::factory(()))
-            .await
-            .try_into_value(),
+        Expression::call(
+            "jsonpath",
+            [query.into(), json],
+            [("mode", mode.map(Expression::from))],
+        )
+        .render::<_, Value>(&TemplateContext::factory(()))
+        .await,
         expected,
     );
 }
@@ -977,13 +963,14 @@ async fn test_select(
     #[case] select: Option<usize>,
     #[case] expected: Result<Value, &str>,
 ) {
-    let template = Template::function_call("select", [options.into()], []);
     let context = TemplateContext {
         prompter: Box::new(TestSelectPrompter::new(select.into_iter())),
         ..TemplateContext::factory(())
     };
     assert_result(
-        template.render_chunks(&context).await.try_into_value(),
+        Expression::call("select", [options.into()], [])
+            .render::<_, Value>(&context)
+            .await,
         expected,
     );
 }
@@ -1021,7 +1008,7 @@ async fn test_sensitive(#[case] input: &str, #[case] expected: &str) {
 #[case::stop_high("abc".into(), 1, Some(5), "bc".into())]
 #[case::utf8_string("nägemist".into(), 1, Some(3), "äg".into())]
 #[case::utf8_bytes_partial_char(b"n\xc3\xa4gemist".into(), 1, Some(2), b"\xc3".into())]
-#[case::utf8_bytes_full_char(b"n\xc3\xa4gemist".into(), 1, Some(3), "ä".into())]
+#[case::utf8_bytes_full_char(b"n\xc3\xa4gemist".into(), 1, Some(3), b"\xc3\xa4".into())]
 #[tokio::test]
 async fn test_slice(
     #[case] value: Expression,
@@ -1029,16 +1016,10 @@ async fn test_slice(
     #[case] stop: Option<i64>,
     #[case] expected: Value,
 ) {
-    let template = Template::function_call(
-        "slice",
-        [start.into(), stop.into(), value],
-        [],
-    );
     assert_eq!(
-        template
-            .render_chunks(&TemplateContext::factory(()))
+        Expression::call("slice", [start.into(), stop.into(), value], [],)
+            .render::<_, Value>(&TemplateContext::factory(()))
             .await
-            .try_into_value()
             .unwrap(),
         expected,
     );
@@ -1063,16 +1044,14 @@ async fn test_split(
     #[case] n: Option<i64>,
     #[case] expected: Result<Vec<&str>, &str>,
 ) {
-    let template = Template::function_call(
-        "split",
-        [separator.into(), value.into()],
-        [("n", n.map(Expression::from))],
-    );
     assert_result(
-        template
-            .render_chunks(&TemplateContext::factory(()))
-            .await
-            .try_into_value(),
+        Expression::call(
+            "split",
+            [separator.into(), value.into()],
+            [("n", n.map(Expression::from))],
+        )
+        .render::<_, Value>(&TemplateContext::factory(()))
+        .await,
         expected.map(Value::from),
     );
 }

--- a/crates/core/src/util/json.rs
+++ b/crates/core/src/util/json.rs
@@ -66,7 +66,7 @@ impl TryFrom<serde_json::Value> for ValueTemplate {
                 ValueTemplate::from_raw_json(primitive)
             }
             // These values could all potentially be dynamic
-            serde_json::Value::String(s) => Self::String(s.parse()?),
+            serde_json::Value::String(s) => s.parse()?,
             serde_json::Value::Array(values) => Self::Array(
                 values
                     .into_iter()
@@ -105,7 +105,7 @@ impl TryFrom<serde_yaml::Value> for ValueTemplate {
                     unreachable!("serde_yaml doesn't support >64-bit numbers");
                 }
             }
-            serde_yaml::Value::String(s) => Self::String(s.parse()?),
+            serde_yaml::Value::String(s) => s.parse()?,
             serde_yaml::Value::Sequence(values) => Self::Array(
                 values
                     .into_iter()

--- a/crates/import/src/v3.rs
+++ b/crates/import/src/v3.rs
@@ -241,7 +241,7 @@ impl IntoV4 for v3::JsonTemplate {
                 Ok(v4::ValueTemplate::from_json_number(number))
             }
             Self::String(template) => {
-                template.into_v4(chains).map(v4::ValueTemplate::String)
+                template.into_v4(chains).map(v4::ValueTemplate::from)
             }
             Self::Array(array) => {
                 array.into_v4(chains).map(v4::ValueTemplate::Array)

--- a/crates/template/src/display.rs
+++ b/crates/template/src/display.rs
@@ -80,6 +80,11 @@ impl Template {
 
         buf
     }
+
+    /// Stringify an expression as a single-chunk template
+    pub fn display_expression(expression: &Expression) -> String {
+        format!("{EXPRESSION_OPEN} {expression} {EXPRESSION_CLOSE}")
+    }
 }
 
 impl Display for Expression {

--- a/crates/template/src/error.rs
+++ b/crates/template/src/error.rs
@@ -9,7 +9,6 @@ use std::{
     str::Utf8Error,
 };
 use thiserror::Error;
-use tracing::error;
 use winnow::error::{ContextError, ParseError};
 
 /// An error while parsing a template

--- a/crates/template/src/expression.rs
+++ b/crates/template/src/expression.rs
@@ -43,8 +43,8 @@ pub enum Expression {
 }
 
 impl Expression {
-    /// Render this expression to bytes
-    pub(crate) async fn render<Ctx, V>(&self, context: &Ctx) -> RenderResult<V>
+    /// Render this expression to a value
+    pub async fn render<Ctx, V>(&self, context: &Ctx) -> RenderResult<V>
     where
         Ctx: Context<V>,
         V: RenderValue,

--- a/crates/template/src/lib.rs
+++ b/crates/template/src/lib.rs
@@ -19,12 +19,12 @@ pub use error::{
 };
 pub use expression::{Expression, FunctionCall, Identifier, Literal};
 pub use value::{
-    Arguments, FunctionOutput, StreamSource, TryFromValue, Value, ValueStream,
+    Arguments, FunctionOutput, RenderValue, StreamSource, TryFromValue, Value,
+    ValueStream,
 };
 
-use crate::value::RenderValue;
-use bytes::{Bytes, BytesMut};
-use futures::{Stream, StreamExt, TryStreamExt, future, stream};
+use bytes::Bytes;
+use futures::{Stream, StreamExt, future, stream};
 use itertools::Itertools;
 #[cfg(test)]
 use proptest::{arbitrary::any, strategy::Strategy};
@@ -113,6 +113,11 @@ impl Template {
             Please report it. {NEW_ISSUE_LINK}"
         );
         Self { chunks }
+    }
+
+    /// Get the contained template chunks
+    pub fn into_chunks(self) -> Vec<TemplateChunk> {
+        self.chunks
     }
 
     /// Create a new template from a raw string, without parsing it at all.
@@ -338,47 +343,10 @@ impl<V: RenderValue> RenderedChunks<V> {
     pub fn iter(&self) -> impl Iterator<Item = &RenderedChunk<V>> {
         self.0.iter()
     }
-
-    /// Unpack this output into a single value
-    ///
-    /// If the output is a single dynamic chunk, unpack it into a scalar value.
-    /// Otherwise, return `Err(self)`.
-    pub fn unpack(self) -> Result<V, Self> {
-        match <[_; 1]>::try_from(self.0) {
-            // If we have a single dynamic chunk, return its value directly
-            Ok([RenderedChunk::Dynamic(value)]) => Ok(value),
-            // Unpack failed
-            Ok(chunks @ [RenderedChunk::Raw(_) | RenderedChunk::Error(_)]) => {
-                Err(Self(chunks.into()))
-            }
-            Err(chunks) => Err(Self(chunks)),
-        }
-    }
 }
 
 // Non-stream functions
 impl RenderedChunks<Value> {
-    /// Collect the rendered chunks into a [Value] by these rules:
-    /// - If the template is a single dynamic chunk, return the output of that
-    ///   chunk, which may be any type of [Value]
-    /// - Any other template will be rendered to a string by stringifying each
-    ///   dynamic chunk and concatenating them all together
-    /// - If rendering to a string fails because the bytes are not valid UTF-8,
-    ///   concatenate into a bytes object instead
-    pub fn try_into_value(self) -> Result<Value, RenderError> {
-        // If we only have one chunk, unpack it into a value
-        let value = match self.unpack() {
-            Ok(value) => value,
-            Err(chunks) => {
-                // Render to bytes
-                let bytes = chunks.try_into_bytes()?;
-                Value::Bytes(bytes)
-            }
-        };
-
-        Ok(value.decode_bytes())
-    }
-
     /// Collect the rendered chunks into a byte string
     ///
     /// If any chunk is an error, return an error.
@@ -408,45 +376,6 @@ impl RenderedChunks<ValueStream> {
         } else {
             None
         }
-    }
-
-    /// Does this output contain *any* stream chunks?
-    pub fn has_stream(&self) -> bool {
-        self.0.iter().any(|chunk| match chunk {
-            RenderedChunk::Raw(_)
-            | RenderedChunk::Dynamic(ValueStream::Value(_))
-            | RenderedChunk::Error(_) => false,
-            RenderedChunk::Dynamic(ValueStream::Stream { .. }) => true,
-        })
-    }
-
-    /// Collect the rendered chunks into a [Value] by these rules:
-    /// - If the template is a single dynamic chunk, return the output of that
-    ///   chunk, which may be any type of [Value]
-    /// - If there are any streams, resolve them to bytes
-    /// - Any other template will be rendered to a string by stringifying each
-    ///   dynamic chunk and concatenating them all together
-    /// - If rendering to a string fails because the bytes are not valid UTF-8,
-    ///   concatenate into a bytes object instead
-    pub async fn try_collect_value(self) -> Result<Value, RenderError> {
-        // If we only have one chunk, unpack it into a value
-        let value = match self.unpack() {
-            Ok(ValueStream::Value(value)) => value,
-            Ok(stream @ ValueStream::Stream { .. }) => stream.resolve().await?,
-            Err(chunks) => {
-                // Render to bytes
-                let bytes = chunks
-                    .try_into_stream()?
-                    .try_collect::<BytesMut>()
-                    .await?
-                    .into();
-                Value::Bytes(bytes)
-            }
-        };
-
-        // Try to convert bytes to string, because that's generally more
-        // useful to the consumer
-        Ok(value.decode_bytes())
     }
 
     /// Convert this output into a byte stream. Each chunk will be yielded as a
@@ -483,24 +412,6 @@ impl RenderedChunks<ValueStream> {
 
         // If none of the chunks failed, we can chain all the streams together
         Ok(stream::iter(chunks).flatten())
-    }
-}
-
-/// Create render output of a single chunk with a value
-impl<V: From<Value>> From<Value> for RenderedChunks<V> {
-    fn from(value: Value) -> Self {
-        Self(vec![RenderedChunk::Dynamic(value.into())])
-    }
-}
-
-/// Create render output of a single chunk that may have failed
-impl<V: From<Value>> From<Result<Value, RenderError>> for RenderedChunks<V> {
-    fn from(result: Result<Value, RenderError>) -> Self {
-        let chunk = match result {
-            Ok(value) => RenderedChunk::Dynamic(value.into()),
-            Err(error) => RenderedChunk::Error(error),
-        };
-        Self(vec![chunk])
     }
 }
 

--- a/crates/template/src/tests.rs
+++ b/crates/template/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Arguments, Context, Identifier, RenderError, Template, Value, ValueStream,
-    value::StreamSource,
+    Arguments, Context, Identifier, RenderError, RenderedChunk, Template,
+    Value, ValueStream, value::StreamSource,
 };
 use bytes::{Bytes, BytesMut};
 use futures::{StreamExt, TryFutureExt, TryStreamExt};
@@ -29,39 +29,8 @@ use tokio_util::io::ReaderStream;
 #[tokio::test]
 async fn test_expression(#[case] template: Template, #[case] expected: Value) {
     assert_eq!(
-        template
-            .render_chunks(&TestContext)
-            .await
-            .try_into_value()
-            .unwrap(),
-        expected
-    );
-}
-
-/// Render to a value. Templates with a single dynamic chunk are allowed to
-/// produce non-string values. This is specifically testing the behavior
-/// of [Template::render_value], rather than expression evaluation.
-#[rstest]
-#[case::unpack("{{ array }}", vec!["a", "b", "c"].into())]
-#[case::string("my name is {{ name }}", "my name is Mike".into())]
-#[case::bytes(
-    "my name is {{ invalid_utf8 }}",
-    Value::Bytes(b"my name is \xc3\x28".as_slice().into(),
-))]
-// Stream gets resolved to bytes, then converted to a string
-#[case::stream("{{ file('data.json') }}", "{ \"a\": 1, \"b\": 2 }".into())]
-#[tokio::test]
-async fn test_render_value(
-    #[case] template: Template,
-    #[case] expected: Value,
-) {
-    assert_eq!(
-        template
-            .render_chunks(&TestContext)
-            .await
-            .try_into_value()
-            .unwrap(),
-        expected
+        template.render_chunks(&TestContext).await.into_chunks(),
+        vec![RenderedChunk::Dynamic(expected)]
     );
 }
 

--- a/crates/template/src/value.rs
+++ b/crates/template/src/value.rs
@@ -247,10 +247,6 @@ pub enum StreamSource {
 }
 
 /// An abstraction for cases that support both [Value] and [ValueStream]
-///
-/// External-facing functions distinguish explicitly between the two value
-/// types, but within the template crate this trait allows depulication of
-/// evaluation/rendering code.
 pub trait RenderValue: Sized {
     /// Convert from a [Value] infallibly
     fn from_value(value: Value) -> Self;

--- a/crates/tui/src/view/util/preview.rs
+++ b/crates/tui/src/view/util/preview.rs
@@ -14,7 +14,8 @@ use slumber_core::{
     util::json::{JsonTemplateError, YamlTemplateError},
 };
 use slumber_template::{
-    RenderedChunk, RenderedChunks, Template, Value, ValueStream,
+    Expression, RenderError, RenderedChunk, RenderedChunks, Template, Value,
+    ValueStream,
 };
 use std::{
     borrow::Cow,
@@ -269,15 +270,17 @@ impl PreviewValue {
         template: &ValueTemplate,
         context: &TemplateContext,
     ) -> Self {
-        Self::render_inner(template, context, async |template, context| {
-            let chunks = template.render_chunks(context).await;
-            match chunks.unpack() {
-                Ok(value) => PreviewValue::Dynamic(value.decode_bytes()),
-                Err(chunks) => PreviewValue::Raw(RawValue::String(
-                    PreviewChunks(chunks.into_chunks()),
-                )),
-            }
-        })
+        Self::render_inner(
+            template,
+            context,
+            Expression::render::<_, Value>,
+            async |template, context| {
+                let chunks = template.render_chunks(context).await;
+                PreviewValue::Raw(RawValue::String(PreviewChunks(
+                    chunks.into_chunks(),
+                )))
+            },
+        )
         .await
     }
 
@@ -288,33 +291,34 @@ impl PreviewValue {
         template: &ValueTemplate,
         context: &TemplateContext,
     ) -> Self {
-        Self::render_inner(template, context, async |template, context| {
-            let chunks = template.render_chunks_stream(context).await;
-            match chunks.unpack() {
-                Ok(stream) => {
-                    PreviewValue::Dynamic(Self::stream_to_value(stream))
-                }
+        Self::render_inner(
+            template,
+            context,
+            async |expression, context| {
+                // Stringify streams
+                expression.render(context).await.map(Self::stream_to_value)
+            },
+            async |template, context| {
+                let chunks = template.render_chunks_stream(context).await;
                 // Map the chunks from stream values to concrete values by
                 // stringifying the streams
-                Err(chunks) => {
-                    let chunks = chunks
-                        .into_iter()
-                        .map(|chunk| match chunk {
-                            RenderedChunk::Raw(s) => RenderedChunk::Raw(s),
-                            RenderedChunk::Dynamic(stream) => {
-                                RenderedChunk::Dynamic(Self::stream_to_value(
-                                    stream,
-                                ))
-                            }
-                            RenderedChunk::Error(error) => {
-                                RenderedChunk::Error(error)
-                            }
-                        })
-                        .collect();
-                    PreviewValue::Raw(RawValue::String(PreviewChunks(chunks)))
-                }
-            }
-        })
+                let chunks = chunks
+                    .into_iter()
+                    .map(|chunk| match chunk {
+                        RenderedChunk::Raw(s) => RenderedChunk::Raw(s),
+                        RenderedChunk::Dynamic(stream) => {
+                            RenderedChunk::Dynamic(Self::stream_to_value(
+                                stream,
+                            ))
+                        }
+                        RenderedChunk::Error(error) => {
+                            RenderedChunk::Error(error)
+                        }
+                    })
+                    .collect();
+                PreviewValue::Raw(RawValue::String(PreviewChunks(chunks)))
+            },
+        )
         .await
     }
 
@@ -322,6 +326,10 @@ impl PreviewValue {
     async fn render_inner(
         template: &ValueTemplate,
         context: &TemplateContext,
+        render_expression: impl AsyncFn(
+            &Expression,
+            &TemplateContext,
+        ) -> Result<Value, RenderError>,
         render_string: impl AsyncFn(&Template, &TemplateContext) -> Self,
     ) -> Self {
         match template {
@@ -333,6 +341,30 @@ impl PreviewValue {
                 PreviewValue::Raw(RawValue::Integer(*i))
             }
             ValueTemplate::Float(f) => PreviewValue::Raw(RawValue::Float(*f)),
+            ValueTemplate::Expression(expression) => {
+                let result = render_expression(expression, context).await;
+                match result {
+                    // Byte strings can't be encoded in JSON or YAML, so replace
+                    // non-UTF-8 bytes with a placeholder. But first, try to
+                    // decode it as a string.
+                    //
+                    // During body construction, JSON will actually encode
+                    // bytes as an int array so this becomes a mismatch, but
+                    // either way it's probably not what the user wants so it's
+                    // not a huge deal. It's easier to handle all formats here.
+                    Ok(value) => match value.decode_bytes() {
+                        Value::Bytes(_) => Self::Dynamic("<binary>".into()),
+                        value => Self::Dynamic(value),
+                    },
+                    // There's no top-level error value, we have to pretend
+                    // this was a chunk in a template
+                    Err(error) => {
+                        Self::Raw(RawValue::String(PreviewChunks(vec![
+                            RenderedChunk::Error(error),
+                        ])))
+                    }
+                }
+            }
             ValueTemplate::String(template) => {
                 render_string(template, context).await
             }
@@ -373,9 +405,9 @@ impl Serialize for PreviewValue {
         S: serde::Serializer,
     {
         match self {
-            PreviewValue::Raw(raw_value) => raw_value.serialize(serializer),
+            Self::Raw(raw_value) => raw_value.serialize(serializer),
             // Tag the entire value as dynamic
-            PreviewValue::Dynamic(value) => StyleInjector::with_tag(
+            Self::Dynamic(value) => StyleInjector::with_tag(
                 || value.serialize(serializer),
                 ChunkTag::Dynamic,
             ),
@@ -518,10 +550,10 @@ mod tests {
         "intro\n{{simple}}\n{{emoji}} 💚💙💜 {{unknown}}\n\noutro\r\nmore outro\n",
         vec![
             Line::from("intro"),
-            Line::from(rendered("ww")),
-            Line::from(rendered("🧡")),
+            Line::from(dynamic("ww")),
+            Line::from(dynamic("🧡")),
             Line::from(vec![
-                rendered("💛"),
+                dynamic("💛"),
                 Span::raw(" 💚💙💜 "),
                 error("Error"),
             ]),
@@ -533,7 +565,7 @@ mod tests {
     )]
     #[case::binary(
         r"binary data: {{ b'\xc3\x28' }}",
-        vec![Line::from(vec![Span::raw("binary data: "), rendered("<binary>")])]
+        vec![Line::from(vec![Span::raw("binary data: "), dynamic("<binary>")])]
     )]
     #[tokio::test]
     async fn test_preview_template(
@@ -560,7 +592,7 @@ mod tests {
     /// - Dynamic chunks
     #[rstest]
     #[case::plain("hello", vec!["hello".into()])]
-    #[case::dynamic("hello {{ name }}", vec!["hello ".into(), rendered("bob")])]
+    #[case::dynamic("hello {{ name }}", vec!["hello ".into(), dynamic("bob")])]
     #[tokio::test]
     async fn test_preview_raw(
         _harness: TestHarness,
@@ -588,10 +620,10 @@ mod tests {
     #[rstest]
     #[case::direct(
         "data: {{ command(['echo', 'test']) }}",
-        vec!["data: ".into(), rendered("<command `echo test`>")])]
+        vec!["data: ".into(), dynamic("<command `echo test`>")])]
     #[case::profile(
         "data: {{ stream }}",
-        vec!["data: ".into(), rendered("<command `echo test`>")],
+        vec!["data: ".into(), dynamic("<command `echo test`>")],
     )]
     #[tokio::test]
     async fn test_preview_stream(
@@ -656,18 +688,19 @@ mod tests {
     #[case::string_escaped(
         json!("i have a \" quote"), r#""i have a \" quote""#.into()
     )]
+    #[case::bytes(json!("{{ invalid_utf8 }}"), dynamic("\"<binary>\"").into())]
     #[case::template(
         json!("my name is {{ 'Ted' }}!"),
         // Just the dynamic part is styled colorly like
-        line(vec!["\"my name is ".into(), rendered("Ted"), "!\"".into()]),
+        line(vec!["\"my name is ".into(), dynamic("Ted"), "!\"".into()]),
     )]
-    #[case::template_unpacked(json!("{{ 3 }}"), rendered("3").into())]
+    #[case::template_unpacked(json!("{{ 3 }}"), dynamic("3").into())]
     #[case::template_escaped(
         // Entire dynamic chunk gets styling. Make sure the escaped quote
         // doesn't cause any off-by-ones
         json!("dynamic: {{ 'with \" quote' }}"),
         line(vec![
-            "\"dynamic: ".into(), rendered(r#"with \" quote"#), quote(),
+            "\"dynamic: ".into(), dynamic(r#"with \" quote"#), quote(),
         ]),
     )]
     #[case::error(
@@ -683,7 +716,7 @@ mod tests {
         vec![
             "[".into(),
             vec![
-                r#"  "dynamic "#.into(), rendered("string"), "\",".into(),
+                r#"  "dynamic "#.into(), dynamic("string"), "\",".into(),
             ].into(),
             vec![r#"  "error "#.into(), error("Error"), "\",".into()].into(),
             "  null".into(),
@@ -716,7 +749,7 @@ mod tests {
             r#"    },"#.into(),
             vec![
                 r#"    "d": "dynamic "#.into(),
-                rendered("string"),
+                dynamic("string"),
                 "\",".into(),
             ].into(),
             vec![
@@ -731,23 +764,23 @@ mod tests {
     // JSON bodies don't support streaming, so these are eaglery evaluated
     #[case::stream(
         json!("stream: {{ command(['echo', '-n', 'test']) }}"),
-        line(vec!["\"stream: ".into(), rendered("test"), quote()]),
+        line(vec!["\"stream: ".into(), dynamic("test"), quote()]),
     )]
     // Stream does not get unpacked as an array of bytes, it's converted to a
     // string
     #[case::stream_unpacked(
         json!("{{ command(['echo', '-n', 'test']) }}"),
-        rendered(r#""test""#).into()
+        dynamic(r#""test""#).into()
     )]
     #[case::nested_dynamic(
         json!({ "double_dynamic": "{{ object }}" }),
         // The entire value is styled as dynamic
         vec![
             "{".into(),
-            vec![r#"  "double_dynamic": "#.into(), rendered("{")].into(),
-            rendered(r#"    "a": 1,"#).into(),
-            rendered(r#"    "b": 2"#).into(),
-            rendered("  }").into(),
+            vec![r#"  "double_dynamic": "#.into(), dynamic("{")].into(),
+            dynamic(r#"    "a": 1,"#).into(),
+            dynamic(r#"    "b": 2"#).into(),
+            dynamic("  }").into(),
             "}".into(),
         ].into()
     )]
@@ -762,6 +795,7 @@ mod tests {
 
         let profile = Profile {
             data: indexmap! {
+                "invalid_utf8".into() => "{{ b'\\xc3\\x28' }}".into(),
                 "object".into() => vec![("a", 1), ("b", 2)].into(),
             },
             ..Profile::factory(())
@@ -808,19 +842,22 @@ mod tests {
         // We have to do some funky stuff to get the serializer to escape quotes
         json!("{i have \"' quotes}"), "'{i have \"'' quotes}'".into()
     )]
+    // Unlike JSON, YAML won't serialize bytes so we have to replace them with
+    // a placeholder
+    #[case::bytes(json!("{{ invalid_utf8 }}"), dynamic("<binary>").into())]
     #[case::template(
         json!("my name is {{ 'Ted' }}!"),
         // Just the dynamic part is styled colorly like
-        line(vec!["my name is ".into(), rendered("Ted"), "!".into()]),
+        line(vec!["my name is ".into(), dynamic("Ted"), "!".into()]),
     )]
-    #[case::template_unpacked(json!("{{ 3 }}"), rendered("3").into())]
+    #[case::template_unpacked(json!("{{ 3 }}"), dynamic("3").into())]
     #[case::template_escaped(
         // Entire dynamic chunk gets styling. Make sure the escaped quote
         // doesn't cause any off-by-ones.
         // The {} wrapper forces the YAML serializer to use quotes
         json!("{dynamic: {{ 'with \\' quote' }}}"),
         line(vec![
-            "'{dynamic: ".into(), rendered("with '' quote"), "}'".into(),
+            "'{dynamic: ".into(), dynamic("with '' quote"), "}'".into(),
         ]),
     )]
     #[case::error(json!("{{ w }}"), error("Error").into())]
@@ -831,7 +868,7 @@ mod tests {
     #[case::array(
         json!(["dynamic {{ 'string' }}", "error {{ w }}", null]),
         vec![
-            vec!["- dynamic ".into(), rendered("string")].into(),
+            vec!["- dynamic ".into(), dynamic("string")].into(),
             vec!["- error ".into(), error("Error")].into(),
             "- null".into(),
         ].into(),
@@ -855,19 +892,19 @@ mod tests {
             "    - 3".into(),
             "    - 4".into(),
             "    - 5".into(),
-            vec!["  d: dynamic ".into(), rendered("string")].into(),
+            vec!["  d: dynamic ".into(), dynamic("string")].into(),
             vec!["  e: error ".into(), error("Error")].into(),
         ].into(),
     )]
     #[case::stream(
         json!("stream: {{ command(['echo', 'test']) }}"),
         line(vec![
-            "'stream: ".into(), rendered("<command `echo test`>"), "'".into(),
+            "'stream: ".into(), dynamic("<command `echo test`>"), "'".into(),
         ]),
     )]
     #[case::stream_unpacked(
         json!("{{ command(['echo', 'test']) }}"),
-        rendered("<command `echo test`>").into()
+        dynamic("<command `echo test`>").into()
     )]
     // This is broken because the YAML serializer seems to buffer its output
     // before passing it to the writer. This means the thread-local styling
@@ -879,8 +916,8 @@ mod tests {
         // The entire value is styled as dynamic
         vec![
             "double_dynamic:".into(),
-            rendered("  a: 1").into(),
-            rendered("  b: 2").into(),
+            dynamic("  a: 1").into(),
+            dynamic("  b: 2").into(),
         ].into()
     )]
     #[tokio::test]
@@ -896,6 +933,7 @@ mod tests {
 
         let profile = Profile {
             data: indexmap! {
+                "invalid_utf8".into() => "{{ b'\\xc3\\x28' }}".into(),
                 "object".into() => vec![("a", 1), ("b", 2)].into(),
             },
             ..Profile::factory(())
@@ -910,8 +948,8 @@ mod tests {
         "\"".into()
     }
 
-    /// Style some text as rendered
-    fn rendered(text: &str) -> Span<'_> {
+    /// Style some text as dynamic
+    fn dynamic(text: &str) -> Span<'_> {
         Span::styled(text, ViewContext::styles().template_preview.dynamic)
     }
 

--- a/schemas/collection.json
+++ b/schemas/collection.json
@@ -148,6 +148,11 @@
           "format": "double"
         },
         {
+          "description": "An unpacked single-chunk template",
+          "type": "string"
+        },
+        {
+          "description": "A template that has not been unpacked\n\nThis is either a single raw chunk or a multi-chunk template",
           "$ref": "#/$defs/Template"
         },
         {


### PR DESCRIPTION
## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

It now parses an unpackable template into a separate `ValueTemplate::Expression` variant at parse time. By the time we're rendering a template, it's statically known if the value will be unpacked or not. It's functionally the same as unpacking at render time, but this will make it easier to switch to explicit unpack syntax.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

I changed a lot of tests, and some of the tested code paths seem a bit fragile. I think the test coverage is sufficient to make sure I didn't add any bugs, but I'm not 100% sure. If something is broken, it will most likely be in the preview code.

## QA

_How did you test this?_

Existing unit tests, and added some new ones.

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
