### PR TITLE
docs: add a short narrated walkthrough video to the Introduction page

### DIFF
--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -2,6 +2,16 @@
 
 Slumber is a terminal-based HTTP client, built for interacting with REST and other HTTP clients. It has two usage modes: Terminal User Interface (TUI) and Command Line Interface (CLI). The TUI is the most useful, and allows for interactively sending requests and viewing responses. The CLI is useful for sending quick requests and scripting.
 
+<div style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;max-width:100%;margin:1.5rem 0;border-radius:10px;border:1px solid rgba(128,128,128,0.2);box-shadow:0 4px 20px rgba(0,0,0,0.15);">
+  <iframe
+    src="https://bisque.cloud/p/github/lucaspickering-slumber"
+    title="Slumber: a terminal HTTP client driven by one YAML file — narrated walkthrough"
+    style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;"
+    loading="lazy"
+    allow="autoplay; fullscreen; encrypted-media"
+    allowfullscreen></iframe>
+</div>
+
 The goal of Slumber is to be **easy to use, configurable, and sharable**. To that end, configuration is defined in a YAML file called the **request collection**. Both usage modes (TUI and CLI) share the same basic configuration, which is called the [request collection](./api/request_collection/index.md).
 
 Check out the [Getting Started guide](./getting_started.md) to try it out, or move onto [Key Concepts](./user_guide/key_concepts.md) to start learning in depth about Slumber.


### PR DESCRIPTION
## Description

Adds a ~90-second **narrated walkthrough** to the top of the Introduction page — what Slumber is, the one-YAML-file *request collection* idea, and sending a first request. The intent is a fast "what is this + first win" for a brand-new reader before they dive into the guide.

It's a single responsive, lazy-loaded `<iframe>` placed just below the opening paragraph of `docs/src/introduction.md`. The walkthrough is hosted on bisque.cloud (a narrated-presentation tool). Docs-only — no new pages, no `book.toml` / preprocessor changes, the demo GIF and everything else untouched.

▶ **Live preview:** https://bisque.cloud/p/github/lucaspickering-slumber  *(renders inline as a 16:9 player; happy to attach static screenshots if you'd prefer them in-thread)*

No associated issue yet — per `CONTRIBUTING.md` I'd normally open one first for a non-trivial change, so I'm glad to convert this to an issue to discuss before you merge if that's better for you.

## Known Risks

- **Third-party embed.** It's a normal sandboxed `<iframe>` — no scripts are injected into your docs, it can't read your page, and there's nothing to install. If the host were ever unavailable the page would just show an empty frame; removing it is deleting the one `<div>`.
- **Build impact: none.** mdBook renders the raw HTML inline, so there's no `book.toml` / preprocessor / theme change and the build is unaffected. `loading="lazy"` keeps it off the initial page load.
- **Not a breaking change** — docs-only, no code touched.

## QA

- Built the book locally with `mdbook` and confirmed the embed renders responsively (16:9) just below the intro paragraph in the dark theme, with no effect on any other page.
- Verified the embed URL loads **publicly / unauthenticated** and plays the narrated walkthrough end to end.
- Fact-checked every claim in the walkthrough against the current docs (install, `slumber new`, the example collection, the CLI).

## Checklist

- [x] Have you read `CONTRIBUTING.md` already?
- [ ] Did you update `CHANGELOG.md`? — N/A: docs-only addition, not a user-facing crate change (per the "user-facing only" note). Glad to add an entry if you'd like one.
- [x] Did you remove all TODOs?
