### PR TITLE
Make prompt methods async

### DIFF
--- a/crates/cli/src/commands/request.rs
+++ b/crates/cli/src/commands/request.rs
@@ -20,10 +20,10 @@ use slumber_core::{
         RequestBody, RequestRecord, RequestSeed, ResponseRecord,
         StoredRequestError, TriggeredRequestError,
     },
-    render::{HttpProvider, Prompt, Prompter, SelectOption, TemplateContext},
+    render::{HttpProvider, Prompter, SelectOption, TemplateContext},
     util::MaybeStr,
 };
-use slumber_template::{Expression, Template};
+use slumber_template::{Expression, Template, Value};
 use slumber_util::{OptionExt, ResultTracedAnyhow};
 use std::{
     error::Error,
@@ -518,13 +518,15 @@ impl HttpProvider for CliHttpProvider {
 #[derive(Debug)]
 struct CliPrompter;
 
-impl CliPrompter {
-    /// Ask the user for text input
-    fn text(
+#[async_trait(?Send)]
+
+impl Prompter for CliPrompter {
+    async fn prompt_text(
+        &self,
         message: String,
         default: Option<String>,
         sensitive: bool,
-    ) -> anyhow::Result<String> {
+    ) -> Option<String> {
         // This will implicitly queue the prompts by blocking the main thread.
         // Since the CLI has nothing else to do while waiting on a response,
         // that's fine.
@@ -551,13 +553,14 @@ impl CliPrompter {
         // If we failed to read the value, print an error and report nothing
         .context("Error reading value from prompt")
         .traced()
+        .ok()
     }
 
-    /// Ask the user to select a value from a list. Return the selected value.
-    fn select(
+    async fn prompt_select(
+        &self,
         message: String,
         mut options: Vec<SelectOption>,
-    ) -> anyhow::Result<slumber_template::Value> {
+    ) -> Option<Value> {
         let index = DialoguerSelect::new()
             .with_prompt(message)
             .items(&options)
@@ -565,34 +568,9 @@ impl CliPrompter {
             .interact()
             // If we failed to read the value, print an error and report nothing
             .context("Error reading value from select")
-            .traced()?;
-        Ok(options.swap_remove(index).value)
-    }
-}
-
-impl Prompter for CliPrompter {
-    fn prompt(&self, prompt: Prompt) {
-        match prompt {
-            Prompt::Text {
-                message,
-                default,
-                sensitive,
-                channel,
-            } => {
-                if let Ok(response) = Self::text(message, default, sensitive) {
-                    channel.reply(response);
-                }
-            }
-            Prompt::Select {
-                message,
-                options,
-                channel,
-            } => {
-                if let Ok(response) = Self::select(message, options) {
-                    channel.reply(response);
-                }
-            }
-        }
+            .traced()
+            .ok()?;
+        Some(options.swap_remove(index).value)
     }
 }
 

--- a/crates/core/src/render.rs
+++ b/crates/core/src/render.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use chrono::Utc;
-use derive_more::{From, derive::Display};
+use derive_more::derive::Display;
 use futures::{StreamExt, TryFutureExt};
 use indexmap::IndexMap;
 use itertools::Itertools;
@@ -37,7 +37,6 @@ use std::{
     fmt::Debug, io, iter, path::PathBuf, process::ExitStatus, sync::Arc,
 };
 use thiserror::Error;
-use tokio::sync::oneshot;
 use tracing::error;
 
 /// A little container struct for all the data that the user can access via
@@ -441,39 +440,28 @@ pub trait HttpProvider: Debug {
 /// multiple templates with prompts are being rendered simultaneously. The
 /// implementor is responsible for queueing prompts to show to the user one at a
 /// time.
+#[async_trait(?Send)]
 pub trait Prompter: Debug {
-    /// Ask the user a question, and use the given channel to return a response.
-    /// To indicate "no response", simply drop the returner.
+    /// Ask the user a textual question and wait for a response.
     ///
-    /// If an error occurs while prompting the user, just drop the returner.
-    /// The implementor is responsible for logging the error as appropriate.
-    fn prompt(&self, prompt: Prompt);
-}
-
-/// Data defining a prompt which should be presented to the user
-#[derive(Debug)]
-pub enum Prompt {
-    /// Ask the user for text input
-    Text {
-        /// Tell the user what we're asking for
+    /// Return `None` if there is no response, e.g. if the user closes the
+    /// prompt without responding.
+    async fn prompt_text(
+        &self,
         message: String,
-        /// Value used to pre-populate the text box
         default: Option<String>,
-        /// Should the value the user is typing be masked? E.g. password input
         sensitive: bool,
-        /// How the prompter will pass the answer back
-        channel: ReplyChannel<String>,
-    },
-    /// Ask the user to pick a value from a list
-    Select {
-        /// Tell the user what we're asking for
+    ) -> Option<String>;
+
+    /// Ask the user a multiple-choice question and wait for a response.
+    ///
+    /// Return `None` if there is no response, e.g. if the user closes the
+    /// prompt without responding.
+    async fn prompt_select(
+        &self,
         message: String,
-        /// List of choices the user can pick from. This will never be empty.
         options: Vec<SelectOption>,
-        /// How the prompter will pass the answer back. The returned value is
-        /// the `value` field from the selected [SelectOption]
-        channel: ReplyChannel<Value>,
-    },
+    ) -> Option<Value>;
 }
 
 /// An entry in a `select()` list
@@ -485,22 +473,6 @@ pub struct SelectOption {
     /// Underlying value to return if this option is selected. This will be the
     /// same as the label if the input was a single string.
     pub value: Value,
-}
-
-/// Channel used to return a reply to a one-time request. This is its own type
-/// so we can provide wrapping functionality
-#[derive(Debug, From)]
-pub struct ReplyChannel<T>(oneshot::Sender<T>);
-
-impl<T> ReplyChannel<T> {
-    /// Return the value that the user gave
-    pub fn reply(self, reply: T) {
-        // This error *shouldn't* ever happen, because the templating task
-        // stays open until it gets a reply
-        if self.0.send(reply).is_err() {
-            error!("Reply listener dropped");
-        }
-    }
 }
 
 /// An error that can occur within a template function

--- a/crates/core/src/render/functions.rs
+++ b/crates/core/src/render/functions.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     collection::RecipeId,
-    render::{FunctionError, Prompt, SelectOption, TemplateContext},
+    render::{FunctionError, SelectOption, TemplateContext},
 };
 use base64::{Engine, prelude::BASE64_STANDARD};
 use bytes::Bytes;
@@ -24,7 +24,6 @@ use tokio::{
     fs::File,
     io::{AsyncRead, AsyncWriteExt},
     process::Command,
-    sync::oneshot,
 };
 use tokio_util::io::ReaderStream;
 use tracing::{Instrument, debug, debug_span};
@@ -872,14 +871,11 @@ pub async fn prompt(
     #[kwarg] default: Option<String>,
     #[kwarg] sensitive: bool,
 ) -> Result<String, FunctionError> {
-    let (tx, rx) = oneshot::channel();
-    context.prompter.prompt(Prompt::Text {
-        message: message.unwrap_or_default(),
-        default,
-        sensitive,
-        channel: tx.into(),
-    });
-    let chunks = rx.await.map_err(|_| FunctionError::PromptNoReply)?;
+    let reply = context
+        .prompter
+        .prompt_text(message.unwrap_or_default(), default, sensitive)
+        .await
+        .ok_or(FunctionError::PromptNoReply)?;
 
     // If the input was sensitive, we should mask the output as well. This only
     // impacts previews as show_sensitive is enabled for request renders. This
@@ -888,9 +884,9 @@ pub async fn prompt(
     // "<prompt>", we show "••••••••". It's "technically" right and plays well
     // in tests. Also it reminds users that a prompt is sensitive in the TUI
     if sensitive {
-        Ok(mask_sensitive(context, chunks))
+        Ok(mask_sensitive(context, reply))
     } else {
-        Ok(chunks)
+        Ok(reply)
     }
 }
 
@@ -1063,13 +1059,11 @@ pub async fn select(
         return Err(FunctionError::SelectNoOptions);
     }
 
-    let (tx, rx) = oneshot::channel();
-    context.prompter.prompt(Prompt::Select {
-        message: message.unwrap_or_default(),
-        options,
-        channel: tx.into(),
-    });
-    rx.await.map_err(|_| FunctionError::PromptNoReply)
+    context
+        .prompter
+        .prompt_select(message.unwrap_or_default(), options)
+        .await
+        .ok_or(FunctionError::PromptNoReply)
 }
 
 /// A select option can be given as an object of `{value, label}` or a single

--- a/crates/core/src/test_util.rs
+++ b/crates/core/src/test_util.rs
@@ -7,14 +7,14 @@ use crate::{
         Exchange, HttpEngine, RequestSeed, StoredRequestError,
         TriggeredRequestError,
     },
-    render::{HttpProvider, Prompt, Prompter, TemplateContext},
+    render::{HttpProvider, Prompter, SelectOption, TemplateContext},
 };
 use async_trait::async_trait;
 use indexmap::IndexMap;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use rstest::fixture;
 use slumber_config::HttpEngineConfig;
-use slumber_template::Template;
+use slumber_template::{Template, Value};
 use std::{
     hash::Hash,
     sync::atomic::{AtomicUsize, Ordering},
@@ -104,25 +104,27 @@ impl TestPrompter {
     }
 }
 
+#[async_trait(?Send)]
 impl Prompter for TestPrompter {
-    fn prompt(&self, prompt: Prompt) {
-        match prompt {
-            Prompt::Text {
-                default, channel, ..
-            } => {
-                // Grab the next value in the sequence. If we're all out, don't
-                // respond
-                let index = self.index.fetch_add(1, Ordering::Relaxed);
-                if let Some(value) = self.responses.get(index) {
-                    channel.reply(value.clone());
-                } else if let Some(default) = default {
-                    channel.reply(default);
-                }
-            }
-            Prompt::Select { .. } => {
-                unimplemented!("TestPrompter does not support selects")
-            }
-        }
+    async fn prompt_text(
+        &self,
+        _message: String,
+        default: Option<String>,
+        _sensitive: bool,
+    ) -> Option<String> {
+        // Grab the next value in the sequence. If we're all out, don't
+        // respond
+        let index = self.index.fetch_add(1, Ordering::Relaxed);
+
+        self.responses.get(index).cloned().or(default)
+    }
+
+    async fn prompt_select(
+        &self,
+        _message: String,
+        _options: Vec<SelectOption>,
+    ) -> Option<Value> {
+        unimplemented!("TestPrompter does not support selects")
     }
 }
 
@@ -144,23 +146,27 @@ impl TestSelectPrompter {
     }
 }
 
+#[async_trait(?Send)]
+
 impl Prompter for TestSelectPrompter {
-    fn prompt(&self, prompt: Prompt) {
-        match prompt {
-            Prompt::Text { .. } => unimplemented!(
-                "TestSelectPrompter does not support text prompts"
-            ),
-            Prompt::Select {
-                mut options,
-                channel,
-                ..
-            } => {
-                let index = self.index.fetch_add(1, Ordering::Relaxed);
-                if let Some(value_index) = self.responses.get(index) {
-                    channel.reply(options.swap_remove(*value_index).value);
-                }
-            }
-        }
+    async fn prompt_text(
+        &self,
+        _message: String,
+        _default: Option<String>,
+        _sensitive: bool,
+    ) -> Option<String> {
+        unimplemented!("TestSelectPrompter does not support text prompts")
+    }
+
+    async fn prompt_select(
+        &self,
+        _message: String,
+        mut options: Vec<SelectOption>,
+    ) -> Option<Value> {
+        let index = self.index.fetch_add(1, Ordering::Relaxed);
+        self.responses
+            .get(index)
+            .map(|value_index| options.swap_remove(*value_index).value)
     }
 }
 

--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -14,9 +14,9 @@ use slumber_core::{
         BuildOptions, Exchange, HttpEngine, RequestRecord, RequestSeed,
         ResponseRecord, StoredRequestError, TriggeredRequestError,
     },
-    render::{HttpProvider, Prompt, Prompter, SelectOption, TemplateContext},
+    render::{HttpProvider, Prompter, SelectOption, TemplateContext},
 };
-use slumber_template::Template;
+use slumber_template::{Template, Value};
 use std::{
     error::Error,
     fmt::{self, Display},
@@ -281,13 +281,15 @@ impl HttpProvider for PythonHttpProvider {
 #[derive(Debug)]
 struct PythonPrompter;
 
-impl PythonPrompter {
-    /// Ask the user for text input
-    fn text(
+#[async_trait(?Send)]
+
+impl Prompter for PythonPrompter {
+    async fn prompt_text(
+        &self,
         message: String,
         default: Option<String>,
         sensitive: bool,
-    ) -> Result<String, dialoguer::Error> {
+    ) -> Option<String> {
         // This will implicitly queue the prompts by blocking the only worker
         // thread. Since the library has nothing to do while waiting on a
         // response, that's fine
@@ -296,53 +298,29 @@ impl PythonPrompter {
                 .with_prompt(message)
                 .allow_empty_password(true)
                 .interact()
+                .ok()
         } else {
             let mut input = Input::new().with_prompt(message).allow_empty(true);
             if let Some(default) = default {
                 input = input.default(default);
             }
-            input.interact()
+            input.interact().ok()
         }
     }
 
-    /// Ask the user to select a value from a list. Return the selected value.
-    fn select(
+    async fn prompt_select(
+        &self,
         message: String,
         mut options: Vec<SelectOption>,
-    ) -> Result<slumber_template::Value, dialoguer::Error> {
+    ) -> Option<Value> {
         let index = DialoguerSelect::new()
             .with_prompt(message)
             .items(&options)
             .default(0)
-            .interact()?;
+            .interact()
+            .ok()?;
 
-        Ok(options.swap_remove(index).value)
-    }
-}
-
-impl Prompter for PythonPrompter {
-    fn prompt(&self, prompt: Prompt) {
-        match prompt {
-            Prompt::Text {
-                message,
-                default,
-                sensitive,
-                channel,
-            } => {
-                if let Ok(response) = Self::text(message, default, sensitive) {
-                    channel.reply(response);
-                }
-            }
-            Prompt::Select {
-                message,
-                options,
-                channel,
-            } => {
-                if let Ok(response) = Self::select(message, options) {
-                    channel.reply(response);
-                }
-            }
-        }
+        Some(options.swap_remove(index).value)
     }
 }
 

--- a/crates/tui/src/message.rs
+++ b/crates/tui/src/message.rs
@@ -4,7 +4,7 @@
 use crate::{
     input::InputEvent,
     util::{ResultReported, TempFile},
-    view::{Event, Question},
+    view::{Event, Prompt, Question, ReplyChannel},
 };
 use anyhow::Context;
 use futures::{FutureExt, future::LocalBoxFuture};
@@ -15,7 +15,7 @@ use slumber_core::{
     http::{
         Exchange, RequestBuildError, RequestError, RequestId, RequestRecord,
     },
-    render::{Prompt, ReplyChannel, TemplateContext},
+    render::TemplateContext,
 };
 use slumber_util::yaml::SourceLocation;
 use std::{

--- a/crates/tui/src/view.rs
+++ b/crates/tui/src/view.rs
@@ -12,7 +12,10 @@ mod util;
 pub use component::ComponentMap;
 pub use context::UpdateContext;
 pub use event::Event;
-pub use util::{InvalidCollection, PreviewPrompter, Question, TuiPrompter};
+pub use util::{
+    InvalidCollection, PreviewPrompter, Prompt, Question, ReplyChannel,
+    TuiPrompter,
+};
 
 use crate::{
     http::{RequestConfig, RequestState, RequestStore},
@@ -30,7 +33,6 @@ use slumber_core::{
     collection::{Collection, ProfileId, RecipeId, ValueTemplate},
     database::CollectionDatabase,
     http::RequestId,
-    render::Prompt,
 };
 use std::{
     fmt::{Debug, Display},

--- a/crates/tui/src/view/component/prompt_form.rs
+++ b/crates/tui/src/view/component/prompt_form.rs
@@ -1,5 +1,5 @@
 use crate::view::{
-    Generate, UpdateContext, ViewContext,
+    Generate, Prompt, ReplyChannel, UpdateContext, ViewContext,
     common::{
         component_select::{
             ComponentSelect, ComponentSelectProps, SelectStyles,
@@ -24,7 +24,7 @@ use slumber_config::Action;
 use slumber_core::{
     collection::{Recipe, RecipeId},
     http::RequestId,
-    render::{Prompt, ReplyChannel, SelectOption},
+    render::SelectOption,
 };
 use slumber_template::Value;
 use std::{borrow::Cow, cmp, mem};

--- a/crates/tui/src/view/util.rs
+++ b/crates/tui/src/view/util.rs
@@ -8,20 +8,24 @@ use crate::{
     util::{ResultReported, TempFile, syntax::SyntaxType},
     view::ViewContext,
 };
+use async_trait::async_trait;
 use chrono::{
     DateTime, Duration, Local, Utc,
     format::{DelayedFormat, StrftimeItems},
 };
+use derive_more::From;
 use itertools::Itertools;
 use mime::Mime;
 use ratatui::text::{Line, Text};
 use slumber_core::{
     collection::{CollectionError, CollectionFile, RecipeId},
     http::RequestId,
-    render::{Prompt, Prompter, ReplyChannel},
+    render::{Prompter, SelectOption},
 };
+use slumber_template::Value;
 use std::{io::Write, sync::Arc};
-use tracing::trace;
+use tokio::sync::oneshot;
+use tracing::{error, trace};
 
 /// Container for the state the view needs to show a collection load error
 #[derive(Debug)]
@@ -82,13 +86,46 @@ impl TuiPrompter {
     }
 }
 
+#[async_trait(?Send)]
 impl Prompter for TuiPrompter {
-    fn prompt(&self, prompt: Prompt) {
+    async fn prompt_text(
+        &self,
+        message: String,
+        default: Option<String>,
+        sensitive: bool,
+    ) -> Option<String> {
+        let (tx, rx) = oneshot::channel();
+        let prompt = Prompt::Text {
+            message,
+            default,
+            sensitive,
+            channel: ReplyChannel(tx),
+        };
         self.messages_tx.send(HttpMessage::Prompt {
             recipe_id: self.recipe_id.clone(),
             request_id: self.request_id,
             prompt,
         });
+        rx.await.ok()
+    }
+
+    async fn prompt_select(
+        &self,
+        message: String,
+        options: Vec<SelectOption>,
+    ) -> Option<Value> {
+        let (tx, rx) = oneshot::channel();
+        let prompt = Prompt::Select {
+            message,
+            options,
+            channel: ReplyChannel(tx),
+        };
+        self.messages_tx.send(HttpMessage::Prompt {
+            recipe_id: self.recipe_id.clone(),
+            request_id: self.request_id,
+            prompt,
+        });
+        rx.await.ok()
     }
 }
 
@@ -97,18 +134,64 @@ impl Prompter for TuiPrompter {
 #[derive(Debug)]
 pub struct PreviewPrompter;
 
+#[async_trait(?Send)]
+
 impl Prompter for PreviewPrompter {
-    fn prompt(&self, prompt: Prompt) {
-        match prompt {
-            Prompt::Text {
-                default, channel, ..
-            } => {
-                let value = default.unwrap_or_else(|| "<prompt>".into());
-                channel.reply(value);
-            }
-            Prompt::Select { channel, .. } => {
-                channel.reply("<select>".into());
-            }
+    async fn prompt_text(
+        &self,
+        _message: String,
+        default: Option<String>,
+        _sensitive: bool,
+    ) -> Option<String> {
+        Some(default.unwrap_or_else(|| "<prompt>".into()))
+    }
+
+    async fn prompt_select(
+        &self,
+        _message: String,
+        _options: Vec<SelectOption>,
+    ) -> Option<Value> {
+        Some("<select>".into())
+    }
+}
+
+/// Data defining a prompt to be presented to the user
+#[derive(Debug)]
+pub enum Prompt {
+    /// Ask the user for text input
+    Text {
+        /// Tell the user what we're asking for
+        message: String,
+        /// Value used to pre-populate the text box
+        default: Option<String>,
+        /// Should the value the user is typing be masked? E.g. password input
+        sensitive: bool,
+        /// How the prompter will pass the answer back
+        channel: ReplyChannel<String>,
+    },
+    /// Ask the user to pick a value from a list
+    Select {
+        /// Tell the user what we're asking for
+        message: String,
+        /// List of choices the user can pick from. This will never be empty.
+        options: Vec<SelectOption>,
+        /// How the prompter will pass the answer back. The returned value is
+        /// the `value` field from the selected [SelectOption]
+        channel: ReplyChannel<Value>,
+    },
+}
+
+/// Channel used to return a reply to a one-time request
+#[derive(Debug, From)]
+pub struct ReplyChannel<T>(oneshot::Sender<T>);
+
+impl<T> ReplyChannel<T> {
+    /// Return the value that the user gave
+    pub fn reply(self, reply: T) {
+        // This error *shouldn't* ever happen, because the templating task
+        // stays open until it gets a reply
+        if self.0.send(reply).is_err() {
+            error!("Reply listener dropped");
         }
     }
 }


### PR DESCRIPTION


## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Instead of a channel, use an async method. It's more direct and easier to follow.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

In the CLI and Python frontends, the implementations block the main thread. This is generally bad in async land, but in this case it's fine because there's nothing else for the thread to do while waiting for the user's response. It was always doing this anyway, it's just more obvious and direct now.

## QA

_How did you test this?_

All the existing tests pass, and I manually tested:
- TUI
- CLI
- Python

Prompts work in all 3.

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
