### PR TITLE
CLI/Python: Run prompts in a blocking thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - Fix crash when previewing a profile value that returns a binary value
+- Prompts in CLI/Python frontend no longer block other request building tasks
 
 ## [5.2.4] - 2026-03-30
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3300,7 +3300,6 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
- "dialoguer",
  "env-lock",
  "indexmap",
  "itertools",
@@ -3314,6 +3313,7 @@ dependencies = [
  "serde_urlencoded",
  "serde_yaml",
  "slumber_config",
+ "slumber_console",
  "slumber_core",
  "slumber_import",
  "slumber_template",
@@ -3347,6 +3347,20 @@ dependencies = [
  "slumber_util",
  "terminput",
  "thiserror 2.0.17",
+ "tracing",
+]
+
+[[package]]
+name = "slumber_console"
+version = "5.2.4"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "dialoguer",
+ "slumber_core",
+ "slumber_template",
+ "slumber_util",
+ "tokio",
  "tracing",
 ]
 
@@ -3444,10 +3458,10 @@ name = "slumber_python"
 version = "5.2.4"
 dependencies = [
  "async-trait",
- "dialoguer",
  "indexmap",
  "pyo3",
  "slumber_config",
+ "slumber_console",
  "slumber_core",
  "slumber_template",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ serde_test = "1.0.176"
 serde_yaml = {version = "0.9.0", default-features = false}
 slumber_cli = {path = "./crates/cli", version = "5.2.4" }
 slumber_config = {path = "./crates/config", version = "5.2.4", default-features = false }
+slumber_console = {path = "./crates/console", version = "5.2.4"}
 slumber_core = {path = "./crates/core", version = "5.2.4" }
 slumber_import = {path = "./crates/import", version = "5.2.4" }
 slumber_macros = {path = "./crates/macros", version = "5.2.4" }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,7 +20,6 @@ async-trait = {workspace = true}
 chrono = {workspace = true}
 clap = {workspace = true, features = ["derive"]}
 clap_complete = {version = "4.5.29", features = ["unstable-dynamic"]}
-dialoguer = {workspace = true, features = ["password"]}
 indexmap = {workspace = true}
 itertools = {workspace = true}
 reqwest = {workspace = true}
@@ -29,6 +28,7 @@ serde = {workspace = true}
 serde_json = {workspace = true, optional = true}
 serde_yaml = {workspace = true}
 slumber_config = {workspace = true}
+slumber_console = {workspace = true}
 slumber_core = {workspace = true}
 slumber_import = {workspace = true, optional = true}
 slumber_template = {workspace = true}

--- a/crates/cli/src/commands/request.rs
+++ b/crates/cli/src/commands/request.rs
@@ -5,10 +5,10 @@ use crate::{
 use anyhow::{Context, anyhow, bail};
 use async_trait::async_trait;
 use clap::{Parser, ValueHint};
-use dialoguer::{Input, Password, Select as DialoguerSelect};
 use indexmap::IndexMap;
 use itertools::Itertools;
 use slumber_config::Config;
+use slumber_console::ConsolePrompter;
 use slumber_core::{
     collection::{
         Authentication, ProfileId, QueryParameterValue, Recipe, RecipeBody,
@@ -20,11 +20,11 @@ use slumber_core::{
         RequestBody, RequestRecord, RequestSeed, ResponseRecord,
         StoredRequestError, TriggeredRequestError,
     },
-    render::{HttpProvider, Prompter, SelectOption, TemplateContext},
+    render::{HttpProvider, TemplateContext},
     util::MaybeStr,
 };
-use slumber_template::{Expression, Template, Value};
-use slumber_util::{OptionExt, ResultTracedAnyhow};
+use slumber_template::{Expression, Template};
+use slumber_util::OptionExt;
 use std::{
     error::Error,
     fs::OpenOptions,
@@ -32,7 +32,6 @@ use std::{
     path::{Path, PathBuf},
     process::ExitCode,
 };
-use tracing::warn;
 
 /// Exit code to return when `exit_status` flag is set and the HTTP response has
 /// an error status code
@@ -386,7 +385,7 @@ impl BuildRequestCommand {
                 // CLI only supports string overrides
                 .map(|(key, template)| (key, ValueTemplate::String(template)))
                 .collect(),
-            prompter: Box::new(CliPrompter),
+            prompter: Box::new(ConsolePrompter),
             show_sensitive: true,
             root_dir: collection_file.parent().to_owned(),
             state: Default::default(),
@@ -511,66 +510,6 @@ impl HttpProvider for CliHttpProvider {
         } else {
             Err(TriggeredRequestError::NotAllowed)
         }
-    }
-}
-
-/// Prompt the user for input on the CLI
-#[derive(Debug)]
-struct CliPrompter;
-
-#[async_trait(?Send)]
-
-impl Prompter for CliPrompter {
-    async fn prompt_text(
-        &self,
-        message: String,
-        default: Option<String>,
-        sensitive: bool,
-    ) -> Option<String> {
-        // This will implicitly queue the prompts by blocking the main thread.
-        // Since the CLI has nothing else to do while waiting on a response,
-        // that's fine.
-        if sensitive {
-            // Dialoguer doesn't support default values here so there's nothing
-            // we can do
-            if default.is_some() {
-                warn!(
-                    "Default value not supported for sensitive prompts in CLI"
-                );
-            }
-
-            Password::new()
-                .with_prompt(message)
-                .allow_empty_password(true)
-                .interact()
-        } else {
-            let mut input = Input::new().with_prompt(message).allow_empty(true);
-            if let Some(default) = default {
-                input = input.default(default);
-            }
-            input.interact()
-        }
-        // If we failed to read the value, print an error and report nothing
-        .context("Error reading value from prompt")
-        .traced()
-        .ok()
-    }
-
-    async fn prompt_select(
-        &self,
-        message: String,
-        mut options: Vec<SelectOption>,
-    ) -> Option<Value> {
-        let index = DialoguerSelect::new()
-            .with_prompt(message)
-            .items(&options)
-            .default(0)
-            .interact()
-            // If we failed to read the value, print an error and report nothing
-            .context("Error reading value from select")
-            .traced()
-            .ok()?;
-        Some(options.swap_remove(index).value)
     }
 }
 

--- a/crates/console/Cargo.toml
+++ b/crates/console/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+authors = {workspace = true}
+description = "Utitilies for console-based Slumber frontends. Not intended for external use."
+edition = {workspace = true}
+homepage = {workspace = true}
+keywords = {workspace = true}
+license = {workspace = true}
+name = "slumber_console"
+repository = {workspace = true}
+rust-version = {workspace = true}
+version = {workspace = true}
+
+[package.metadata.release]
+tag = false
+
+[dependencies]
+anyhow = {workspace = true}
+async-trait = {workspace = true}
+dialoguer = {workspace = true, features = ["password"]}
+slumber_core = {workspace = true}
+slumber_template = {workspace = true}
+slumber_util = {workspace = true}
+tokio = {workspace = true, features = ["sync"]}
+tracing = {workspace = true}

--- a/crates/console/src/lib.rs
+++ b/crates/console/src/lib.rs
@@ -1,0 +1,100 @@
+//! Utilities for console-based Slumber frontends
+
+use anyhow::Context as _;
+use async_trait::async_trait;
+use dialoguer::{Input, Password, Select};
+use slumber_core::render::{Prompter, SelectOption};
+use slumber_template::Value;
+use slumber_util::ResultTracedAnyhow;
+use tokio::sync::Mutex;
+use tracing::warn;
+
+/// A proxy for a lock on stdout
+///
+/// Forces prompts to run one at a time, so they don't fight over the console.
+/// This is a static instead of being in [ConsolePrompter] because there could
+/// theoretically be multiple prompters running simultaneously.
+static CONSOLE_LOCK: Mutex<()> = Mutex::const_new(());
+
+/// Prompt the user for input on the console
+///
+/// This uses [dialoguer] to generate the prompts. Since its API is blocking,
+/// this runs each prompt in a tokio blocking thread.
+#[derive(Debug)]
+pub struct ConsolePrompter;
+
+impl ConsolePrompter {
+    /// Spawn a blocking prompt in a background task
+    async fn spawn_prompt<T, F>(&self, f: F) -> Option<T>
+    where
+        T: 'static + Send,
+        F: 'static + FnOnce() -> anyhow::Result<T> + Send,
+    {
+        let guard = CONSOLE_LOCK.lock().await;
+        let result = tokio::task::spawn_blocking(f)
+            .await
+            .context("Prompt panicked")
+            .flatten()
+            .traced();
+        // Make sure the guard is held while the task is running. Since the lock
+        // doesn't actually contain the locked resource, I wanna be careful.
+        drop(guard);
+        result.ok()
+    }
+}
+
+#[async_trait(?Send)]
+impl Prompter for ConsolePrompter {
+    async fn prompt_text(
+        &self,
+        message: String,
+        default: Option<String>,
+        sensitive: bool,
+    ) -> Option<String> {
+        self.spawn_prompt(move || {
+            if sensitive {
+                // Dialoguer doesn't support default values here so there's
+                // nothing we can do
+                if default.is_some() {
+                    warn!(
+                        "Default value not supported for sensitive CLI prompts"
+                    );
+                }
+
+                Password::new()
+                    .with_prompt(message)
+                    .allow_empty_password(true)
+                    .interact()
+            } else {
+                let mut input =
+                    Input::new().with_prompt(message).allow_empty(true);
+                if let Some(default) = default {
+                    input = input.default(default);
+                }
+                input.interact()
+            }
+            // If we failed to read the value, print an error and report nothing
+            .context("Error reading value from prompt")
+        })
+        .await
+    }
+
+    async fn prompt_select(
+        &self,
+        message: String,
+        mut options: Vec<SelectOption>,
+    ) -> Option<Value> {
+        self.spawn_prompt(move || {
+            let index = Select::new()
+                .with_prompt(message)
+                .items(&options)
+                .default(0)
+                .interact()
+                // If we failed to read the value, print an error and report
+                // nothing
+                .context("Error reading value from select")?;
+            Ok(options.swap_remove(index).value)
+        })
+        .await
+    }
+}

--- a/crates/core/src/test_util.rs
+++ b/crates/core/src/test_util.rs
@@ -147,7 +147,6 @@ impl TestSelectPrompter {
 }
 
 #[async_trait(?Send)]
-
 impl Prompter for TestSelectPrompter {
     async fn prompt_text(
         &self,

--- a/crates/python/Cargo.toml
+++ b/crates/python/Cargo.toml
@@ -22,10 +22,10 @@ crate-type = ["cdylib"]
 
 [dependencies]
 async-trait = {workspace = true}
-dialoguer = {workspace = true, features = ["password"]}
 indexmap = {workspace = true}
 pyo3 = {version = "0.27.2", features = ["experimental-async", "indexmap"]}
 slumber_config = {workspace = true}
+slumber_console = {workspace = true}
 slumber_core = {workspace = true}
 slumber_template = {workspace = true}
 tokio = {workspace = true, features = ["rt-multi-thread"]}

--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-use dialoguer::{Input, Password, Select as DialoguerSelect};
 use indexmap::IndexMap;
 use pyo3::{
     PyErr, PyResult,
@@ -7,6 +6,7 @@ use pyo3::{
     pyclass, pymethods, pymodule,
 };
 use slumber_config::Config;
+use slumber_console::ConsolePrompter;
 use slumber_core::{
     collection::{CollectionFile, ProfileId, RecipeId},
     database::{CollectionDatabase, Database},
@@ -14,9 +14,9 @@ use slumber_core::{
         BuildOptions, Exchange, HttpEngine, RequestRecord, RequestSeed,
         ResponseRecord, StoredRequestError, TriggeredRequestError,
     },
-    render::{HttpProvider, Prompter, SelectOption, TemplateContext},
+    render::{HttpProvider, TemplateContext},
 };
-use slumber_template::{Template, Value};
+use slumber_template::Template;
 use std::{
     error::Error,
     fmt::{self, Display},
@@ -278,52 +278,6 @@ impl HttpProvider for PythonHttpProvider {
     }
 }
 
-#[derive(Debug)]
-struct PythonPrompter;
-
-#[async_trait(?Send)]
-
-impl Prompter for PythonPrompter {
-    async fn prompt_text(
-        &self,
-        message: String,
-        default: Option<String>,
-        sensitive: bool,
-    ) -> Option<String> {
-        // This will implicitly queue the prompts by blocking the only worker
-        // thread. Since the library has nothing to do while waiting on a
-        // response, that's fine
-        if sensitive {
-            Password::new()
-                .with_prompt(message)
-                .allow_empty_password(true)
-                .interact()
-                .ok()
-        } else {
-            let mut input = Input::new().with_prompt(message).allow_empty(true);
-            if let Some(default) = default {
-                input = input.default(default);
-            }
-            input.interact().ok()
-        }
-    }
-
-    async fn prompt_select(
-        &self,
-        message: String,
-        mut options: Vec<SelectOption>,
-    ) -> Option<Value> {
-        let index = DialoguerSelect::new()
-            .with_prompt(message)
-            .items(&options)
-            .default(0)
-            .interact()
-            .ok()?;
-
-        Some(options.swap_remove(index).value)
-    }
-}
-
 /// Wrapper to stringify an error and convert it to Python. This is clumsy
 /// because it converts everything to a `RuntimeError`, but it's simple and
 /// effective.
@@ -395,7 +349,7 @@ impl Request {
             selected_profile,
             http_provider: Box::new(http_provider),
             overrides,
-            prompter: Box::new(PythonPrompter),
+            prompter: Box::new(ConsolePrompter),
             show_sensitive: true,
             root_dir: self.root_dir,
             state: Default::default(),

--- a/crates/tui/src/view/util.rs
+++ b/crates/tui/src/view/util.rs
@@ -135,7 +135,6 @@ impl Prompter for TuiPrompter {
 pub struct PreviewPrompter;
 
 #[async_trait(?Send)]
-
 impl Prompter for PreviewPrompter {
     async fn prompt_text(
         &self,


### PR DESCRIPTION

## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

Dialoguer's interface is entirely blocking. The prompts themselves must be single-threaded because stdout can only handle one prompt at a time. By pushing them into a background thread, we allow the rest of the build to make progress while waiting on the prompt. For example, if there's a triggered request or command subprocess needed for the build as well, those can run and be handled while waiting on the prompt response.

This involved adding a new crate, because I didn't want to duplicate the prompter stuff across 2 crates. Especially since the fs frontend will need this as well, so soon it'll be 3 crates. This can't go into slumber_core because I don't want to add dialoguer and anyhow as dependencies there.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Could break simultaneous. I tested that manually (CLI and python) to make sure.

## QA

_How did you test this?_

I manually tested both the CLI and Python with multiple simultaneous prompts. Dialoguer properly queues them so the user only gets one prompt at a time.

## Checklist

- [ ] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [ ] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
