### PR TITLE
Resizable panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 <!-- ANCHOR: changelog -->
 
+### Fixed
+
+- Border of the selected pane is always fully highlighted
+
 ## [5.2.5] - 2026-04-12
 
 <!-- ANCHOR: changelog -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 <!-- ANCHOR: changelog -->
 
+### Changed
+
+- Exit fullscreen whenever changing panes
+  - With resizable panes, keeping fullscreen persistent ends up being more annoying than useful
+
 ### Fixed
 
 - Border of the selected pane is always fully highlighted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 <!-- ANCHOR: changelog -->
 
+### Added
+
+- Resize panes dynamically with `[` and `]`
+  - [Rebind](https://slumber.lucaspickering.me/api/configuration/input_bindings.html) the actions `resize_back` and `resize_forward` to customize
+
 ### Changed
 
 - Exit fullscreen whenever changing panes

--- a/crates/config/src/tui/input.rs
+++ b/crates/config/src/tui/input.rs
@@ -178,6 +178,10 @@ pub enum Action {
     // Aliases for backward compatibility
     #[serde(alias = "select_request", alias = "select_response")]
     BottomPane,
+    /// Shift the moveable edge of the selected pane left/up
+    ResizeBack,
+    /// Shift the moveable edge of the selected pane right/down
+    ResizeForward,
     // ^^^^^ If making changes, make sure to update the docs ^^^^^
 }
 
@@ -514,6 +518,8 @@ impl Default for InputMap {
             (Action::RecipeList, KeyCode::Char('r').into()),
             (Action::TopPane, KeyCode::Char('1').into()),
             (Action::BottomPane, KeyCode::Char('2').into()),
+            (Action::ResizeBack, KeyCode::Char('[').into()),
+            (Action::ResizeForward, KeyCode::Char(']').into()),
             // ^^^^^ If making changes, make sure to update the docs ^^^^^
         ]))
     }

--- a/crates/core/src/render.rs
+++ b/crates/core/src/render.rs
@@ -37,7 +37,6 @@ use std::{
     fmt::Debug, io, iter, path::PathBuf, process::ExitStatus, sync::Arc,
 };
 use thiserror::Error;
-use tracing::error;
 
 /// A little container struct for all the data that the user can access via
 /// templating. Unfortunately this has to own all data so templating can be

--- a/crates/tui/src/view/common.rs
+++ b/crates/tui/src/view/common.rs
@@ -25,8 +25,9 @@ use chrono::{DateTime, Duration, Utc};
 use itertools::{Itertools, Position};
 use ratatui::{
     prelude::{Buffer, Rect},
+    style::Style,
     symbols::merge::MergeStrategy,
-    text::{Span, Text},
+    text::{Line, Span, Text},
     widgets::{Block, Borders, Widget},
 };
 use reqwest::{StatusCode, header::HeaderValue};
@@ -52,13 +53,18 @@ impl Generate for Pane<'_> {
     {
         let styles = ViewContext::styles().pane;
         let (border_type, border_style) = styles.border(self.has_focus);
+        let title_style = if self.has_focus {
+            styles.title_selected
+        } else {
+            Style::default()
+        };
         Block::default()
             .borders(Borders::ALL)
             .border_type(border_type)
             .border_style(border_style)
             .merge_borders(MergeStrategy::Fuzzy)
             .style(styles.default)
-            .title(self.title)
+            .title(Line::styled(self.title, title_style))
     }
 }
 

--- a/crates/tui/src/view/component/help.rs
+++ b/crates/tui/src/view/component/help.rs
@@ -209,6 +209,10 @@ fn input_groups() -> impl IntoIterator<Item = (&'static str, Vec<Action>)> {
             ],
         ),
         (
+            "Layout Control",
+            vec![Action::ResizeBack, Action::ResizeForward],
+        ),
+        (
             "Interaction",
             vec![
                 Action::OpenActions,

--- a/crates/tui/src/view/component/primary.rs
+++ b/crates/tui/src/view/component/primary.rs
@@ -292,7 +292,7 @@ impl PrimaryView {
         });
         canvas.render_widget(
             format!(
-                "Toggle Sidebar {binding}",
+                "Hide {binding}",
                 binding = ViewContext::binding_display(Action::ToggleSidebar),
             ),
             bottom_row,
@@ -369,6 +369,10 @@ impl Component for PrimaryView {
                 Action::Cancel if self.view.is_fullscreen() => {
                     self.view.exit_fullscreen();
                 }
+
+                Action::ResizeBack => self.view.resize_back(),
+                Action::ResizeForward => self.view.resize_forward(),
+
                 _ => propagate.set(),
             })
             .broadcast(|event| match event {

--- a/crates/tui/src/view/component/primary.rs
+++ b/crates/tui/src/view/component/primary.rs
@@ -16,7 +16,7 @@ use crate::{
             history::History,
             misc::{SidebarEvent, SidebarProps},
             primary::view_state::{
-                PrimaryLayout, PrimaryPane, SelectedState, Sidebar, ViewState,
+                Header, PaneArea, Sidebar, ViewState, VisiblePane,
             },
             profile_detail::ProfileDetail,
             profile_list::ProfileList,
@@ -259,156 +259,29 @@ impl PrimaryView {
         RecipeDetail::new(node)
     }
 
-    /// Draw the layout with wide panes
-    ///
-    /// +---------+
-    /// | HEADERS |
-    /// +---------+
-    /// |         |
-    /// |   TOP   |
-    /// +---------+
-    /// |         |
-    /// | BOTTOM  |
-    /// +---------+
-    fn draw_wide_layout(
-        &self,
-        canvas: &mut Canvas,
-        area: Rect,
-        top: SelectedState<PrimaryPane>,
-        bottom: SelectedState<PrimaryPane>,
-    ) {
-        let headers: &[&dyn Draw<_>] = &[&self.profile_list, &self.recipe_list];
-
-        let [headers_area, top_area, bottom_area] = Layout::vertical([
-            Constraint::Length(3),
-            Constraint::Fill(1),
-            Constraint::Fill(1),
-        ])
-        .spacing(Spacing::Overlap(1))
-        .areas(area);
-        let headers_areas = Layout::horizontal(iter::repeat_n(
-            Constraint::Fill(1),
-            headers.len(),
-        ))
-        .spacing(Spacing::Overlap(1))
-        .split(headers_area);
-
-        // Header
-        for (header, area) in headers.iter().zip(&*headers_areas) {
-            let header_props = SidebarProps::header();
-            canvas.draw(*header, header_props, *area, false);
-        }
-
-        // Panes
-        self.draw_pane(canvas, top_area, top);
-        self.draw_pane(canvas, bottom_area, bottom);
-    }
-
-    /// Draw the sidebar layout
-    ///
-    /// +---+---------+
-    /// | S | HEADERS |
-    /// | I +---------+
-    /// | D |         |
-    /// | E |   TOP   |
-    /// | B +---------+
-    /// | A |         |
-    /// | R | BOTTOM  |
-    /// +---+---------+
-    fn draw_sidebar_layout(
-        &self,
-        canvas: &mut Canvas,
-        area: Rect,
-        sidebar: SelectedState<Sidebar>,
-        top: SelectedState<PrimaryPane>,
-        bottom: SelectedState<PrimaryPane>,
-    ) {
-        let headers: &[&dyn Draw<_>] = match sidebar.value {
-            Sidebar::Profile => &[&self.recipe_list],
-            Sidebar::Recipe => &[&self.profile_list],
-            Sidebar::History => &[&self.profile_list, &self.recipe_list],
-        };
-
-        // Split the areas
-        let [sidebar_area, rest] =
-            Layout::horizontal([Constraint::Length(30), Constraint::Fill(1)])
-                .spacing(Spacing::Overlap(1))
-                .areas(area);
-        let [headers_area, top_area, bottom_area] = Layout::vertical([
-            Constraint::Length(3),
-            Constraint::Fill(1),
-            Constraint::Fill(1),
-        ])
-        .spacing(Spacing::Overlap(1))
-        .areas(rest);
-        let headers_areas = Layout::horizontal(iter::repeat_n(
-            Constraint::Fill(1),
-            headers.len(),
-        ))
-        .spacing(Spacing::Overlap(1))
-        .split(headers_area);
-
-        // Header
-        for (header, area) in headers.iter().zip(&*headers_areas) {
-            let header_props = SidebarProps::header();
-            canvas.draw(*header, header_props, *area, false);
-        }
-
-        self.draw_sidebar(canvas, sidebar_area, sidebar);
-        self.draw_pane(canvas, top_area, top);
-        self.draw_pane(canvas, bottom_area, bottom);
-    }
-
-    /// Draw a primary pane to the given area
-    fn draw_pane(
-        &self,
-        canvas: &mut Canvas,
-        area: Rect,
-        pane: SelectedState<PrimaryPane>,
-    ) {
-        match pane.value {
-            PrimaryPane::Recipe => {
-                canvas.draw(&self.recipe_detail, (), area, pane.selected);
-            }
-            PrimaryPane::Exchange => {
-                canvas.draw(&self.exchange_pane, (), area, pane.selected);
-            }
-            PrimaryPane::Profile => {
-                canvas.draw(&self.profile_detail, (), area, pane.selected);
-            }
-            PrimaryPane::Sidebar(sidebar) => self.draw_sidebar(
-                canvas,
-                area,
-                SelectedState {
-                    value: sidebar,
-                    selected: pane.selected,
-                },
-            ),
-        }
-    }
-
     /// Draw a sidebar pane
     fn draw_sidebar(
         &self,
         canvas: &mut Canvas,
+        sidebar: Sidebar,
         area: Rect,
-        sidebar: SelectedState<Sidebar>,
+        selected: bool,
     ) {
-        match sidebar.value {
+        match sidebar {
             Sidebar::Profile => canvas.draw(
                 &self.profile_list,
                 SidebarProps::list(),
                 area,
-                sidebar.selected,
+                selected,
             ),
             Sidebar::Recipe => canvas.draw(
                 &self.recipe_list,
                 SidebarProps::list(),
                 area,
-                sidebar.selected,
+                selected,
             ),
             Sidebar::History => {
-                canvas.draw(&self.history, (), area, sidebar.selected);
+                canvas.draw(&self.history, (), area, selected);
             }
         }
 
@@ -424,6 +297,34 @@ impl PrimaryView {
             ),
             bottom_row,
         );
+    }
+
+    /// Draw all boxes within the header area
+    fn draw_headers(
+        &self,
+        canvas: &mut Canvas,
+        headers: &[Header],
+        area: Rect,
+    ) {
+        let areas = Layout::horizontal(iter::repeat_n(
+            Constraint::Fill(1),
+            headers.len(),
+        ))
+        .spacing(Spacing::Overlap(1))
+        .split(area);
+
+        // Header
+        for (header, area) in headers.iter().zip(&*areas) {
+            let props = SidebarProps::header();
+            match header {
+                Header::Profile => {
+                    canvas.draw(&self.profile_list, props, *area, false);
+                }
+                Header::Recipe => {
+                    canvas.draw(&self.recipe_list, props, *area, false);
+                }
+            }
+        }
     }
 }
 
@@ -581,19 +482,28 @@ impl Component for PrimaryView {
 
 impl Draw for PrimaryView {
     fn draw(&self, canvas: &mut Canvas, (): (), metadata: DrawMetadata) {
-        let area = metadata.area();
-
-        match self.view.layout() {
-            PrimaryLayout::Wide { top, bottom } => {
-                self.draw_wide_layout(canvas, area, top, bottom);
-            }
-            PrimaryLayout::Sidebar {
-                sidebar,
-                top,
-                bottom,
-            } => self.draw_sidebar_layout(canvas, area, sidebar, top, bottom),
-            PrimaryLayout::Fullscreen { pane } => {
-                self.draw_pane(canvas, area, pane);
+        for pane in self.view.layout(metadata.area()) {
+            let PaneArea {
+                pane,
+                selected,
+                area,
+            } = pane;
+            match pane {
+                VisiblePane::Recipe => {
+                    canvas.draw(&self.recipe_detail, (), area, selected);
+                }
+                VisiblePane::Exchange => {
+                    canvas.draw(&self.exchange_pane, (), area, selected);
+                }
+                VisiblePane::Profile => {
+                    canvas.draw(&self.profile_detail, (), area, selected);
+                }
+                VisiblePane::Sidebar(sidebar) => {
+                    self.draw_sidebar(canvas, sidebar, area, selected);
+                }
+                VisiblePane::Headers(headers) => {
+                    self.draw_headers(canvas, headers, area);
+                }
             }
         }
 
@@ -626,6 +536,7 @@ mod tests {
         message::{Message, RecipeCopyTarget},
         view::test_util::{TestComponent, TestHarness, harness},
     };
+    use pretty_assertions::assert_eq;
     use rstest::rstest;
     use slumber_core::http::BuildOptions;
     use slumber_util::assert_matches;
@@ -634,21 +545,56 @@ mod tests {
     /// Test various workflows that modify the layout
     #[rstest]
     #[case::submit_sidebar(
+        // Open profile sidebar, then close it
         &[KeyCode::Char('p'), KeyCode::Enter],
-        PrimaryLayout::Sidebar {
-            sidebar: state(Sidebar::Recipe, true),
-            top: state(PrimaryPane::Recipe, false),
-            bottom: state(PrimaryPane::Exchange, false),
-        },
+        vec![
+            PaneArea {
+                pane: VisiblePane::Headers(&[Header::Profile]),
+                area: Rect::new(29, 0, 21, 3),
+                selected: false,
+            },
+            PaneArea {
+                pane: VisiblePane::Recipe,
+                area: Rect::new(29, 2, 21, 25),
+                selected: false,
+            },
+            PaneArea {
+                pane: VisiblePane::Exchange,
+                area: Rect::new(29, 26, 21, 24),
+                selected: false,
+            },
+            PaneArea {
+                pane: VisiblePane::Sidebar(Sidebar::Recipe),
+                area: Rect::new(0, 0, 30, 50),
+                selected: true,
+            },
+        ],
     )]
     #[case::cancel_sidebar(
         // Functionally the same as submitting the sidebar
         &[KeyCode::Char('p'), KeyCode::Esc],
-        PrimaryLayout::Sidebar {
-            sidebar: state(Sidebar::Recipe, true),
-            top: state(PrimaryPane::Recipe, false),
-            bottom: state(PrimaryPane::Exchange, false),
-        },
+        vec![
+            PaneArea {
+                pane: VisiblePane::Headers(&[Header::Profile]),
+                area: Rect::new(29, 0, 21, 3),
+                selected: false,
+            },
+            PaneArea {
+                pane: VisiblePane::Recipe,
+                area: Rect::new(29, 2, 21, 25),
+                selected: false,
+            },
+            PaneArea {
+                pane: VisiblePane::Exchange,
+                area: Rect::new(29, 26, 21, 24),
+                selected: false,
+            },
+            PaneArea {
+                pane: VisiblePane::Sidebar(Sidebar::Recipe),
+                area: Rect::new(0, 0, 30, 50),
+                selected: true,
+            },
+        ],
     )]
     #[case::fullscreen_exchange_after_profile(
         // There was a bug where this would fullscreen the Profile pane instead
@@ -659,12 +605,16 @@ mod tests {
             KeyCode::Char('f'), // Fullscreen it
         ],
         // Exchange pane should be fullscreened
-        PrimaryLayout::Fullscreen { pane: state(PrimaryPane::Exchange, true) },
+        vec![PaneArea {
+            pane: VisiblePane::Exchange,
+            area: Rect::new(0, 0, 50, 50),
+            selected: true,
+        }]
     )]
     fn test_layout_transitions(
         mut harness: TestHarness,
         #[case] keys: &[KeyCode],
-        #[case] expected: PrimaryLayout,
+        #[case] expected: Vec<PaneArea>,
     ) {
         let mut component = create_component(&mut harness);
         component
@@ -672,7 +622,13 @@ mod tests {
             .send_keys(keys.to_owned())
             .assert()
             .empty();
-        assert_eq!(component.view.layout(), expected);
+        let area = Rect {
+            width: 50,
+            height: 50,
+            x: 0,
+            y: 0,
+        };
+        assert_eq!(component.view.layout(area), expected);
     }
 
     /// Test selected pane and fullscreen mode loading from persistence
@@ -790,9 +746,5 @@ mod tests {
         // Clear template preview messages so we can test what we want
         harness.messages_rx().clear();
         component
-    }
-
-    fn state<T>(value: T, selected: bool) -> SelectedState<T> {
-        SelectedState { value, selected }
     }
 }

--- a/crates/tui/src/view/component/primary/view_state.rs
+++ b/crates/tui/src/view/component/primary/view_state.rs
@@ -1,3 +1,4 @@
+use ratatui::layout::{Constraint, Layout, Rect, Spacing};
 use serde::{Deserialize, Serialize};
 
 /// Which panes are visible in the primary view?
@@ -30,53 +31,123 @@ pub struct ViewState {
 }
 
 impl ViewState {
-    /// Get the current sidebar/pane layout
-    pub fn layout(&self) -> PrimaryLayout {
-        let top_pane = PrimaryPane::Recipe;
+    /// Get the set of panes to be drawn to the primary view
+    pub fn layout(&self, area: Rect) -> Vec<PaneArea> {
+        let top_pane = VisiblePane::Recipe;
         // Bottom pane depends on the sidebar
         let bottom_pane = match self.sidebar {
-            Sidebar::Profile => PrimaryPane::Profile,
-            Sidebar::Recipe | Sidebar::History => PrimaryPane::Exchange,
+            Sidebar::Profile => VisiblePane::Profile,
+            Sidebar::Recipe | Sidebar::History => VisiblePane::Exchange,
         };
 
-        if self.fullscreen {
+        let mut areas = if self.fullscreen {
+            // Fullscreen
             let pane = match self.selected_pane {
-                SelectedPane::Sidebar => PrimaryPane::Sidebar(self.sidebar),
+                SelectedPane::Sidebar => VisiblePane::Sidebar(self.sidebar),
                 SelectedPane::Top => top_pane,
                 SelectedPane::Bottom => bottom_pane,
             };
-            PrimaryLayout::Fullscreen {
-                pane: SelectedState {
-                    value: pane,
-                    selected: true,
+            vec![PaneArea {
+                pane,
+                area,
+                selected: true,
+            }]
+        } else if self.sidebar_open {
+            // +---+---------+
+            // | S | HEADERS |
+            // | I +---------+
+            // | D |         |
+            // | E |   TOP   |
+            // | B +---------+
+            // | A |         |
+            // | R | BOTTOM  |
+            // +---+---------+
+            //
+            // Visible headers depend on the open sidebar
+            let headers: &[Header] = match self.sidebar {
+                Sidebar::Profile => &[Header::Recipe],
+                Sidebar::Recipe => &[Header::Profile],
+                Sidebar::History => &[Header::Profile, Header::Recipe],
+            };
+
+            // Sidebar open
+            let [sidebar_area, rest] = Layout::horizontal([
+                Constraint::Length(30),
+                Constraint::Fill(1),
+            ])
+            .spacing(Spacing::Overlap(1))
+            .areas(area);
+            let [headers_area, top_area, bottom_area] = Layout::vertical([
+                Constraint::Length(3),
+                Constraint::Fill(1),
+                Constraint::Fill(1),
+            ])
+            .spacing(Spacing::Overlap(1))
+            .areas(rest);
+            vec![
+                PaneArea {
+                    pane: VisiblePane::Headers(headers),
+                    selected: false, // This pane isn't selectable
+                    area: headers_area,
                 },
-            }
-        } else {
-            // Multiple panes are visible
-            let top = SelectedState {
-                value: top_pane,
-                selected: self.selected_pane == SelectedPane::Top,
-            };
-            let bottom = SelectedState {
-                value: bottom_pane,
-                selected: self.selected_pane == SelectedPane::Bottom,
-            };
-            if self.sidebar_open {
-                // Sidebar is open
-                let sidebar = SelectedState {
-                    value: self.sidebar,
+                PaneArea {
+                    pane: VisiblePane::Sidebar(self.sidebar),
                     selected: self.selected_pane == SelectedPane::Sidebar,
-                };
-                PrimaryLayout::Sidebar {
-                    sidebar,
-                    top,
-                    bottom,
-                }
-            } else {
-                // Sidebar closed
-                PrimaryLayout::Wide { top, bottom }
-            }
-        }
+                    area: sidebar_area,
+                },
+                PaneArea {
+                    pane: top_pane,
+                    selected: self.selected_pane == SelectedPane::Top,
+                    area: top_area,
+                },
+                PaneArea {
+                    pane: bottom_pane,
+                    selected: self.selected_pane == SelectedPane::Bottom,
+                    area: bottom_area,
+                },
+            ]
+        } else {
+            // +---------+
+            // | HEADERS |
+            // +---------+
+            // |         |
+            // |   TOP   |
+            // +---------+
+            // |         |
+            // | BOTTOM  |
+            // +---------+
+            let [headers_area, top_area, bottom_area] = Layout::vertical([
+                Constraint::Length(3),
+                Constraint::Fill(1),
+                Constraint::Fill(1),
+            ])
+            .spacing(Spacing::Overlap(1))
+            .areas(area);
+            vec![
+                PaneArea {
+                    pane: VisiblePane::Headers(&[
+                        Header::Profile,
+                        Header::Recipe,
+                    ]),
+                    selected: false, // This pane isn't selectable
+                    area: headers_area,
+                },
+                PaneArea {
+                    pane: top_pane,
+                    selected: self.selected_pane == SelectedPane::Top,
+                    area: top_area,
+                },
+                PaneArea {
+                    pane: bottom_pane,
+                    selected: self.selected_pane == SelectedPane::Bottom,
+                    area: bottom_area,
+                },
+            ]
+        };
+
+        // Put the selected pane last so its highlighted border goes on top
+        areas.sort_by_key(|pane| pane.selected);
+        areas
     }
 
     /// Open the sidebar with specific content
@@ -190,44 +261,46 @@ impl Default for ViewState {
     }
 }
 
-/// User-facing pane state. This maps 1:1 with what will be rendered.
-///
-/// Any state this represents should be theoretically drawable, but won't
-/// necessarily be a valid state that the user can get into. The goal of this
-/// is to minimize the work that `PrimaryView` has to do during the draw. So
-/// this represents exactly what should be drawn with minimal interpretation.
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub enum PrimaryLayout {
-    /// Layout with no sidebar visible. The primary panes are *wider*.
-    Wide {
-        top: SelectedState<PrimaryPane>,
-        bottom: SelectedState<PrimaryPane>,
-    },
-    /// Layout with the sidebar open and two panes visible
-    Sidebar {
-        sidebar: SelectedState<Sidebar>,
-        top: SelectedState<PrimaryPane>,
-        bottom: SelectedState<PrimaryPane>,
-    },
-    /// A single pane is visible (could be the sidebar pane)
-    Fullscreen { pane: SelectedState<PrimaryPane> },
-}
-
-/// A pane plus its focus state
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub struct SelectedState<T> {
-    pub value: T,
+/// Definition of a pane to be drawn
+#[derive(Debug, PartialEq)]
+pub struct PaneArea {
+    /// Which pane to draw
+    pub pane: VisiblePane,
+    /// Where to draw the pane
+    pub area: Rect,
+    /// Is the pane active?
     pub selected: bool,
 }
 
-/// A selectable pane in the primary view
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub enum PrimaryPane {
+/// Any pane that can be drawn
+#[derive(Debug, PartialEq)]
+pub enum VisiblePane {
     Recipe,
     Exchange,
     Profile,
     /// Tall skinny guy
     Sidebar(Sidebar),
+    /// Informational pane at the top
+    ///
+    /// The set of visible headers is dynamic, based on the sidebar.
+    Headers(&'static [Header]),
+}
+
+/// Part of the informational pane at the top
+#[derive(Debug, PartialEq)]
+pub enum Header {
+    /// Show selected profile
+    Profile,
+    /// Show selected recipe
+    Recipe,
+}
+
+/// List content that can be displayed in the sidebar
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum Sidebar {
+    Profile,
+    Recipe,
+    History,
 }
 
 /// Internal state for which pane is selected
@@ -239,14 +312,6 @@ enum SelectedPane {
     Sidebar,
     Top,
     Bottom,
-}
-
-/// List content that can be displayed in the sidebar
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub enum Sidebar {
-    Profile,
-    Recipe,
-    History,
 }
 
 /// Get a next/previous pane in the list based on the offset

--- a/crates/tui/src/view/component/primary/view_state.rs
+++ b/crates/tui/src/view/component/primary/view_state.rs
@@ -154,7 +154,7 @@ impl ViewState {
     pub fn open_sidebar(&mut self, sidebar: Sidebar) {
         self.sidebar = sidebar;
         self.sidebar_open = true;
-        self.selected_pane = SelectedPane::Sidebar;
+        self.select_pane(SelectedPane::Sidebar);
     }
 
     /// Reset to the recipe sidebar
@@ -171,22 +171,26 @@ impl ViewState {
         // sidebar. When re-opening, we want to re-show the same sidebar.
         self.sidebar_open ^= true;
         if !self.sidebar_open && self.selected_pane == SelectedPane::Sidebar {
-            self.selected_pane = SelectedPane::Top;
+            self.select_pane(SelectedPane::Top);
         }
     }
 
     /// Select the previous pane in the cycle
     pub fn previous_pane(&mut self) {
-        self.exit_fullscreen();
-        self.selected_pane =
-            offset(self.selectable_panes(), self.selected_pane, -1);
+        self.select_pane(offset(
+            self.selectable_panes(),
+            self.selected_pane,
+            -1,
+        ));
     }
 
     /// Select the next pane in the cycle
     pub fn next_pane(&mut self) {
-        self.exit_fullscreen();
-        self.selected_pane =
-            offset(self.selectable_panes(), self.selected_pane, 1);
+        self.select_pane(offset(
+            self.selectable_panes(),
+            self.selected_pane,
+            1,
+        ));
     }
 
     /// Get the set of selectable panes for the current state
@@ -204,12 +208,12 @@ impl ViewState {
 
     /// Move focus to the upper pane in the layout
     pub fn select_top_pane(&mut self) {
-        self.selected_pane = SelectedPane::Top;
+        self.select_pane(SelectedPane::Top);
     }
 
     /// Move focus to the lower pane in the layout
     pub fn select_bottom_pane(&mut self) {
-        self.selected_pane = SelectedPane::Bottom;
+        self.select_pane(SelectedPane::Bottom);
     }
 
     /// Move focus to the Recipe pane
@@ -231,6 +235,17 @@ impl ViewState {
         // If the Exchange pane isn't visible, do nothing
         if !self.sidebar_open || self.sidebar != Sidebar::Profile {
             self.select_bottom_pane();
+        }
+    }
+
+    /// Select a pane
+    ///
+    /// Always use this for changing the pane, because it exits fullscren too.
+    fn select_pane(&mut self, pane: SelectedPane) {
+        if pane != self.selected_pane {
+            self.selected_pane = pane;
+            // Changing pane always exits fullscreen
+            self.exit_fullscreen();
         }
     }
 
@@ -443,6 +458,46 @@ mod tests {
         ViewState {
             sidebar_open: false,
             fullscreen: true,
+            ..Default::default()
+        },
+    )]
+    // Select specific panes
+    #[case::select_top(
+        ViewState {
+            selected_pane: SelectedPane::Bottom,
+            fullscreen: true,
+            ..Default::default()
+        },
+        ViewState::select_top_pane,
+        ViewState {
+            selected_pane: SelectedPane::Top,
+            fullscreen: false, // Exits fullscreen
+            ..Default::default()
+        },
+    )]
+    #[case::select_bottom(
+        ViewState {
+            selected_pane: SelectedPane::Top,
+            fullscreen: true,
+            ..Default::default()
+        },
+        ViewState::select_bottom_pane,
+        ViewState {
+            selected_pane: SelectedPane::Bottom,
+            fullscreen: false, // Exits fullscreen
+            ..Default::default()
+        },
+    )]
+    #[case::select_same(
+        ViewState {
+            selected_pane: SelectedPane::Top,
+            fullscreen: true,
+            ..Default::default()
+        },
+        ViewState::select_top_pane,
+        ViewState {
+            selected_pane: SelectedPane::Top,
+            fullscreen: true, // Pane didn't change, so retain fullscreen
             ..Default::default()
         },
     )]

--- a/crates/tui/src/view/component/primary/view_state.rs
+++ b/crates/tui/src/view/component/primary/view_state.rs
@@ -1,5 +1,6 @@
 use ratatui::layout::{Constraint, Layout, Rect, Spacing};
 use serde::{Deserialize, Serialize};
+use std::cell::Cell;
 
 /// Which panes are visible in the primary view?
 ///
@@ -19,6 +20,8 @@ pub struct ViewState {
     /// focused when it's closed. Each state transition needs to ensure this
     /// remains valid.
     selected_pane: SelectedPane,
+    /// Adjustable height for the top pane
+    top_constraint: CustomConstraint,
     /// Selected sidebar. If the sidebar is closed, we still track this so we
     /// know which sidebar to show if it's toggled open
     sidebar: Sidebar,
@@ -26,6 +29,8 @@ pub struct ViewState {
     /// if a pane is fullscreened but the sidebar was visible in the last
     /// multi-pane layout.
     sidebar_open: bool,
+    /// Adjustable width for the sidebar pane
+    sidebar_constraint: CustomConstraint,
     /// Is the selected pane fullscreened?
     fullscreen: bool,
 }
@@ -72,14 +77,18 @@ impl ViewState {
 
             // Sidebar open
             let [sidebar_area, rest] = Layout::horizontal([
-                Constraint::Length(30),
+                self.sidebar_constraint
+                    .constraint()
+                    .unwrap_or(Constraint::Length(30)),
                 Constraint::Fill(1),
             ])
             .spacing(Spacing::Overlap(1))
             .areas(area);
             let [headers_area, top_area, bottom_area] = Layout::vertical([
                 Constraint::Length(3),
-                Constraint::Fill(1),
+                self.top_constraint
+                    .constraint()
+                    .unwrap_or(Constraint::Fill(1)),
                 Constraint::Fill(1),
             ])
             .spacing(Spacing::Overlap(1))
@@ -118,7 +127,9 @@ impl ViewState {
             // +---------+
             let [headers_area, top_area, bottom_area] = Layout::vertical([
                 Constraint::Length(3),
-                Constraint::Fill(1),
+                self.top_constraint
+                    .constraint()
+                    .unwrap_or(Constraint::Fill(1)),
                 Constraint::Fill(1),
             ])
             .spacing(Spacing::Overlap(1))
@@ -147,6 +158,29 @@ impl ViewState {
 
         // Put the selected pane last so its highlighted border goes on top
         areas.sort_by_key(|pane| pane.selected);
+
+        // Retain sizes for resizable constraints
+        for pane in &areas {
+            match pane.pane {
+                VisiblePane::Recipe => {
+                    self.top_constraint.set_draw_sizes(PaneSizes {
+                        pane: pane.area.height,
+                        parent: area.height - 2, // -2 for the header
+                    });
+                }
+                VisiblePane::Sidebar(_) => {
+                    self.sidebar_constraint.set_draw_sizes(PaneSizes {
+                        pane: pane.area.width,
+                        // Parent width is the full screen
+                        parent: area.width,
+                    });
+                }
+                VisiblePane::Exchange
+                | VisiblePane::Profile
+                | VisiblePane::Headers(_) => {}
+            }
+        }
+
         areas
     }
 
@@ -263,15 +297,47 @@ impl ViewState {
     pub fn exit_fullscreen(&mut self) {
         self.fullscreen = false;
     }
+
+    /// Move the movable edge of this pane up/left
+    pub fn resize_back(&mut self) {
+        if let Some(constraint) = self.active_constraint() {
+            constraint.resize(-1);
+        }
+    }
+
+    /// Move the movable edge of this pane down/right
+    pub fn resize_forward(&mut self) {
+        if let Some(constraint) = self.active_constraint() {
+            constraint.resize(1);
+        }
+    }
+
+    /// Get the current pane size constraint that can be modified
+    ///
+    /// Return None if in fullscreen mode, because there's no bounds to resize.
+    fn active_constraint(&mut self) -> Option<&mut CustomConstraint> {
+        if self.fullscreen {
+            None
+        } else {
+            Some(match self.selected_pane {
+                SelectedPane::Sidebar => &mut self.sidebar_constraint,
+                SelectedPane::Top | SelectedPane::Bottom => {
+                    &mut self.top_constraint
+                }
+            })
+        }
+    }
 }
 
 impl Default for ViewState {
     fn default() -> Self {
         Self {
+            selected_pane: SelectedPane::Top,
+            top_constraint: CustomConstraint::default(),
             sidebar: Sidebar::Recipe,
             sidebar_open: true,
+            sidebar_constraint: CustomConstraint::default(),
             fullscreen: false,
-            selected_pane: SelectedPane::Top,
         }
     }
 }
@@ -329,6 +395,71 @@ enum SelectedPane {
     Bottom,
 }
 
+/// A layout [Constraint] that can be resized
+///
+/// This is a very simple implementation of resizable panes that only works for
+/// for static groups of 2 panes.
+#[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
+struct CustomConstraint {
+    /// Custom size for this pane
+    ///
+    /// Cell is needed so it can be adjusted on resize
+    custom: Cell<Option<u16>>,
+    /// Pane and parent size on the most recent draw
+    draw_sizes: Cell<PaneSizes>,
+}
+
+impl CustomConstraint {
+    /// If there is a custom length, get a constraint specifying it
+    fn constraint(&self) -> Option<Constraint> {
+        self.custom.get().map(Constraint::Length)
+    }
+
+    /// Update the sizes for the pane/parent on draw
+    fn set_draw_sizes(&self, sizes: PaneSizes) {
+        self.draw_sizes.set(sizes);
+        // Reclamp in case the parent size changed
+        self.custom.update(|mut size| {
+            size.as_mut()
+                .map(|size| (*size).clamp(sizes.min(), sizes.max()))
+        });
+    }
+
+    /// Adjust the size of the constraint up or down
+    fn resize(&mut self, delta: i32) {
+        let sizes = self.draw_sizes.get();
+        let custom = self.custom.get_mut().get_or_insert(sizes.pane);
+        // Cast to signed int to prevent panics
+        *custom = (i32::from(*custom) + delta)
+            .clamp(sizes.min().into(), sizes.max().into())
+            as u16;
+    }
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+struct PaneSizes {
+    /// Width/height of the adjust container
+    pane: u16,
+    /// Width/height of the parent container. This it the size of the adjust
+    /// container plus its sibling
+    parent: u16,
+}
+
+impl PaneSizes {
+    /// Can't shrink a pane beyond this size
+    const MIN_PANE_SIZE: u16 = 3;
+
+    fn min(self) -> u16 {
+        Self::MIN_PANE_SIZE
+    }
+
+    fn max(self) -> u16 {
+        // Don't allow growing larger than the parent, minus some buffer
+        // space to let our sibling breathe
+        self.parent.saturating_sub(Self::MIN_PANE_SIZE)
+    }
+}
+
 /// Get a next/previous pane in the list based on the offset
 fn offset(
     all: &[SelectedPane],
@@ -361,6 +492,7 @@ mod tests {
             sidebar: Sidebar::Profile,
             sidebar_open: false,
             fullscreen: false,
+            ..Default::default()
         },
         ViewState::toggle_sidebar,
         // Selected pane is retained
@@ -369,6 +501,7 @@ mod tests {
             sidebar: Sidebar::Profile,
             sidebar_open: true,
             fullscreen: false,
+            ..Default::default()
         },
     )]
     #[case::toggle_sidebar_close(
@@ -377,6 +510,7 @@ mod tests {
             sidebar: Sidebar::Profile,
             sidebar_open: true,
             fullscreen: false,
+            ..Default::default()
         },
         ViewState::toggle_sidebar,
         // Selected pane is retained
@@ -385,6 +519,7 @@ mod tests {
             sidebar: Sidebar::Profile,
             sidebar_open: false,
             fullscreen: false,
+            ..Default::default()
         },
     )]
     #[case::toggle_sidebar_close_sidebar_selected(
@@ -393,6 +528,7 @@ mod tests {
             sidebar: Sidebar::Profile,
             sidebar_open: true,
             fullscreen: false,
+            ..Default::default()
         },
         ViewState::toggle_sidebar,
         // Can't keep the sidebar selected, so default to the top pane
@@ -401,6 +537,7 @@ mod tests {
             sidebar: Sidebar::Profile,
             sidebar_open: false,
             fullscreen: false,
+            ..Default::default()
         },
     )]
     #[case::reset_sidebar(
@@ -424,6 +561,7 @@ mod tests {
             sidebar: Sidebar::Recipe,
             sidebar_open: true,
             fullscreen: false,
+            ..Default::default()
         },
         ViewState::toggle_fullscreen,
         ViewState {
@@ -431,6 +569,7 @@ mod tests {
             sidebar: Sidebar::Recipe,
             sidebar_open: true,
             fullscreen: true,
+            ..Default::default()
         },
     )]
     #[case::toggle_fullscreen_close(
@@ -439,6 +578,7 @@ mod tests {
             sidebar: Sidebar::Recipe,
             sidebar_open: true,
             fullscreen: true,
+            ..Default::default()
         },
         ViewState::toggle_fullscreen,
         ViewState {
@@ -446,6 +586,7 @@ mod tests {
             sidebar: Sidebar::Recipe,
             sidebar_open: true,
             fullscreen: false,
+            ..Default::default()
         },
     )]
     #[case::toggle_fullscreen_open_wide(

--- a/crates/tui/src/view/styles.rs
+++ b/crates/tui/src/view/styles.rs
@@ -83,6 +83,8 @@ pub struct PaneStyles {
     pub border_type_selected: BorderType,
     /// Pane generic style
     pub default: Style,
+    /// Title text when the pane is selected
+    pub title_selected: Style,
 }
 
 impl PaneStyles {
@@ -221,6 +223,8 @@ impl Styles {
                 border_type: BorderType::Rounded,
                 border_type_selected: BorderType::Double,
                 default: Style::default().fg(theme.text_color.into()),
+                title_selected: Style::default()
+                    .add_modifier(Modifier::UNDERLINED),
             },
             status_code: StatusCodeStyles {
                 success: Style::default()

--- a/docs/src/api/configuration/input_bindings.md
+++ b/docs/src/api/configuration/input_bindings.md
@@ -65,6 +65,8 @@ input_bindings:
 | `recipe_list`       | `r`                     | Select Recipe List pane                                                                                                           |
 | `top_pane`          | `1`                     | Select the upper pane (the recipe pane). Aliased to `select_recipe` for backward compatibility                                    |
 | `bottom_pane`       | `2`                     | Select the lower pane (Request/Response or Profile). Aliased to `select_request` and `select_response` for backward compatibility |
+| `resize_back`       | `[`                     | Shift the moveable edge of the selected pane left/up                                                                              |
+| `resize_forward`    | `]`                     | Shift the moveable edge of the selected pane right/down                                                                           |
 
 ## Key Combinations
 

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -180,6 +180,12 @@
         ],
         "bottom_pane": [
           "2"
+        ],
+        "resize_back": [
+          "["
+        ],
+        "resize_forward": [
+          "]"
         ]
       }
     },
@@ -351,6 +357,12 @@
         ],
         "bottom_pane": [
           "2"
+        ],
+        "resize_back": [
+          "["
+        ],
+        "resize_forward": [
+          "]"
         ]
       },
       "theme": {


### PR DESCRIPTION
- **Split visible area in ViewState**
- **Exit fullscreen on pane change**
- **Resize panes dynamically**

## Description

_Describe the change. If there is an associated issue, please include the issue link (e.g. "Closes #xxx"). For UI changes, please also include screenshots._

The sidebar and recipe panes can now be resized dynamically. By default the keybinds are `[` and `]`. Also:

- Changing pane now exits fullscreen. There's less need for a persistent fullscreen now with resizable panes, and getting stuck in fullscreen has annoyed me for a long time.
- The selected pane is always rendered last now, so its colored outline doesn't get eaten anymore.

## Known Risks

_What issues could potentially go wrong with this change? Is it a breaking change? What have you done to mitigate any potential risks?_

Right now there's no way to reset the sizing. I'm gonna test it out and if that's annoying, I'll fix it before release.

## QA

_How did you test this?_

Added some unit tests, manual testing too!

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [x] Did you update `CHANGELOG.md`?
  - Only user-facing changes belong in the changelog. Internal changes such as refactors should only be included if they'll impact users, e.g. via performance improvement.
- [x] Did you remove all TODOs?
  - If there are unresolved issues, please open a follow-on issue and link to it in a comment so future work can be tracked
